### PR TITLE
Default to only building on JDK 8

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ buildPlugin
 
 ==== Optional arguments
 
-* `jdkVersions` (default: `[7, 8]`) - JDK version numbers, must match a version
+* `jdkVersions` (default: `[8]`) - JDK version numbers, must match a version
   number jdk tool installed
 * `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
 * `failFast` (default: `true`) - instruct Maven tests to fail fast

--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,7 @@ Jenkins project's own link:https://ci.jenkins.io[Jenkins] instance(s).
 Applies the appropriate defaults for building a Maven-based plugin project on
 Linux and Windows.
 
+You are advised to be using a link:https://github.com/jenkinsci/plugin-pom/blob/master/README.md[2.x parent POM].
 
 .Jenkinsfile
 [source,groovy]

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -3,7 +3,7 @@
 /**
  * Simple wrapper step for building a plugin
  */
-def call(List<Integer> jdkVersions = [7, 8],
+def call(List<Integer> jdkVersions = [8],
         String repo = null,
         Boolean failFast = true,
         List<String> platforms = ['linux', 'windows']) {


### PR DESCRIPTION
We only really recommend building on JDK 8, so do not waste resources doing extra builds with JDK 7.

All plugins using a 2.x parent POM will anyway be specifying an explicit baseline Java Platform version—7 by default. So all that is skipped here is running tests on Java 7. Since the majority of users are on 8, and we will soon be requiring 8 for new versions of Jenkins, this will just mean that we will not be catching functional problems which only manifest themselves on an EOL platform. I think that is a reasonably price to pay for cheaper builds.

(And if you are on an obsolete parent POM, well what are you doing using a shiny new `Jenkinsfile`?)

@reviewbybees