### PR TITLE
skipAfterFailureCount was bogus

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -52,8 +52,7 @@ def call(Map params = [:]) {
                                         '--batch-mode',
                                         '--errors',
                                         '--update-snapshots',
-                                        '-Dmaven.test.failure.ignore=true',
-                                        "-DskipAfterFailureCount=${failFast}",
+                                        '-Dmaven.test.failure.ignore',
                                 ]
                                 if (jenkinsVersion) {
                                     mavenOptions += "-Djenkins.version=${jenkinsVersion}"


### PR DESCRIPTION
Introduced in 5a466bced52272357fa477870c23678ca6b4236e yet if you look at the [documentation](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#skipAfterFailureCount) you will see that

* it is supposed to take a number, not a boolean
* the user property (not the POM configuration XML element name) starts with `surefire.`

Better to just delete rather than pass a misleading argument, though if you like it could be set to 1.

@reviewbybees esp. @rtyler