### PR TITLE
Add support for using Docker Hub credentials inside trusted.ci

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -3,3 +3,14 @@
 Boolean isTrusted() {
     return env.JENKINS_URL == 'https://trusted.ci.jenkins.io:1443/'
 }
+
+Object withDockerCredentials(Closure body) {
+    if (isTrusted()) {
+        withCredentials([[$class: 'ZipFileBinding', credentialsId: 'jenkins-dockerhub', variable: 'DOCKER_CONFIG']]) {
+            return body.call()
+        }
+    }
+    else {
+        echo 'Cannot use Docker credentials outside of the trusted environment'
+    }
+}


### PR DESCRIPTION
The credentials code is already being used in jenkins-infra/account-app