### PR TITLE
[INFRA-1277] - Do not use settings-azure.xml when running outside Azure.

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -50,7 +50,7 @@ def call(Map params = [:]) {
                                         '--update-snapshots',
                                         '-Dmaven.test.failure.ignore',
                                 ]
-                                if (jdk.toInteger() > 7) {
+                                if (jdk.toInteger() > 7 && infra.isRunsOnJenkinsAzure()) {
                                     /* Azure mirror only works for sufficiently new versions of the JDK due to Letsencrypt cert */
                                     def settingsXml = "${pwd tmp: true}/settings-azure.xml"
                                     writeFile file: settingsXml, text: libraryResource('settings-azure.xml')

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -50,7 +50,7 @@ def call(Map params = [:]) {
                                         '--update-snapshots',
                                         '-Dmaven.test.failure.ignore',
                                 ]
-                                if (jdk.toInteger() > 7 && infra.isRunsOnJenkinsAzure()) {
+                                if (jdk.toInteger() > 7 && infra.isRunningOnJenkinsInfra()) {
                                     /* Azure mirror only works for sufficiently new versions of the JDK due to Letsencrypt cert */
                                     def settingsXml = "${pwd tmp: true}/settings-azure.xml"
                                     writeFile file: settingsXml, text: libraryResource('settings-azure.xml')

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 Boolean isRunningOnJenkinsInfra() {
-    return env.JENKINS_URL == 'https://ci.jenkins.io' || isTrusted()
+    return env.JENKINS_URL == 'https://ci.jenkins.io/' || isTrusted()
 }
 
 Boolean isTrusted() {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -1,11 +1,7 @@
 #!/usr/bin/env groovy
 
-Boolean isRunsOnJenkinsAzure() {
-    return isJenkinsIO() || isTrusted()
-}
-
-Boolean isJenkinsIO() {
-    return env.JENKINS_URL == 'https://ci.jenkins.io'
+Boolean isRunningOnJenkinsInfra() {
+    return env.JENKINS_URL == 'https://ci.jenkins.io' || isTrusted()
 }
 
 Boolean isTrusted() {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -1,5 +1,13 @@
 #!/usr/bin/env groovy
 
+Boolean isRunsOnJenkinsAzure() {
+    return isJenkinsIO() || isTrusted()
+}
+
+Boolean isJenkinsIO() {
+    return env.JENKINS_URL == 'https://ci.jenkins.io'
+}
+
 Boolean isTrusted() {
     return env.JENKINS_URL == 'https://trusted.ci.jenkins.io:1443/'
 }


### PR DESCRIPTION
The script may be invoked from outside, e.g. during the patch development for it.
This change just disables the logic when it runs at one of Jenkins instances within our Azure infrastructure. Just a money saver.

@rtyler @jglick 