### PR TITLE
Apply timeout only inside each node block

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -20,6 +20,7 @@ def call(Map params = [:]) {
 
                 tasks[stageIdentifier] = {
                     node(label) {
+                        timeout(60) {
                         boolean isMaven
 
                         stage("Checkout (${stageIdentifier})") {
@@ -101,17 +102,13 @@ def call(Map params = [:]) {
                             archiveArtifacts artifacts: artifacts, fingerprint: true
                         }
                     }
+                    }
                 }
             }
         }
     }
 
-    /* If we cannot complete in 60 minutes, we should fail the build. Compute
-     * isn't free!
-     */
-    timeout(60) {
-        timestamps {
-            return parallel(tasks)
-        }
+    timestamps {
+        return parallel(tasks)
     }
 }


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-multibranch-plugin/pull/67 failed simply because the Windows node [took 52½m to be scheduled](https://ci.jenkins.io/job/Plugins/job/workflow-multibranch-plugin/job/PR-67/1/execution/node/18/log/), and then the remaining 7½m was not long enough to run the build, especially since most of that was downloading artifacts. We should apply the 1h timeout only to the actual build process once the executor slot is available.

@reviewbybees