### PR TITLE
Update builds: Refactoring, Parallel test support, Coverages, etc.

### DIFF
--- a/vars/buildGradleComponent.groovy
+++ b/vars/buildGradleComponent.groovy
@@ -9,7 +9,7 @@
  * @param jdk JDK version to be used, {@code 8} by default
  * @param jenkinsVersion Version of Jenkins to be used. {@code null} if the default version in pom.xml should be used
  * @param repo Repository to be used for Git checkout. Use {@code null} for Multi-Branch
- * @parem failFast Fail the build if one of the branches fails
+ * @param failFast Fail the build if one of the branches fails
  */
 def call(String stageIdentifier, String label = "linux", String jdk = 8, String jenkinsVersion = null,
          String repo = null, boolean failFast = true) {

--- a/vars/buildGradleComponent.groovy
+++ b/vars/buildGradleComponent.groovy
@@ -1,10 +1,19 @@
 #!/usr/bin/env groovy
 
 /**
- * Builds a component, which implements Jenkins Plugin POM.
- * It may be either Jenkins plugin or module, depending on the packaging.
+ * Builds a component using Gradle.
+ * This build has less features than Maven-based builds.
+ *
+ * @param stageIdentifier Stage identifier
+ * @param label Node label to be used, {@code linux} by default
+ * @param jdk JDK version to be used, {@code 8} by default
+ * @param jenkinsVersion Version of Jenkins to be used. {@code null} if the default version in pom.xml should be used
+ * @param repo Repository to be used for Git checkout. Use {@code null} for Multi-Branch
+ * @parem failFast Fail the build if one of the branches fails
  */
-def call(String stageIdentifier, String label = "linux", String jdk = 8, String repo = null, boolean failFast = true) {
+def call(String stageIdentifier, String label = "linux", String jdk = 8, String jenkinsVersion = null,
+         String repo = null, boolean failFast = true) {
+
     node(label) {
         timeout(60) {
             String testReports
@@ -12,9 +21,6 @@ def call(String stageIdentifier, String label = "linux", String jdk = 8, String 
 
             stage("Checkout (${stageIdentifier})") {
                 commonSteps.checkout(repo)
-            }
-
-            stage("Analyze project") {
                 testReports = '**/build/test-results/**/*.xml'
                 artifacts = '**/build/libs/*.hpi,**/build/libs/*.jpi'
             }

--- a/vars/buildGradleComponent.groovy
+++ b/vars/buildGradleComponent.groovy
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+
+/**
+ * Builds a component, which implements Jenkins Plugin POM.
+ * It may be either Jenkins plugin or module, depending on the packaging.
+ */
+def call(String stageIdentifier, String label = "linux", String jdk = 8, String repo = null, boolean failFast = true) {
+    node(label) {
+        timeout(60) {
+            String testReports
+            String artifacts
+
+            stage("Checkout (${stageIdentifier})") {
+                commonSteps.checkout(repo)
+            }
+
+            stage("Analyze project") {
+                testReports = '**/build/test-results/**/*.xml'
+                artifacts = '**/build/libs/*.hpi,**/build/libs/*.jpi'
+            }
+
+            stage("Build (${stageIdentifier})") {
+                List<String> gradleOptions = [
+                    '--no-daemon',
+                    'cleanTest',
+                    'build',
+                ]
+                String command = "gradlew ${gradleOptions.join(' ')}"
+                if (isUnix()) {
+                    command = "./" + command
+                }
+
+                commonSteps.runWithJava(command, jdk)
+            }
+
+            stage("Archive (${stageIdentifier})") {
+                junit testReports
+                if (failFast && currentBuild.result == 'UNSTABLE') {
+                    error 'There were test failures; halting early'
+                }
+                archiveArtifacts artifacts: artifacts, fingerprint: true
+            }
+        }
+    }
+
+    return;
+}

--- a/vars/buildMavenPluginPom.groovy
+++ b/vars/buildMavenPluginPom.groovy
@@ -4,27 +4,19 @@
  * Builds a component, which implements Jenkins Plugin POM.
  * It may be either Jenkins plugin or module, depending on the packaging.
  *
- * @param stageIdentifier Textual identifier for operations
- * @param label Node label, which should be used for the build
- * @param jdk JDK version, which should be used for the build. E.g. {@code 8}
- * @param jenkinsVersion Jenkins version, which should be used for the build. {@code null} for default defined in POM.xml
- * @param repo Repository to be used. {@code null} can be used in Multi-branch build
+ * @param stageIdentifier Stage identifier
+ * @param label Node label to be used, {@code linux} by default
+ * @param jdk JDK version to be used, {@code 8} by default
+ * @param jenkinsVersion Version of Jenkins to be used. {@code null} if the default version in pom.xml should be used
+ * @param repo Repository to be used for Git checkout. Use {@code null} for Multi-Branch
+ * @parem failFast Fail the build if one of the branches fails
+ * @param testParallelism Number of parallel test builds, {@code 1} by default
  */
-Boolean call(Map params = [:]) {
-
-    def stageIdentifier = params.stageIdentifier
-    def label = params.containsKey('label') ? params.label : 'linux'
-    def jdk = params.containsKey('jdk') ? params.jdk : 8
-    def jenkinsVersion = params.containsKey('jenkinsVersion') ? params.jenkinsVersion : [null]
-    def repo = params.containsKey('repo') ? params.repo : null
-    def failFast = params.containsKey('failFast') ? params.failFast : true
-    def testParallelism = params.containsKey('testParallelism') ? params.testParallelism : 1
-    boolean runFindbugs = params.containsKey('runFindbugs') ? params.runFindbugs : true
-    boolean archiveFindbugs = params.containsKey('archiveFindbugs') ? params.archiveFindbugs : true
-    boolean runCheckstyle = params.containsKey('runCheckstyle') ? params.runCheckstyle : true
-    boolean archiveCheckstyle = params.containsKey('archiveCheckstyle') ? params.archiveCheckstyle : true
-    boolean runCobertura = params.containsKey('runCobertura') ? params.runCobertura : true
-
+def call(String stageIdentifier, String label = "linux", String jdk = "8", String jenkinsVersion = null,
+             String repo = null, boolean failFast = true, int testParallelism = 1,
+             boolean runFindbugs = true, boolean archiveFindbugs = true,
+             boolean runCheckstyle = true, boolean archiveCheckstyle = true,
+             boolean runCobertura = true) {
 
     node(label) {
         timeout(60) {
@@ -136,5 +128,4 @@ Boolean call(Map params = [:]) {
             }
         }
     }
-    return true
 }

--- a/vars/buildMavenPluginPom.groovy
+++ b/vars/buildMavenPluginPom.groovy
@@ -1,0 +1,140 @@
+#!/usr/bin/env groovy
+
+/**
+ * Builds a component, which implements Jenkins Plugin POM.
+ * It may be either Jenkins plugin or module, depending on the packaging.
+ *
+ * @param stageIdentifier Textual identifier for operations
+ * @param label Node label, which should be used for the build
+ * @param jdk JDK version, which should be used for the build. E.g. {@code 8}
+ * @param jenkinsVersion Jenkins version, which should be used for the build. {@code null} for default defined in POM.xml
+ * @param repo Repository to be used. {@code null} can be used in Multi-branch build
+ */
+Boolean call(Map params = [:]) {
+
+    def stageIdentifier = params.stageIdentifier
+    def label = params.containsKey('label') ? params.label : 'linux'
+    def jdk = params.containsKey('jdk') ? params.jdk : 8
+    def jenkinsVersion = params.containsKey('jenkinsVersion') ? params.jenkinsVersion : [null]
+    def repo = params.containsKey('repo') ? params.repo : null
+    def failFast = params.containsKey('failFast') ? params.failFast : true
+    def testParallelism = params.containsKey('testParallelism') ? params.testParallelism : 1
+    boolean runFindbugs = params.containsKey('runFindbugs') ? params.runFindbugs : true
+    boolean archiveFindbugs = params.containsKey('archiveFindbugs') ? params.archiveFindbugs : true
+    boolean runCheckstyle = params.containsKey('runCheckstyle') ? params.runCheckstyle : true
+    boolean archiveCheckstyle = params.containsKey('archiveCheckstyle') ? params.archiveCheckstyle : true
+    boolean runCobertura = params.containsKey('runCobertura') ? params.runCobertura : true
+
+
+    node(label) {
+        timeout(60) {
+            boolean isParallelTestMode
+            List<String> baseMavenParameters
+            String testReports
+            String artifacts
+
+            def mavenEnvVars = ["PATH+MAVEN=${tool 'mvn'}/bin"];
+
+            stage("Checkout (${stageIdentifier})") {
+                commonSteps.checkout(repo)
+
+                // Manage test parallelism
+                if (testParallelism > 1) {
+                    echo "Using parallel tests mode"
+                }
+                isParallelTestMode = testParallelism > 1
+
+                // Prepare Maven defaults
+                baseMavenParameters = [
+                    '--batch-mode',
+                    '--errors',
+                    '--update-snapshots',
+                    '-Dmaven.test.failure.ignore',
+                ]
+                if (jdk.toInteger() > 7 && infra.isRunningOnJenkinsInfra()) {
+                    /* Azure mirror only works for sufficiently new versions of the JDK due to Letsencrypt cert */
+                    def settingsXml = "${pwd tmp: true}/settings-azure.xml"
+                    writeFile file: settingsXml, text: libraryResource('settings-azure.xml')
+                    baseMavenParameters += "-s $settingsXml"
+                }
+                if (jenkinsVersion) {
+                    baseMavenParameters += "-Djenkins.version=${jenkinsVersion}"
+                }
+
+                // Artifacts to publish
+                testReports = '**/target/surefire-reports/**/*.xml'
+                artifacts = '**/target/*.hpi,**/target/*.jpi'
+            }
+
+            stage("Build (${stageIdentifier})") {
+                List<String> mavenOptions = new ArrayList<>(baseMavenParameters)
+                List<String> profiles = [];
+                if (params?.findbugs?.run || params?.findbugs?.archive) {
+                    mavenOptions += isParallelTestMode ? "-Dfindbugs.skip=true" : "-Dfindbugs.failOnError=false"
+                }
+                if (params?.checkstyle?.run || params?.checkstyle?.archive) {
+                    mavenOptions += isParallelTestMode ? "-Dcheckstyle.skip=true" : "-Dcheckstyle.failOnViolation=false -Dcheckstyle.failsOnError=false"
+                }
+                if (isParallelTestMode) {
+                    mavenOptions += "-DskipTests"
+                    profiles << "!skip-findbugs-with-tests"
+                }
+                mavenOptions += "clean install"
+                if (runFindbugs && !isParallelTestMode) {
+                    mavenOptions += "findbugs:findbugs"
+                }
+                if (runCheckstyle && !isParallelTestMode) {
+                    mavenOptions += "checkstyle:checkstyle"
+                }
+                if (runCobertura && !isParallelTestMode) {
+                    profiles << "coverage"
+                }
+
+                commonSteps.runWithJava("mvn ${mavenOptions.join(' ')}", jdk, mavenEnvVars)
+            }
+
+            if (isParallelTestMode) {
+                stage("Test (${stageIdentifier})") {
+                    List<String> mavenOptions = new ArrayList<>(baseMavenParameters)
+                    mavenOptions += "-Dfindbugs.skip=true"
+                    mavenOptions += "-Dcheckstyle.skip=true"
+                    String prefix = "${label}-${jdk}"
+                    runParallelTests(prefix, label, mavenOptions, jdk, ((boolean)repo) ? repo : null, testParallelism, mavenEnvVars)
+                }
+            }
+
+            stage("Archive (${stageIdentifier})") {
+
+                if (!isParallelTestMode) {
+                    junit testReports
+                    // TODO do this in a finally-block so we capture all test results even if one branch aborts early
+                }
+                if (archiveFindbugs) {
+                    def fp = [pattern: params?.findbugs?.pattern ?: '**/target/findbugsXml.xml']
+                    if (params?.findbugs?.unstableNewAll) {
+                        fp['unstableNewAll'] ="${params.findbugs.unstableNewAll}"
+                    }
+                    if (params?.findbugs?.unstableTotalAll) {
+                        fp['unstableTotalAll'] ="${params.findbugs.unstableTotalAll}"
+                    }
+                    findbugs(fp)
+                }
+                if (archiveCheckstyle) {
+                    def cp = [pattern: params?.checkstyle?.pattern ?: '**/target/checkstyle-result.xml']
+                    if (params?.checkstyle?.unstableNewAll) {
+                        cp['unstableNewAll'] ="${params.checkstyle.unstableNewAll}"
+                    }
+                    if (params?.checkstyle?.unstableTotalAll) {
+                        cp['unstableTotalAll'] ="${params.checkstyle.unstableTotalAll}"
+                    }
+                    checkstyle(cp)
+                }
+                if (failFast && currentBuild.result == 'UNSTABLE') {
+                    error 'There were test failures; halting early'
+                }
+                archiveArtifacts artifacts: artifacts, fingerprint: true
+            }
+        }
+    }
+    return true
+}

--- a/vars/buildMavenPluginPom.groovy
+++ b/vars/buildMavenPluginPom.groovy
@@ -9,7 +9,7 @@
  * @param jdk JDK version to be used, {@code 8} by default
  * @param jenkinsVersion Version of Jenkins to be used. {@code null} if the default version in pom.xml should be used
  * @param repo Repository to be used for Git checkout. Use {@code null} for Multi-Branch
- * @parem failFast Fail the build if one of the branches fails
+ * @param failFast Fail the build if one of the branches fails
  * @param testParallelism Number of parallel test builds, {@code 1} by default
  */
 def call(String stageIdentifier, String label = "linux", String jdk = "8", String jenkinsVersion = null,

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -49,27 +49,34 @@ def call(Map params = [:]) {
 
                 tasks[stageIdentifier] = {
                     if (isMaven) {
-                        boolean runFindbugs = first && params?.findbugs?.run
-                        boolean runCheckstyle = first && params?.checkstyle?.run
-                        boolean runCobertura = first && params?.cobertura?.run
-                        boolean archiveFindbugs = first && params?.findbugs?.archive
-                        boolean archiveCheckstyle = first && params?.checkstyle?.archive
+                        boolean runFindbugs = (first && params?.findbugs?.run) ?: false
+                        boolean runCheckstyle = (first && params?.checkstyle?.run) ?: false
+                        boolean runCobertura = (first && params?.cobertura?.run) ?: false
+                        boolean archiveFindbugs = (first && params?.findbugs?.archive) ?: false
+                        boolean archiveCheckstyle = (first && params?.checkstyle?.archive) ?: false
 
                         buildMavenPluginPom(
-                            stageIdentifier: stageIdentifier,
-                            label: label,
-                            jdk: jdk,
-                            jenkinsVersion: jenkinsVersion,
-                            repo: repo,
-                            testParallelism: testParallelism,
-                            runFindbugs: runFindbugs,
-                            archiveFindbugs: archiveFindbugs,
-                            runCheckstyle: runCheckstyle,
-                            archiveCheckstyle: archiveCheckstyle,
-                            runCobertura: runCobertura);
+                            stageIdentifier,
+                            label,
+                            jdk,
+                            jenkinsVersion,
+                            repo,
+                            failFast,
+                            testParallelism,
+                            runFindbugs,
+                            archiveFindbugs,
+                            runCheckstyle,
+                            archiveCheckstyle,
+                            runCobertura);
                     } else {
                         //TODO: add support of Jenkins Version
-                         buildGradleComponent(stageIdentifier, label, jdk, failFast)
+                         buildGradleComponent(
+                             stageIdentifier,
+                             label,
+                             jdk,
+                             jenkinsVersion,
+                             repo,
+                             failFast)
                     }
                 }
             }

--- a/vars/cobertura.groovy
+++ b/vars/cobertura.groovy
@@ -1,0 +1,21 @@
+/**
+ * Publishes Cobertura report.
+ * @param coberturaReportFile Report File to publish
+ * @param failUnhealthy Fail if the coverage is unhealthy
+ * @param failUnstable Fail if the build is unstable
+ * @return nothing
+ */
+def publish(String coberturaReportFile, boolean failUnhealthy=false, boolean failUnstable=false) {
+    step([$class: 'CoberturaPublisher',
+          autoUpdateHealth: false,
+          autoUpdateStability: false,
+          coberturaReportFile: 'target/coverage.xml',
+          failNoReports: false,
+          failUnhealthy: failUnhealthy,
+          failUnstable: failUnstable,
+          maxNumberOfBuilds: 0,
+          onlyStable: false,
+          sourceEncoding: 'ASCII',
+          zoomCoverageChart: false]
+    )
+}

--- a/vars/commonSteps.groovy
+++ b/vars/commonSteps.groovy
@@ -1,0 +1,32 @@
+Object checkout(String repo = null) {
+    if (env.BRANCH_NAME) {
+        checkout scm
+    }
+    else if ((env.BRANCH_NAME == null) && (repo)) {
+        git repo
+    }
+    else {
+        error 'buildPlugin must be used as part of a Multibranch Pipeline *or* a `repo` argument must be provided'
+    }
+}
+
+Object runWithJava(String command, String jdk = 8, List<String> extraEnv = null) {
+    String jdkTool = "jdk${jdk}"
+    List<String> env = [
+        "JAVA_HOME=${tool jdkTool}",
+        'PATH+JAVA=${JAVA_HOME}/bin',
+    ]
+    if (extraEnv != null) {
+        env.addAll(extraEnv)
+    }
+
+    withEnv(env) {
+        if (isUnix()) {
+            sh command
+        } else {
+            bat command
+        }
+    }
+}
+
+

--- a/vars/runParallelTests.groovy
+++ b/vars/runParallelTests.groovy
@@ -1,0 +1,48 @@
+def call(String prefix, String label, List<String> mavenOptions, String jdk = 8,
+         String repo = null, int testParallelism=1,
+         List<String> extraEnvVars = null) {
+
+    /* Request the test groupings.  Based on previous test results. */
+    /* see https://wiki.jenkins-ci.org/display/JENKINS/Parallel+Test+Executor+Plugin and demo on github
+    /* Using arbitrary parallelism of 4 and "generateInclusions" feature added in v1.8. */
+    def splits = splitTests parallelism: [$class: 'CountDrivenParallelism', size: testParallelism], generateInclusions: true
+
+    /* Create dictionary to hold set of parallel test executions. */
+    def testGroups = [:]
+
+    for (int i = 0; i < splits.size(); i++) {
+        def splitNo = i
+        def split = splits[i]
+
+        /* Loop over each record in splits to prepare the testGroups that we'll run in parallel. */
+        /* Split records returned from splitTests contain { includes: boolean, list: List<String> }. */
+        /*     includes = whether list specifies tests to include (true) or tests to exclude (false). */
+        /*     list = list of tests for inclusion or exclusion. */
+        /* The list of inclusions is constructed based on results gathered from */
+        /* the previous successfully completed job. One additional record will exclude */
+        /* all known tests to run any tests not seen during the previous run.  */
+        testGroups["${prefix}-split-${splitNo}"] = {  // example, "split3"
+            node(label) {
+                commonSteps.checkout(repo)
+
+                def command = "mvn clean verify -DMaven.test.failure.ignore=true ${mavenOptions.join(' ')}"
+
+                /* Write includesFile or excludesFile for tests.  Split record provided by splitTests. */
+                /* Tell Maven to read the appropriate file. */
+                if (split.includes) {
+                    writeFile file: "tmp/parallel-test-includes-${splitNo}.txt", text: split.list.join("\n")
+                    command += " -Dsurefire.includesFile=tmp/parallel-test-includes-${splitNo}.txt"
+                } else {
+                    writeFile file: "tmp/parallel-test-excludes-${splitNo}.txt", text: split.list.join("\n")
+                    command += " -Dsurefire.excludesFile=tmp/parallel-test-excludes-${splitNo}.txt"
+                }
+
+                commonSteps.runWithJava(command, jdk, extraEnvVars);
+
+                /* Archive the test results */
+                junit '**/target/surefire-reports/TEST-*.xml'
+            }
+        }
+    }
+    parallel testGroups
+}

--- a/vars/runParallelTests.txt
+++ b/vars/runParallelTests.txt
@@ -1,0 +1,3 @@
+<p>
+    Run tests in parallel and then reports them. Supports only Maven projects.
+</p>


### PR DESCRIPTION
This is a WiP pull request, which updates the Pipeline library a bit. My main idea is to have a more comprehensive Pipeline library demo, which also offers more features on jenkins.io.

- [x] - Refactor buildPlugin and introduce buildMavenPluginPom and buildGradleComponent methods
- [x] - Introduce the `repoType` parameter, which enforces Maven or Gradle without doing the repo checkout. Ideally `buildMavenPluginPom()` should fallback to radle so there will be no extra `node()` block in the default logic
- [x] - Add support of parallel testing in Maven projects.
- [x] - Add stages
- [x] - Add Cobertura sample for coverage publishing
- [ ] - Add `jacoco` support forCoverage publishing, which is supported OOTB in Plugin POMs
- [ ] - Add tests using Pipeline Unit

Pipeline for a single platform:

<img width="741" alt="screen shot 2017-12-03 at 19 05 54" src="https://user-images.githubusercontent.com/3000480/33527247-6bf7e302-d85e-11e7-93b4-042608013607.png">

Multi-platform Pipeline:

<img width="498" alt="screen shot 2017-12-03 at 19 09 35" src="https://user-images.githubusercontent.com/3000480/33527250-8092532e-d85e-11e7-898e-0e66d830747b.png">

Multi-platform Pipeline with parallel tests:

<img width="584" alt="screen shot 2017-12-03 at 19 19 47" src="https://user-images.githubusercontent.com/3000480/33527278-f7f3c0ba-d85e-11e7-9f14-684fc4afeca0.png">

The latter graph looks strange, CC @abayer @svanoort. I'd guess BlueOcean does not support parallel-in-parallel.


