### PR TITLE
Add support of Pipeline library Javadoc generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+// Builds a module using https://github.com/jenkins-infra/pipeline-library
+// In the case of this repository, just generates Javadocs so far.
+// More comprehensive CI will be created later.
+buildPlugin(platforms: ['linux'])

--- a/demo/heisenbug-1-firstPipeline.groovy
+++ b/demo/heisenbug-1-firstPipeline.groovy
@@ -1,0 +1,4 @@
+node("linux") {
+    demo.checkout() // Wrapper for the demo checkout
+    sh "mvn clean verify"
+}

--- a/demo/heisenbug-2-withPublish.groovy
+++ b/demo/heisenbug-2-withPublish.groovy
@@ -1,0 +1,8 @@
+node('linux') {
+    demo.checkout()
+    sh "mvn clean verify -Dmaven.test.failure.ignore -Pcoverage"
+
+    junit "target/**/TEST-*.xml"
+    findbugs pattern: "**/target/findbugsXml.xml"
+    cobertura("target/coverage.xml")
+}

--- a/demo/heisenbug-3-withStages.groovy
+++ b/demo/heisenbug-3-withStages.groovy
@@ -1,0 +1,16 @@
+node('linux') {
+    stage("Checkout") {
+        demo.checkout()
+    }
+    try {
+        stage("Build") {
+            sh "mvn clean verify -Dmaven.test.failure.ignore -Pcoverage"
+        }
+    } finally {
+        stage("Archive") {
+            junit "target/**/TEST-*.xml"
+            findbugs pattern: "**/target/findbugsXml.xml"
+            cobertura("target/coverage.xml")
+        }
+    }
+}

--- a/demo/heisenbug-4-withErrorHandlers.groovy
+++ b/demo/heisenbug-4-withErrorHandlers.groovy
@@ -1,0 +1,18 @@
+node('linux') {
+    stage("Checkout") {
+        demo.checkout()
+    }
+    try {
+        stage("Build") {
+            commons.withErrorHandlers(10) {
+                sh "mvn clean verify -Djava.level=9 -Dmaven.test.failure.ignore -Pcoverage"
+            }
+        }
+    } finally {
+        stage("Archive") {
+            junit "target/**/TEST-*.xml"
+            findbugs pattern: "**/target/findbugsXml.xml"
+            cobertura("target/coverage.xml")
+        }
+    }
+}

--- a/demo/heisenbug-5-withEmail.groovy
+++ b/demo/heisenbug-5-withEmail.groovy
@@ -1,0 +1,16 @@
+import my.pipeline.lib.MailExtSender
+
+node('linux') {
+    stage("Checkout") {
+        demo.checkout()
+    }
+
+    stage("Notify") {
+        def builder = new MailExtSender(this)
+            .withSubject("Test results for project Foo")
+            .withRecipient("oleg-nenashev@foo.bar")
+            .withTestReports(true)
+            .send()
+    }
+
+}

--- a/demo/heisenbug-6-realDemo.groovy
+++ b/demo/heisenbug-6-realDemo.groovy
@@ -1,0 +1,17 @@
+node('linux') {
+    stage("Checkout") {
+        demo.checkout()
+    }
+    try {
+        stage("Build") {
+            sh "mvn clean verify -DskipTests"
+        }
+    } finally {
+        stage("Archive") {
+            findbugs pattern: "**/target/findbugsXml.xml"
+        }
+    }
+
+    demo.runParallel(2, true)
+    cobertura.mergeStashes(2)
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,103 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Depends on Jenkins plugin POM to retrieve the default tooling for Groovy -->
+  <!-- TODO: create a new Parent POM for Pipeline libs?-->
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>3.2</version>
+  </parent>
+
+  <groupId>org.jenkins-ci.infra.ci</groupId>
+  <artifactId>pipeline-library</artifactId>
+  <version>1.2-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>jenkins.io Pipeline Library</name>
+  <url>https://github.com/jenkins-infra/pipeline-library</url>
+
+  <properties>
+    <jenkins.version>2.73.3</jenkins.version>
+    <java.level>8</java.level>
+  </properties>
+
+  <licenses>
+    <license>
+      <name>The MIT license</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:ssh://github.com/jenkins-infra/pipeline-library.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/jenkins-infra/pipeline-library.git</developerConnection>
+    <url>https://github.com/jenkinsci/jenkins-infra/pipeline-library</url>
+  </scm>
+
+  <build>
+    <sourceDirectory>./src</sourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>gmaven-plugin</artifactId>
+        <version>1.5-jenkins-4-20171204.003627-2</version>
+        <executions>
+          <execution>
+            <id>groovy-stubs</id>
+            <goals>
+              <goal>generateStubs</goal>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.0.6</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <sources>
+            <source>
+              <directory>${project.basedir}/src/</directory>
+              <includes>
+                <include>**/*.groovy</include>
+              </includes>
+            </source>
+            <source>
+              <directory>${project.basedir}/vars/</directory>
+              <includes>
+                <include>**/*.groovy</include>
+              </includes>
+            </source>
+          </sources>
+          <testSources>
+            <testSource>
+              <directory>${project.basedir}/src/test/java</directory>
+              <includes>
+                <include>**/*.groovy</include>
+              </includes>
+            </testSource>
+          </testSources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+</project>  

--- a/src/my/pipeline/lib/MailExtSender.groovy
+++ b/src/my/pipeline/lib/MailExtSender.groovy
@@ -1,0 +1,36 @@
+package my.pipeline.lib
+
+class MailExtSender {
+
+    final def script
+    String subject = "Undefined"
+    String body = "Undefined"
+    List<String> recipients = []
+    String attachmentsPattern = null
+
+    MailExtSender(def script) {
+        this.script = script
+    }
+
+    def withSubject(String subject) {
+        this.subject = subject
+        return this
+    }
+
+    def withRecipient(String email) {
+        this.recipients << email
+        return this
+    }
+
+    def withTestReports(boolean add) {
+        this.attachmentsPattern = add ? "target/**/TEST-*.xml" : null
+        return this
+    }
+
+    void send() {
+        script.emailext subject: subject, body: body,
+                        attachmentsPattern: attachmentsPattern,
+            to: recipients.join(',')
+    }
+}
+

--- a/vars/buildGradleComponent.groovy
+++ b/vars/buildGradleComponent.groovy
@@ -1,0 +1,53 @@
+#!/usr/bin/env groovy
+
+/**
+ * Builds a component using Gradle.
+ * This build has less features than Maven-based builds.
+ *
+ * @param stageIdentifier Stage identifier
+ * @param label Node label to be used, {@code linux} by default
+ * @param jdk JDK version to be used, {@code 8} by default
+ * @param jenkinsVersion Version of Jenkins to be used. {@code null} if the default version in pom.xml should be used
+ * @param repo Repository to be used for Git checkout. Use {@code null} for Multi-Branch
+ * @param failFast Fail the build if one of the branches fails
+ */
+def call(String stageIdentifier, String label = "linux", String jdk = 8, String jenkinsVersion = null,
+         String repo = null, boolean failFast = true) {
+
+    node(label) {
+        timeout(60) {
+            String testReports
+            String artifacts
+
+            stage("Checkout (${stageIdentifier})") {
+                commons.checkout(repo)
+                testReports = '**/build/test-results/**/*.xml'
+                artifacts = '**/build/libs/*.hpi,**/build/libs/*.jpi'
+            }
+
+            stage("Build (${stageIdentifier})") {
+                List<String> gradleOptions = [
+                    '--no-daemon',
+                    'cleanTest',
+                    'build',
+                ]
+                String command = "gradlew ${gradleOptions.join(' ')}"
+                if (isUnix()) {
+                    command = "./" + command
+                }
+
+                commons.runWithJava(command, jdk)
+            }
+
+            stage("Archive (${stageIdentifier})") {
+                junit testReports
+                if (failFast && currentBuild.result == 'UNSTABLE') {
+                    error 'There were test failures; halting early'
+                }
+                archiveArtifacts artifacts: artifacts, fingerprint: true
+            }
+        }
+    }
+
+    return;
+}

--- a/vars/buildMavenPluginPom.groovy
+++ b/vars/buildMavenPluginPom.groovy
@@ -1,0 +1,131 @@
+#!/usr/bin/env groovy
+
+/**
+ * Builds a component, which implements Jenkins Plugin POM.
+ * It may be either Jenkins plugin or module, depending on the packaging.
+ *
+ * @param stageIdentifier Stage identifier
+ * @param label Node label to be used, {@code linux} by default
+ * @param jdk JDK version to be used, {@code 8} by default
+ * @param jenkinsVersion Version of Jenkins to be used. {@code null} if the default version in pom.xml should be used
+ * @param repo Repository to be used for Git checkout. Use {@code null} for Multi-Branch
+ * @param failFast Fail the build if one of the branches fails
+ * @param testParallelism Number of parallel test builds, {@code 1} by default
+ */
+def call(String stageIdentifier, String label = "linux", String jdk = "8", String jenkinsVersion = null,
+             String repo = null, boolean failFast = true, int testParallelism = 1,
+             boolean runFindbugs = true, boolean archiveFindbugs = true,
+             boolean runCheckstyle = true, boolean archiveCheckstyle = true,
+             boolean runCobertura = true) {
+
+    node(label) {
+        timeout(60) {
+            boolean isParallelTestMode
+            List<String> baseMavenParameters
+            String testReports
+            String artifacts
+
+            def mavenEnvVars = ["PATH+MAVEN=${tool 'mvn'}/bin"];
+
+            stage("Checkout (${stageIdentifier})") {
+                commons.checkout(repo)
+
+                // Manage test parallelism
+                if (testParallelism > 1) {
+                    echo "Using parallel tests mode"
+                }
+                isParallelTestMode = testParallelism > 1
+
+                // Prepare Maven defaults
+                baseMavenParameters = [
+                    '--batch-mode',
+                    '--errors',
+                    '--update-snapshots',
+                    '-Dmaven.test.failure.ignore',
+                ]
+                if (jdk.toInteger() > 7 && infra.isRunningOnJenkinsInfra()) {
+                    /* Azure mirror only works for sufficiently new versions of the JDK due to Letsencrypt cert */
+                    def settingsXml = "${pwd tmp: true}/settings-azure.xml"
+                    writeFile file: settingsXml, text: libraryResource('settings-azure.xml')
+                    baseMavenParameters += "-s $settingsXml"
+                }
+                if (jenkinsVersion) {
+                    baseMavenParameters += "-Djenkins.version=${jenkinsVersion}"
+                }
+
+                // Artifacts to publish
+                testReports = '**/target/surefire-reports/**/*.xml'
+                artifacts = '**/target/*.hpi,**/target/*.jpi'
+            }
+
+            stage("Build (${stageIdentifier})") {
+                List<String> mavenOptions = new ArrayList<>(baseMavenParameters)
+                List<String> profiles = [];
+                if (params?.findbugs?.run || params?.findbugs?.archive) {
+                    mavenOptions += isParallelTestMode ? "-Dfindbugs.skip=true" : "-Dfindbugs.failOnError=false"
+                }
+                if (params?.checkstyle?.run || params?.checkstyle?.archive) {
+                    mavenOptions += isParallelTestMode ? "-Dcheckstyle.skip=true" : "-Dcheckstyle.failOnViolation=false -Dcheckstyle.failsOnError=false"
+                }
+                if (isParallelTestMode) {
+                    mavenOptions += "-DskipTests"
+                    profiles << "!skip-findbugs-with-tests"
+                }
+                mavenOptions += "clean install"
+                if (runFindbugs && !isParallelTestMode) {
+                    mavenOptions += "findbugs:findbugs"
+                }
+                if (runCheckstyle && !isParallelTestMode) {
+                    mavenOptions += "checkstyle:checkstyle"
+                }
+                if (runCobertura && !isParallelTestMode) {
+                    profiles << "coverage"
+                }
+
+                commons.runWithJava("mvn ${mavenOptions.join(' ')}", jdk, mavenEnvVars)
+            }
+
+            if (isParallelTestMode) {
+                stage("Test (${stageIdentifier})") {
+                    List<String> mavenOptions = new ArrayList<>(baseMavenParameters)
+                    mavenOptions += "-Dfindbugs.skip=true"
+                    mavenOptions += "-Dcheckstyle.skip=true"
+                    String prefix = "${label}-${jdk}"
+                    runParallelTests(prefix, label, mavenOptions, jdk, ((boolean)repo) ? repo : null, testParallelism, mavenEnvVars)
+                }
+            }
+
+            stage("Archive (${stageIdentifier})") {
+
+                if (!isParallelTestMode) {
+                    junit testReports
+                    // TODO do this in a finally-block so we capture all test results even if one branch aborts early
+                }
+                if (archiveFindbugs) {
+                    def fp = [pattern: params?.findbugs?.pattern ?: '**/target/findbugsXml.xml']
+                    if (params?.findbugs?.unstableNewAll) {
+                        fp['unstableNewAll'] ="${params.findbugs.unstableNewAll}"
+                    }
+                    if (params?.findbugs?.unstableTotalAll) {
+                        fp['unstableTotalAll'] ="${params.findbugs.unstableTotalAll}"
+                    }
+                    findbugs(fp)
+                }
+                if (archiveCheckstyle) {
+                    def cp = [pattern: params?.checkstyle?.pattern ?: '**/target/checkstyle-result.xml']
+                    if (params?.checkstyle?.unstableNewAll) {
+                        cp['unstableNewAll'] ="${params.checkstyle.unstableNewAll}"
+                    }
+                    if (params?.checkstyle?.unstableTotalAll) {
+                        cp['unstableTotalAll'] ="${params.checkstyle.unstableTotalAll}"
+                    }
+                    checkstyle(cp)
+                }
+                if (failFast && currentBuild.result == 'UNSTABLE') {
+                    error 'There were test failures; halting early'
+                }
+                archiveArtifacts artifacts: artifacts, fingerprint: true
+            }
+        }
+    }
+}

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -9,7 +9,32 @@ def call(Map params = [:]) {
     def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
+    def testParallelism = params.containsKey('testParallelism') ? params.testParallelism : 1
+    def projectType = params.containsKey('projectType') ? params.projectType : null
     Map tasks = [failFast: failFast]
+
+    boolean isMaven
+    //TODO: probably it makes sense to default to Maven instead
+    if (projectType == null) {
+        stage("Determine the project type") {
+            timeout(10) {
+                node("docker") {
+                    commons.checkout(repo)
+                    if (fileExists('pom.xml')) {
+                        projectType = "maven"
+                        isMaven = true
+                    } else if (fileExists('build.gradle')) {
+                        projectType = "gradle"
+                    } else {
+                        error("Cannot determine the project type")
+                    }
+                }
+            }
+        }
+    }
+    echo "Project type is ${projectType}"
+
+    String firstStageIdentifier
     for (int i = 0; i < platforms.size(); ++i) {
         for (int j = 0; j < jdkVersions.size(); ++j) {
             for (int k = 0; k < jenkinsVersions.size(); ++k) {
@@ -18,128 +43,40 @@ def call(Map params = [:]) {
                 String jenkinsVersion = jenkinsVersions[k]
                 String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
                 boolean first = i == 0 && j == 0 && k == 0
-                boolean runFindbugs = first && params?.findbugs?.run
-                boolean runCheckstyle = first && params?.checkstyle?.run
-                boolean archiveFindbugs = first && params?.findbugs?.archive
-                boolean archiveCheckstyle = first && params?.checkstyle?.archive
+                if (first) {
+                    firstStageIdentifier = stageIdentifier
+                }
 
                 tasks[stageIdentifier] = {
-                    node(label) {
-                        timeout(60) {
-                        boolean isMaven
+                    if (isMaven) {
+                        boolean runFindbugs = (first && params?.findbugs?.run) ?: false
+                        boolean runCheckstyle = (first && params?.checkstyle?.run) ?: false
+                        boolean runCobertura = (first && params?.cobertura?.run) ?: false
+                        boolean archiveFindbugs = (first && params?.findbugs?.archive) ?: false
+                        boolean archiveCheckstyle = (first && params?.checkstyle?.archive) ?: false
 
-                        stage("Checkout (${stageIdentifier})") {
-                            if (env.BRANCH_NAME) {
-                                checkout scm
-                            }
-                            else if ((env.BRANCH_NAME == null) && (repo)) {
-                                git repo
-                            }
-                            else {
-                                error 'buildPlugin must be used as part of a Multibranch Pipeline *or* a `repo` argument must be provided'
-                            }
-
-                            isMaven = fileExists('pom.xml')
-                        }
-
-                        stage("Build (${stageIdentifier})") {
-                            String jdkTool = "jdk${jdk}"
-                            List<String> env = [
-                                    "JAVA_HOME=${tool jdkTool}",
-                                    'PATH+JAVA=${JAVA_HOME}/bin',
-                            ]
-                            String command
-                            if (isMaven) {
-                                List<String> mavenOptions = [
-                                        '--batch-mode',
-                                        '--errors',
-                                        '--update-snapshots',
-                                        '-Dmaven.test.failure.ignore',
-                                ]
-                                if (jdk.toInteger() > 7 && infra.isRunningOnJenkinsInfra()) {
-                                    /* Azure mirror only works for sufficiently new versions of the JDK due to Letsencrypt cert */
-                                    def settingsXml = "${pwd tmp: true}/settings-azure.xml"
-                                    writeFile file: settingsXml, text: libraryResource('settings-azure.xml')
-                                    mavenOptions += "-s $settingsXml"
-                                }
-                                if (jenkinsVersion) {
-                                    mavenOptions += "-Djenkins.version=${jenkinsVersion}"
-                                }
-                                if (params?.findbugs?.run || params?.findbugs?.archive) {
-                                    mavenOptions += "-Dfindbugs.failOnError=false"
-                                }
-                                if (params?.checkstyle?.run || params?.checkstyle?.archive) {
-                                    mavenOptions += "-Dcheckstyle.failOnViolation=false -Dcheckstyle.failsOnError=false"
-                                }
-                                mavenOptions += "clean install"
-                                if (runFindbugs) {
-                                    mavenOptions += "findbugs:findbugs"
-                                }
-                                if (runCheckstyle) {
-                                    mavenOptions += "checkstyle:checkstyle"
-                                }
-                                command = "mvn ${mavenOptions.join(' ')}"
-                                env << "PATH+MAVEN=${tool 'mvn'}/bin"
-                            } else {
-                                List<String> gradleOptions = [
-                                        '--no-daemon',
-                                        'cleanTest',
-                                        'build',
-                                ]
-                                command = "gradlew ${gradleOptions.join(' ')}"
-                                if (isUnix()) {
-                                    command = "./" + command
-                                }
-                            }
-
-                            withEnv(env) {
-                                if (isUnix()) { // TODO JENKINS-44231 candidate for simplification
-                                    sh command
-                                }
-                                else {
-                                    bat command
-                                }
-                            }
-                        }
-
-                        stage("Archive (${stageIdentifier})") {
-                            String testReports
-                            String artifacts
-                            if (isMaven) {
-                                testReports = '**/target/surefire-reports/**/*.xml'
-                                artifacts = '**/target/*.hpi,**/target/*.jpi'
-                            } else {
-                                testReports = '**/build/test-results/**/*.xml'
-                                artifacts = '**/build/libs/*.hpi,**/build/libs/*.jpi'
-                            }
-
-                            junit testReports // TODO do this in a finally-block so we capture all test results even if one branch aborts early
-                            if (isMaven && archiveFindbugs) {
-                                def fp = [pattern: params?.findbugs?.pattern ?: '**/target/findbugsXml.xml']
-                                if (params?.findbugs?.unstableNewAll) {
-                                    fp['unstableNewAll'] ="${params.findbugs.unstableNewAll}"
-                                }
-                                if (params?.findbugs?.unstableTotalAll) {
-                                    fp['unstableTotalAll'] ="${params.findbugs.unstableTotalAll}"
-                                }
-                                findbugs(fp)
-                            }
-                            if (isMaven && archiveCheckstyle) {
-                                def cp = [pattern: params?.checkstyle?.pattern ?: '**/target/checkstyle-result.xml']
-                                if (params?.checkstyle?.unstableNewAll) {
-                                    cp['unstableNewAll'] ="${params.checkstyle.unstableNewAll}"
-                                }
-                                if (params?.checkstyle?.unstableTotalAll) {
-                                    cp['unstableTotalAll'] ="${params.checkstyle.unstableTotalAll}"
-                                }
-                                checkstyle(cp)
-                            }
-                            if (failFast && currentBuild.result == 'UNSTABLE') {
-                                error 'There were test failures; halting early'
-                            }
-                            archiveArtifacts artifacts: artifacts, fingerprint: true
-                        }
-                    }
+                        buildMavenPluginPom(
+                            stageIdentifier,
+                            label,
+                            jdk,
+                            jenkinsVersion,
+                            repo,
+                            failFast,
+                            testParallelism,
+                            runFindbugs,
+                            archiveFindbugs,
+                            runCheckstyle,
+                            archiveCheckstyle,
+                            runCobertura);
+                    } else {
+                        //TODO: add support of Jenkins Version
+                         buildGradleComponent(
+                             stageIdentifier,
+                             label,
+                             jdk,
+                             jenkinsVersion,
+                             repo,
+                             failFast)
                     }
                 }
             }
@@ -147,6 +84,10 @@ def call(Map params = [:]) {
     }
 
     timestamps {
-        return parallel(tasks)
+        if (tasks.size() > 2) { // tasks + failFast
+            return parallel(tasks)
+        } else {
+            tasks[firstStageIdentifier].call()
+        }
     }
 }

--- a/vars/cobertura.groovy
+++ b/vars/cobertura.groovy
@@ -1,0 +1,36 @@
+/**
+ * Publishes Cobertura report.
+ * @param file Report File to publish
+ * @param failUnhealthy Fail if the coverage is unhealthy
+ * @param failUnstable Fail if the build is unstable
+ * @return nothing
+ */
+def call(String file = target/coverage.xml, boolean failUnhealthy=false, boolean failUnstable=false) {
+    step([$class: 'CoberturaPublisher',
+          autoUpdateHealth: false,
+          autoUpdateStability: false,
+          coberturaReportFile: file,
+          failNoReports: false,
+          failUnhealthy: failUnhealthy,
+          failUnstable: failUnstable,
+          maxNumberOfBuilds: 0,
+          onlyStable: false,
+          sourceEncoding: 'ASCII',
+          zoomCoverageChart: false]
+    )
+}
+
+def mergeStashes(int testParallelism) {
+    node('linux') {
+        for (int I = 0; I < testParallelism; i++) {
+            unstash"coverage-${i}.xml"
+        }
+        cobertura.merge("coverage-*.xml", "coverage-merged.xml")
+        cobertura(file: "coverage-merged.xml")
+    }
+}
+
+def merge(String pattern, String out) {
+    //TODO: Write your own impl
+    sh "cp coverage-1.xml ${out}"
+}

--- a/vars/commons.groovy
+++ b/vars/commons.groovy
@@ -1,0 +1,46 @@
+Object checkout(String repo = null, String branch = null) {
+    if (env.BRANCH_NAME) {
+        // Multi-branch Pipeline
+        checkout scm
+    }
+    else if ((env.BRANCH_NAME == null) && (repo)) {
+        git url: repo, branch: branch
+    }
+    else {
+        error 'buildPlugin must be used as part of a Multibranch Pipeline *or* a `repo` argument must be provided'
+    }
+}
+
+Object runWithJava(String command, String jdk = 8, List<String> extraEnv = null) {
+    String jdkTool = "jdk${jdk}"
+    List<String> env = [
+        "JAVA_HOME=${tool jdkTool}",
+        'PATH+JAVA=${JAVA_HOME}/bin',
+    ]
+    if (extraEnv != null) {
+        env.addAll(extraEnv)
+    }
+
+    withEnv(env) {
+        if (isUnix()) {
+            sh command
+        } else {
+            bat command
+        }
+    }
+}
+
+Object withErrorHandlers(int timeout, Closure body) {
+    timeout(timeout) {
+        timestamps {
+            try {
+                body()
+            } catch (Exception ex) {
+                echo "Caught exception: ${ex}"
+                throw ex // Propagate it
+            }
+        }
+    }
+}
+
+

--- a/vars/commons.groovy
+++ b/vars/commons.groovy
@@ -1,4 +1,4 @@
-Object checkout(String repo = null, String branch = null) {
+Object checkout(String repo = null, String branch = "master") {
     if (env.BRANCH_NAME) {
         // Multi-branch Pipeline
         checkout scm

--- a/vars/demo.groovy
+++ b/vars/demo.groovy
@@ -1,0 +1,47 @@
+def checkout() {
+    commons.checkout("https://github.com/oleg-nenashev/job-restrictions-plugin", 'cobertura-profile')
+}
+
+def runParallel(int testParallelism=1, boolean runCobertura=false) {
+
+    def splits = splitTests parallelism: [$class: 'CountDrivenParallelism', size: testParallelism], generateInclusions: true
+    /* Create dictionary to hold set of parallel test executions. */
+    def testGroups = [:]
+
+    for (int i = 0; i < splits.size(); i++) {
+        def splitNo = i
+        def split = splits[i]
+
+        testGroups["split-${splitNo}"] = {  // example, "split3"
+            node('linux') {
+                commons.checkout("https://github.com/oleg-nenashev/job-restrictions-plugin", 'cobertura-profile')
+
+                def command = "mvn clean verify -DMaven.test.failure.ignore=true"
+
+                /* Write includesFile or excludesFile for tests.  Split record provided by splitTests. */
+                /* Tell Maven to read the appropriate file. */
+                if (split.includes) {
+                    writeFile file: "tmp/parallel-test-includes-${splitNo}.txt", text: split.list.join("\n")
+                    command += " -Dsurefire.includesFile=tmp/parallel-test-includes-${splitNo}.txt"
+                } else {
+                    writeFile file: "tmp/parallel-test-excludes-${splitNo}.txt", text: split.list.join("\n")
+                    command += " -Dsurefire.excludesFile=tmp/parallel-test-excludes-${splitNo}.txt"
+                }
+
+                if (runCobertura) {
+                    command += " -Pcobertura"
+                }
+
+                sh command
+
+                /* Archive the test results */
+                junit '**/target/surefire-reports/TEST-*.xml'
+
+                if (runCobertura) {
+                    stash includes: 'target/coverage.xml', name: "coverage-${splitNo}.xml"
+                }
+            }
+        }
+    }
+    parallel testGroups
+}

--- a/vars/runParallelTests.groovy
+++ b/vars/runParallelTests.groovy
@@ -1,0 +1,48 @@
+def call(String prefix, String label, List<String> mavenOptions, String jdk = 8,
+         String repo = null, int testParallelism=1,
+         List<String> extraEnvVars = null) {
+
+    /* Request the test groupings.  Based on previous test results. */
+    /* see https://wiki.jenkins-ci.org/display/JENKINS/Parallel+Test+Executor+Plugin and demo on github
+    /* Using arbitrary parallelism of 4 and "generateInclusions" feature added in v1.8. */
+    def splits = splitTests parallelism: [$class: 'CountDrivenParallelism', size: testParallelism], generateInclusions: true
+
+    /* Create dictionary to hold set of parallel test executions. */
+    def testGroups = [:]
+
+    for (int i = 0; i < splits.size(); i++) {
+        def splitNo = i
+        def split = splits[i]
+
+        /* Loop over each record in splits to prepare the testGroups that we'll run in parallel. */
+        /* Split records returned from splitTests contain { includes: boolean, list: List<String> }. */
+        /*     includes = whether list specifies tests to include (true) or tests to exclude (false). */
+        /*     list = list of tests for inclusion or exclusion. */
+        /* The list of inclusions is constructed based on results gathered from */
+        /* the previous successfully completed job. One additional record will exclude */
+        /* all known tests to run any tests not seen during the previous run.  */
+        testGroups["${prefix}-split-${splitNo}"] = {  // example, "split3"
+            node(label) {
+                commons.checkout(repo)
+
+                def command = "mvn clean verify -DMaven.test.failure.ignore=true ${mavenOptions.join(' ')}"
+
+                /* Write includesFile or excludesFile for tests.  Split record provided by splitTests. */
+                /* Tell Maven to read the appropriate file. */
+                if (split.includes) {
+                    writeFile file: "tmp/parallel-test-includes-${splitNo}.txt", text: split.list.join("\n")
+                    command += " -Dsurefire.includesFile=tmp/parallel-test-includes-${splitNo}.txt"
+                } else {
+                    writeFile file: "tmp/parallel-test-excludes-${splitNo}.txt", text: split.list.join("\n")
+                    command += " -Dsurefire.excludesFile=tmp/parallel-test-excludes-${splitNo}.txt"
+                }
+
+                commons.runWithJava(command, jdk, extraEnvVars);
+
+                /* Archive the test results */
+                junit '**/target/surefire-reports/TEST-*.xml'
+            }
+        }
+    }
+    parallel testGroups
+}

--- a/vars/runParallelTests.txt
+++ b/vars/runParallelTests.txt
@@ -1,0 +1,3 @@
+<p>
+    Run tests in parallel and then reports them. Supports only Maven projects.
+</p>


### PR DESCRIPTION
Currently I am preparing a talk about Jenkins Pipeline libraries. After some experiments with multiple cross-dependent libs I decided that I need to add support of Javadoc generation for Pipeline libs... After that I also want to add GDSL generation, but it will be done later.

- [x] Add pom.xml, which generates Javadoc using the patched gmaven version: https://github.com/jenkinsci/gmaven/pull/1
- [x] Add Jenkinsfile, which generates Javadoc. See example for #21 with classes in the attachment: [apidocs.zip](https://github.com/jenkins-infra/pipeline-library/files/1525345/apidocs.zip)

@reviewbybees @rtyler @abayer @svanoort 