### PR TITLE
Do not include the JDK version in stage names unless multiple JDKs are actually in use

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -16,7 +16,7 @@ def call(Map params = [:]) {
                 String label = platforms[i]
                 String jdk = jdkVersions[j]
                 String jenkinsVersion = jenkinsVersions[k]
-                String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
+                String stageIdentifier = "${label}{jdkVersions.size() > 1 ? '-' + jdk : ''}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
                 boolean first = i == 0 && j == 0 && k == 0
                 boolean runFindbugs = first && params?.findbugs?.run
                 boolean runCheckstyle = first && params?.checkstyle?.run


### PR DESCRIPTION
After #2, and https://github.com/jenkinsci/plugin-pom/pull/89, it is going to be unusual that there are multiple JDKs in use, so it is just annoying to have `-8` always be included in stage names.

@reviewbybees