### PR TITLE
Do not archive build products from nondefault Jenkins versions

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -137,7 +137,9 @@ def call(Map params = [:]) {
                             if (failFast && currentBuild.result == 'UNSTABLE') {
                                 error 'There were test failures; halting early'
                             }
-                            archiveArtifacts artifacts: artifacts, fingerprint: true
+                            if (!jenkinsVersion) {
+                                archiveArtifacts artifacts: artifacts, fingerprint: true
+                            }
                         }
                     }
                     }


### PR DESCRIPTION
Someone (?) noticed that the `*.hpi` download links from PRs builds using the `jenkinsVersions` option (e.g., https://github.com/jenkinsci/tikal-multijob-plugin/pull/129) could randomly (depending on branch completion order) include a plugin built against a newer Jenkins core baseline, making the snapshot unusable in older versions including the baseline actually declared in the POM. We should only archive plugin builds from the official baseline.

As usual, untested.

@reviewbybees