### PR TITLE
Use performance-optimized mode for plugin builds

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -4,6 +4,11 @@
  * Simple wrapper step for building a plugin
  */
 def call(Map params = [:]) {
+    // Faster build and reduces IO needs
+    properties([
+        durabilityHint('PERFORMANCE_OPTIMIZED')
+    ])
+
     def platforms = params.containsKey('platforms') ? params.platforms : ['linux', 'windows']
     def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : [8]
     def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]


### PR DESCRIPTION
Takes advantage of the new PERFORMANCE-OPTIMIZED build mode for plugins, see https://jenkins.io/doc/book/pipeline/scaling-pipeline/

Reduces IO needs for plugin builds by a little bit. 

The impact on any single build probably will not be visible (they're pretty lightweight on the master), but the impact on resource use for the master should be visible when it comes to running the gajillion builds we do.