### PR TITLE
Add JSON files and content type to publishReports

### DIFF
--- a/vars/publishReports.groovy
+++ b/vars/publishReports.groovy
@@ -27,6 +27,9 @@ def call(List<String> files, Map params = [:]) {
                         case ~/(?i).*\.css/:
                             uploadFlags = '--content-type="text/css"'
                             break
+                        case ~/(?i).*\json/:
+                            uploadFlags = '--content-type="application/json"'
+                            break
                         case ~/(?i).*\.js/:
                             uploadFlags = '--content-type="application/javascript"'
                             break


### PR DESCRIPTION
This would allow keeping data and report HTML somewhat separate.

I wonder whether we could allow CORS so that the HTML could live e.g. on jenkins.io, and the data is uploaded using `publishReports` from trusted.ci.