### PR TITLE
Pass -Daccess-modifier-checker.failOnError=false when using a custom baseline

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -68,7 +68,7 @@ def call(Map params = [:]) {
                                     mavenOptions += "-s $settingsXml"
                                 }
                                 if (jenkinsVersion) {
-                                    mavenOptions += "-Djenkins.version=${jenkinsVersion}"
+                                    mavenOptions += "-Djenkins.version=${jenkinsVersion} -Daccess-modifier-checker.failOnError=false"
                                 }
                                 if (params?.findbugs?.run || params?.findbugs?.archive) {
                                     mavenOptions += "-Dfindbugs.failOnError=false"


### PR DESCRIPTION
Justification given in https://github.com/kohsuke/access-modifier/pull/10. As usual, this is untested.

@reviewbybees esp. @dwnusbaum