### PR TITLE
Do not fail the build because of findbugs errors when using a custom baseline

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -68,7 +68,7 @@ def call(Map params = [:]) {
                                     mavenOptions += "-s $settingsXml"
                                 }
                                 if (jenkinsVersion) {
-                                    mavenOptions += "-Djenkins.version=${jenkinsVersion}"
+                                    mavenOptions += "-Djenkins.version=${jenkinsVersion} -Dfindbugs.failOnError=false"
                                 }
                                 if (params?.findbugs?.run || params?.findbugs?.archive) {
                                     mavenOptions += "-Dfindbugs.failOnError=false"


### PR DESCRIPTION
Untested. Somewhat similar to #31. This change adds `-Dfindbugs.failOnError=false` when using a custom baseline to prevent cases where, for example, you cannot use `Jenkins#getInstance` because its nullability annotations have changed between the versions you want to test.

Sometimes these errors are useless (e.g. REDUNDANT_NULL_CHECK in the newer baseline), but other times a new error might point to an existing problem that went unnoticed. However, as @jglick mentioned in https://github.com/jenkins-infra/pipeline-library/pull/31#issuecomment-371885808 anyone testing against multiple baselines is probably most concerned with using the plugin's tests to find any serious integration problems, and any FindBugs errors are likely to be significantly less helpful.

@reviewbybees @jglick 
