### PR TITLE
[JENKINS-50405] Fix ensureInNode so it can be used with several labels 

### DIFF
--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -26,7 +26,7 @@ def call(Map params = [:]) {
 
     def localPluginsStashName = env.RUN_ATH_LOCAL_PLUGINS_STASH_NAME ?: "localPlugins"
 
-    ensureInNode(env, env.RUN_ATH_SOURCES_AND_VALIDATION_NODE ?: ['docker', 'highmem'], {
+    ensureInNode(env, env.RUN_ATH_SOURCES_AND_VALIDATION_NODE ?: "docker,highmem", {
         List<String> env = [
                 "JAVA_HOME=${tool 'jdk8'}",
                 'PATH+JAVA=${JAVA_HOME}/bin',
@@ -118,7 +118,7 @@ def call(Map params = [:]) {
         }
     })
 
-    ensureInNode(env, env.RUN_ATH_DOCKER_NODE ?: ['docker','highmem'], {
+    ensureInNode(env, env.RUN_ATH_DOCKER_NODE ?: "docker,highmem", {
         if (skipExecution) {
             return
         }
@@ -216,10 +216,11 @@ private String getLocalPluginsList() {
   */
 private void ensureInNode(env, nodeLabels, body) {
     def inCorrectNode = true
+    def splitted = nodeLabels.split(",")
     if (env.NODE_LABELS == null) {
         inCorrectNode = false
     } else {
-        for (label in nodeLabels) {
+        for (label in splitted) {
             if (!env.NODE_LABELS.contains(label)) {
                 inCorrectNode = false
                 break
@@ -230,7 +231,7 @@ private void ensureInNode(env, nodeLabels, body) {
     if (inCorrectNode) {
         body()
     } else {
-        node(nodeLabels.join("&&")) {
+        node(splitted.join("&&")) {
             body()
         }
     }

--- a/vars/runATH.txt
+++ b/vars/runATH.txt
@@ -25,7 +25,10 @@ The list of step's params and the related default values are:
 <p>
     <b>Note that this step uses the <i>linux</i> and <i>docker && highmem</i> nodes in case that you need to run in different nodes
     you can use the env variables <i>RUN_ATH_SOURCES_AND_VALIDATION_NODE</i> and <i>RUN_ATH_DOCKER_NODE</i> respectively to overwrite
-    the node to use</b>. Nodes are allocated automatically by the step if needed, but if the step is already running in the appropriate node no allocation is done
+    the node to use</b>. If you need to specify more than one label just use a comma separated list of labels
+    Nodes are allocated automatically by the step if needed, but if the step is already running in the appropriate node no allocation is done
+    <b> Please note that this step is not able to manage complex labels and checks for them literally, so do not try to use labels like 'docker,(lowmemory&&linux)' as it will result in
+    the step launching a new node as is unable to find the label '(lowmemory&&linux)' in the list of labels for the current node</b>
 </p>
 
 <p>


### PR DESCRIPTION
See [JENKINS-50405](https://issues.jenkins-ci.org/browse/JENKINS-50405)

With this change, the labels for the  `ensureInNode` method (which is a private one BTW) are specified as a comma-separated list and the method checks if the current node (if any) contains all the labels, 

This is IMO as fas as the `ensureInNode` method should go, enough to deal with existing infra without blocking nodes.

The better solution, however, would be to contribute some step to `workflow-durable-task-step` that is able to deal with any label expression and provides the same functionality than `ensureInNode` but in a more robust way. But as that is not needed for the moment it can be done in a follow-up task when needed

@jenkins-infra/essentials @abayer  