### PR TITLE
Fix maven profile initialization with Azure settings

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -43,7 +43,7 @@ Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = nu
         /* Azure mirror only works for sufficiently new versions of the JDK due to Letsencrypt cert */
         def settingsXml = "${pwd tmp: true}/settings-azure.xml"
         writeFile file: settingsXml, text: libraryResource('settings-azure.xml')
-        mavenOptions += "-s $settingsXml"
+        mvnOptions += "-s $settingsXml"
     }
     mvnOptions.addAll(options)
     String command = "mvn ${mvnOptions.join(' ')}"


### PR DESCRIPTION
I messed up ci.jenkins.io, sorry about that @rtyler and @raul-arabaolaza .
My test instance does not enter this routine, so I didn't notice the mistake in tests. 

I will work to setup a better emulation on my setup + maybe move it to the CI flow using Jenkinsfile runner from @kohsuke 
