### PR TITLE
Silence the downloaded progress bars during maven build

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -45,6 +45,7 @@ def call(Map params = [:]) {
                                         '--batch-mode',
                                         '--errors',
                                         '--update-snapshots',
+                                        '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn',
                                         '-Dmaven.test.failure.ignore',
                                 ]
                                 if (jenkinsVersion) {


### PR DESCRIPTION
This removes the build logspam from download progress such as in the snippet below (the Downloading line should still appear though). 

> Downloading: http://repo.jenkins-ci.org/public/xerces/xercesImpl/2.8.1/xercesImpl-2.8.1.jar
4/6 KB   14/30 KB   14/32 KB     
4/6 KB   14/30 KB   18/32 KB   
4/6 KB   15/30 KB   18/32 KB   
4/6 KB   18/30 KB   18/32 KB   
4/6 KB   18/30 KB   4/110 KB   18/32 KB   
4/6 KB   18/30 KB   8/110 KB   18/32 KB   
4/6 KB   18/30 KB   12/110 KB   18/32 KB   
4/6 KB   18/30 KB   16/110 KB   18/32 KB   
4/6 KB   18/30 KB   20/110 KB   18/32 KB   
4/6 KB   18/30 KB   24/110 KB   18/32 KB 

See: https://stackoverflow.com/questions/21638697/disable-maven-download-progress-indication  