### PR TITLE
[INFRA-1587] Fix return value when using custom maven settings

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -46,8 +46,8 @@ boolean retrieveMavenSettingsFile(String settingsXml, String jdk = 8) {
             } else {
                 bat "copy ${mvnSettingsFile} ${settingsXml}"
             }
-            return true
         }
+        return true
     } else if (jdk.toInteger() > 7 && isRunningOnJenkinsInfra()) {
         /* Azure mirror only works for sufficiently new versions of the JDK due to Letsencrypt cert */
         writeFile file: settingsXml, text: libraryResource('settings-azure.xml')


### PR DESCRIPTION
[INFRA-1587](https://issues.jenkins-ci.org/browse/INFRA-1587)

The returning was exiting the block of configFileProvider but not the method itself, so in the end if you are using a custom maven settings the method was returning false

cc @oleg-nenashev 