### PR TITLE
Fix JSON publishing

### DIFF
--- a/vars/publishReports.groovy
+++ b/vars/publishReports.groovy
@@ -27,7 +27,7 @@ def call(List<String> files, Map params = [:]) {
                         case ~/(?i).*\.css/:
                             uploadFlags = '--content-type="text/css"'
                             break
-                        case ~/(?i).*\json/:
+                        case ~/(?i).*\.json/:
                             uploadFlags = '--content-type="application/json"'
                             break
                         case ~/(?i).*\.js/:


### PR DESCRIPTION
Fix bug introduced in #27.

So glad this passed two reviews of people just as blind as me 😅 

    java.util.regex.PatternSyntaxException: Illegal/unsupported escape sequence near index 7
    (?i).*\json
           ^