### PR TITLE
Workaround for JENKINS-33510, the function was not working properly

### DIFF
--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -166,7 +166,5 @@ private void unstashResources(localSnapshots, localPluginsStashName) {
 }
 
 private String getLocalPluginsList() {
-    dir("localPlugins") {
-       return sh(script : "ls -p -d -1 ${pwd()}/*.* | tr '\n' ':'| sed 's/.\$//'", returnStdout: true).trim()
-    }
+       return sh(script : "ls -p -d -1 localPlugins/*.* | tr '\n' ':'| sed 's/.\$//'", returnStdout: true).trim()
 }


### PR DESCRIPTION
The function was being executed in the root resulting in the list of plugins being always empty and hence no local versions of the plugins used in the ATH

cc @oleg-nenashev @rtyler 