### PR TITLE
[INFRA-1617, INFRA-1595] - Draft implementation of a library method for integration testing

### DIFF
--- a/vars/customWARPackager.groovy
+++ b/vars/customWARPackager.groovy
@@ -22,7 +22,7 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
     def jdk = metadata.packaging.jdk ?: "8"
     //TODO: replace by a stable release once ready, better name?
     def cwpVersion = metadata.packaging.cwpVersion ?: "0.1-alpha-5"
-    def archiveArtifacts = metadata.packaging.archiveArtifacts ?: false
+    def archiveProducedArtifacts = metadata.packaging.archiveArtifacts ?: false
     def installArtifacts = metadata.packaging.installArtifacts ?: true
 
     // Resolve the CWP configuration file
@@ -122,7 +122,7 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
     infra.runWithMaven(command)
 
     dir("tmp/output/target/") {
-        if (archiveArtifacts) {
+        if (archiveProducedArtifacts) {
             archiveArtifacts artifacts: "${artifactId}-${version}.war"
             archiveArtifacts artifacts: "${artifactId}-${version}.bom.yml"
         }

--- a/vars/customWARPackager.groovy
+++ b/vars/customWARPackager.groovy
@@ -13,6 +13,10 @@
  */
 def build(String metadataFile, String outputWAR, String outputBOM, String mvnSettingsFile) {
     def metadata = readYaml(file: metadataFile)
+    if (metadata.packaging == null) {
+        error "No 'packaging' section in the metadata file ${metadataFile}"
+    }
+
     def bomFilePath = metadata.packaging.bom ?: null
     def environment = metadata.packaging.environment
     def jdk = metadata.packaging.jdk ?: "8"
@@ -34,6 +38,7 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
     // Resolve the Maven configuration file if not passed
     if (mvnSettingsFile == null) {
         mvnSettingsFile = "${pwd tmp: true}/settings-azure.xml"
+        infra.retrieveMavenSettingsFile(mvnSettingsFile)
     }
 
     // In order to run packager, we require artifactId and version for packaging

--- a/vars/customWARPackager.groovy
+++ b/vars/customWARPackager.groovy
@@ -75,7 +75,7 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
     }
 
     if (version == null) {
-        version = "1.0-SNAPSHOT"
+        version = "256.0-custom-war-packager-default-SNAPSHOT"
     }
     if (artifactId == null) {
         artifactId = "jenkins-war"

--- a/vars/customWARPackager.groovy
+++ b/vars/customWARPackager.groovy
@@ -11,7 +11,7 @@
  *                  If {@code null}, it will be determined automatically.
  * @return nothing
  */
-def build(String metadataFile, String outputWAR, String outputBOM, String mvnSettingsFile) {
+def build(String metadataFile, String outputWAR, String outputBOM, String mvnSettingsFile = null) {
     def metadata = readYaml(file: metadataFile)
     if (metadata.packaging == null) {
         error "No 'packaging' section in the metadata file ${metadataFile}"

--- a/vars/customWARPackager.groovy
+++ b/vars/customWARPackager.groovy
@@ -40,7 +40,7 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
     // Resolve the Maven configuration file if not passed
     if (mvnSettingsFile == null) {
         def location = "${pwd tmp: true}/settings-azure.xml"
-        if (infra.retrieveMavenSettingsFile(mvnSettingsFile)) {
+        if (infra.retrieveMavenSettingsFile(location)) {
             mvnSettingsFile = location
         }
     }

--- a/vars/customWARPackager.groovy
+++ b/vars/customWARPackager.groovy
@@ -37,8 +37,10 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
 
     // Resolve the Maven configuration file if not passed
     if (mvnSettingsFile == null) {
-        mvnSettingsFile = "${pwd tmp: true}/settings-azure.xml"
-        infra.retrieveMavenSettingsFile(mvnSettingsFile)
+        def location = "${pwd tmp: true}/settings-azure.xml"
+        if (infra.retrieveMavenSettingsFile(mvnSettingsFile)) {
+            mvnSettingsFile = location
+        }
     }
 
     // In order to run packager, we require artifactId and version for packaging

--- a/vars/customWARPackager.groovy
+++ b/vars/customWARPackager.groovy
@@ -21,7 +21,9 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
     def environment = metadata.packaging.environment
     def jdk = metadata.packaging.jdk ?: "8"
     //TODO: replace by a stable release once ready, better name?
-    def cwpVersion = metadata.packaging.cwpVersion ?: "0.1-alpha-5-20180503.142207-7"
+    def cwpVersion = metadata.packaging.cwpVersion ?: "0.1-alpha-5"
+    def archiveArtifacts = metadata.packaging.archiveArtifacts ?: false
+    def installArtifacts = metadata.packaging.installArtifacts ?: true
 
     // Resolve the CWP configuration file
     def configFilePath = null
@@ -113,11 +115,17 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
     if (mvnSettingsFile != null) {
         command += " -mvnSettingsFile=${mvnSettingsFile}"
     }
+    if (installArtifacts) {
+        command += " --installArtifacts"
+    }
+
     infra.runWithMaven(command)
 
     dir("tmp/output/target/") {
-        archiveArtifacts artifacts: "${artifactId}-${version}.war"
-        archiveArtifacts artifacts: "${artifactId}-${version}.bom.yml"
+        if (archiveArtifacts) {
+            archiveArtifacts artifacts: "${artifactId}-${version}.war"
+            archiveArtifacts artifacts: "${artifactId}-${version}.bom.yml"
+        }
         sh "cp ${artifactId}-${version}.war ${outputWAR}"
         sh "cp ${artifactId}-${version}.bom.yml ${outputBOM}"
     }

--- a/vars/customWARPackager.groovy
+++ b/vars/customWARPackager.groovy
@@ -1,0 +1,117 @@
+/**
+ * Builds a custom Jenkins WAR using <a href="https://github.com/jenkinsci/custom-war-packager">Custom WAR Packager</a>.
+ * The method supports both YAML BOM and Custom WAR Packager YAM as an input.
+ *
+ * @param metadataFile Path to the metadata file.
+ * @param outputWAR Path, to which the output WAR file should be written
+ * @param outputBOM Path, to which the output BOM file should be written.
+ *                  More info about BOMs: https://github.com/jenkinsci/jep/pull/92
+ * @param mvnSettingsFile
+ *                  Maven Settings file to be used during the build.
+ *                  If {@code null}, it will be determined automatically.
+ * @return nothing
+ */
+def build(String metadataFile, String outputWAR, String outputBOM, String mvnSettingsFile) {
+    def metadata = readYaml(file: metadataFile)
+    def bomFilePath = metadata.packaging.bom ?: null
+    def environment = metadata.packaging.environment
+    def jdk = metadata.packaging.jdk ?: "8"
+    //TODO: replace by a stable release once ready, better name?
+    def cwpVersion = metadata.packaging.cwpVersion ?: "0.1-alpha-5-20180503.142207-7"
+
+    // Resolve the CWP configuration file
+    def configFilePath = null
+    if (metadata.packaging.config != null) {
+        configFilePath = "${pwd tmp: true}/packager-config.yml"
+        sh "rm -rf ${configFilePath}"
+        writeYaml(file: configFilePath, data: metadata.packaging.config)
+    } else if (metadata.packaging.configFile) {
+        configFilePath = metadata.packaging.configFile
+    } else {
+        error "packaging.config or packaging.configFile must be defined"
+    }
+
+    // Resolve the Maven configuration file if not passed
+    if (mvnSettingsFile == null) {
+        mvnSettingsFile = "${pwd tmp: true}/settings-azure.xml"
+    }
+
+    // In order to run packager, we require artifactId and version for packaging
+    def version = null
+    def artifactId = null
+    if (bomFilePath == null) {
+        def files = findFiles(glob: "bom.yml")
+        if (files != null && files.length > 0) {
+            echo "BOM file is not explicitly defined, but there is bom.yml in the root. Using it"
+            bomFilePath = files[0]
+        }
+    }
+    if (bomFilePath != null ) {
+        def bom = readYaml(file: bomFilePath)
+        //TODO: adjust if parameters are made optional
+        if (bom.metadata.labels != null) {
+            version = bom.metadata.labels.version
+            artifactId = bom.metadata.labels.artifactId
+        }
+    }
+
+    if ((version == null || artifactId == null) && configFilePath != null) { // Try config YML
+        def config = readYaml(file: configFilePath)
+        if (config.bundle != null && artifactId == null) {
+            artifactId = config.bundle.artifactId
+        }
+        if (config.buildSettings != null && version == null) {
+            version = config.buildSettings.version
+        }
+    }
+
+    if (version == null) {
+        version = "1.0-SNAPSHOT"
+    }
+    if (artifactId == null) {
+        artifactId = "jenkins-war"
+    }
+
+    // Warm-up
+    // TODO: Remove once JENKINS-51070 is fixed
+    List<String> mavenWarmup = [
+        '--batch-mode', '--errors',
+        "org.apache.maven.plugins:maven-dependency-plugin:3.0.2:get",
+        "-Dartifact=io.jenkins.tools.custom-war-packager:custom-war-packager-cli:${cwpVersion}",
+        "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+    ]
+    infra.runMaven(mavenWarmup, jdk, null, mvnSettingsFile)
+
+    echo "Downloading Custom WAR Packager CLI ${cwpVersion}"
+    List<String> mavenOptions = [
+        '--batch-mode', '--errors',
+        "com.googlecode.maven-download-plugin:download-maven-plugin:1.4.0:artifact",
+        "-DgroupId=io.jenkins.tools.custom-war-packager",
+        "-DartifactId=custom-war-packager-cli",
+        "-Dclassifier=jar-with-dependencies",
+        "-Dversion=${cwpVersion}",
+        "-DoutputDirectory=${pwd()}",
+        "-DoutputFileName=cwp-cli.jar",
+        "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+    ]
+    infra.runMaven(mavenOptions, jdk, null, mvnSettingsFile)
+
+    def command = "java -jar cwp-cli.jar --batch-mode -configPath ${configFilePath} -version=${version}"
+    if (environment != null) {
+        command += " --environment ${environment}"
+    }
+    if (bomFilePath != null) {
+        command += " --bomPath ${bomFilePath}"
+    }
+    if (mvnSettingsFile != null) {
+        command += " -mvnSettingsFile=${mvnSettingsFile}"
+    }
+    infra.runWithMaven(command)
+
+    dir("tmp/output/target/") {
+        archiveArtifacts artifacts: "${artifactId}-${version}.war"
+        archiveArtifacts artifacts: "${artifactId}-${version}.bom.yml"
+        sh "cp ${artifactId}-${version}.war ${outputWAR}"
+        sh "cp ${artifactId}-${version}.bom.yml ${outputBOM}"
+    }
+}

--- a/vars/customWARPackager.txt
+++ b/vars/customWARPackager.txt
@@ -1,0 +1,9 @@
+<p>
+    Builds a custom Jenkins WAR using <a href="https://github.com/jenkinsci/custom-war-packager">Custom WAR Packager</a>.
+    Configuration is driven by a YAML metadata file, <code>packaging</code> section.
+    See Javadoc for more information.
+</p>
+
+<!--
+vim: ft=html
+-->

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -17,7 +17,7 @@ def call(Map params = [:]) {
             def customWarURI = "file://" + customWAR
 
             stage("Build Custom WAR") {
-                customWARPackager.build(metadataPath, customWAR, customBOM, mvnSettingsFile)
+                customWARPackager.build(metadataPath, customWAR, customBOM)
             }
 
             if (!metadata.ath.disabled) {

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -31,9 +31,7 @@ def call(Map params = [:]) {
 
             if (!metadata.ath.disabled) {
                 stage("Run PCT") {
-                    runPCT jenkins: customWarURI, metadataFile: metadataPath,
-                        javaOptions: ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn",
-                                      "-Dcdkata-test.enabled=true"]
+                    runPCT jenkins: customWarURI, metadataFile: metadataPath
                 }
             }
         }

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -2,7 +2,6 @@ def call(Map params = [:]) {
     def baseDir = params.containsKey('baseDir') ? params.baseDir : "."
     def metadataFile = params.containsKey('metadataFile') ? params.metadataFile : "essentials.yml"
     def labels = params.containsKey('labels') ? params.labels : "docker && highmem"
-    cdkata(metadataFile, labels, baseDir)
 
     node(labels) {
         stage("Checkout") {

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -1,0 +1,41 @@
+def call(Map params = [:]) {
+    def baseDir = params.containsKey('baseDir') ? params.baseDir : "."
+    def metadataFile = params.containsKey('metadataFile') ? params.metadataFile : "essentials.yml"
+    def labels = params.containsKey('labels') ? params.labels : "docker && highmem"
+    cdkata(metadataFile, labels, baseDir)
+
+    node(labels) {
+        stage("Checkout") {
+            infra.checkout()
+        }
+
+        dir(baseDir) {
+            def metadataPath = "${pwd()}/${metadataFile}"
+            metadata = readYaml(file: metadataPath)
+
+            def customBOM = "${pwd tmp: true}/custom.bom.yml"
+            def customWAR = "${pwd tmp: true}/custom.war"
+            def customWarURI = "file://" + customWAR
+
+            stage("Build Custom WAR") {
+                customWARPackager.build(metadataPath, customWAR, customBOM, mvnSettingsFile)
+            }
+
+            if (!metadata.ath.disabled) {
+                stage("Run ATH") {
+                    dir("ath") {
+                        runATH jenkins: customWarURI, metadataFile: metadataPath
+                    }
+                }
+            }
+
+            if (!metadata.ath.disabled) {
+                stage("Run PCT") {
+                    runPCT jenkins: customWarURI, metadataFile: metadataPath,
+                        javaOptions: ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn",
+                                      "-Dcdkata-test.enabled=true"]
+                }
+            }
+        }
+    }
+}

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -20,7 +20,7 @@ def call(Map params = [:]) {
                 customWARPackager.build(metadataPath, customWAR, customBOM)
             }
 
-            if (!metadata.ath.disabled) {
+            if (metadata.ath != null && !metadata.ath.disabled) {
                 stage("Run ATH") {
                     dir("ath") {
                         runATH jenkins: customWarURI, metadataFile: metadataPath
@@ -28,7 +28,7 @@ def call(Map params = [:]) {
                 }
             }
 
-            if (!metadata.ath.disabled) {
+            if (metadata.pct != null && !metadata.pct.disabled) {
                 stage("Run PCT") {
                     runPCT jenkins: customWarURI, metadataFile: metadataPath
                 }

--- a/vars/essentialsTest.txt
+++ b/vars/essentialsTest.txt
@@ -1,0 +1,9 @@
+<p>
+    Runs PCT and ATH for a custom set of versions.
+    The configuration is driven by a YAML metadata file which should combine sections for
+    <code>customWARPackager.build()</code>, <code>runATH()</code> and <code>runPCT()</code>.
+</p>
+
+<!--
+vim: ft=html
+-->

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -65,9 +65,11 @@ boolean retrieveMavenSettingsFile(String settingsXml, String jdk = 8) {
  * @return nothing
  * @see #retrieveMavenSettingsFile(String)
  */
-Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = null) {
+Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = null, String settingsFile = null) {
     List<String> mvnOptions = [ ]
-    if (jdk.toInteger() > 7 && isRunningOnJenkinsInfra()) {
+    if (settingsFile != null) {
+        mvnOptions += "-s $settingsFile"
+    } else if (jdk.toInteger() > 7 && isRunningOnJenkinsInfra()) {
         /* Azure mirror only works for sufficiently new versions of the JDK due to Letsencrypt cert */
         def settingsXml = "${pwd tmp: true}/settings-azure.xml"
         if (retrieveMavenSettingsFile(settingsXml)) {

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -30,11 +30,11 @@
     See method Javadoc in the repository for more information.
 </p>
 
-<strong>infra.runMaven(List&lt;String&gt; options, String jdk = 8, List&lt;String&gt; extraEnv = null)</strong>
+<strong>infra.runMaven(List&lt;String&gt; options, String jdk = 8, List&lt;String&gt; extraEnv = null, String settingsFile = null)</strong>
 
 <p>
     Runs Maven for the specified options in the current workspace.
-    Maven settings will be added by default if needed.
+    If <code>settingsFile</code> is <code>null</code>, Maven settings will be added usin <code>retrieveMavenSettingsFile</code>.
 </p>
 
 <p>

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -127,7 +127,7 @@ def call(Map params = [:]) {
                         }
                         def command = "JENKINS_WAR_PATH=${warAbsolutePath} run-pct ${pctBranchOptions.join(' ')}"
                         if (!javaOptions.isEmpty()) {
-                            command = "JAVA_OPTS=${javaOptions.join(' ')} ${command}"
+                            command = """JAVA_OPTS="${javaOptions.join(' ')}" ${command}"""
                         }
                         if (localSnapshots && localPluginsStashName) {
                             dir("localPlugins") {


### PR DESCRIPTION
https://issues.jenkins-ci.org/projects/INFRA/issues/INFRA-1617

This change offers a single-method runner for Essentials-alike flow with PCT and ATH. This flow may be used for testing both plugins, Jenkins core and Core components. Hence it uses [Custom WAR Packager](https://github.com/jenkinsci/custom-war-packager) and offers a utility method for it (as requested in [INFRA-1595](https://issues.jenkins-ci.org/browse/INFRA-1595)).

Demos:
* for Remoting w/o BOM: https://github.com/oleg-nenashev/remoting/pull/2
* for Artifact Manager S3 with BOM: https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/20

Sample configuration (for Remoting):

```yml
---
packaging:
  config:
    bundle:
      groupId: "io.jenkins.tools.war-packager.demo"
      artifactId: "jenkins-remoting-it"
      vendor: "Jenkins project"
      title: "Remoting Integration Tests WAR"
      description: "Jenkins WAR, which bundles local Remoting build and plugin for PCT"
    war:
      groupId: "org.jenkins-ci.main"
      artifactId: "jenkins-war"
      source:
        version: "2.107.2"
    plugins:
      - groupId: "org.jenkins-ci.plugins"
        artifactId: "ssh-slaves"
        source:
          version: "1.25"
      - groupId: "org.jenkins-ci.plugins"
        artifactId: "command-launcher"
        source:
          version: "1.2"
      - groupId: "org.jenkins-ci.plugins"
        artifactId: "windows-slaves"
        source:
          version: "1.3.1"
      - groupId: "org.jenkins-ci.plugins"
        artifactId: "credentials"
        source:
          version: "2.1.10"
      - groupId: "org.jenkins-ci.plugins"
        artifactId: "ssh-credentials"
        source:
          version: "1.12"
    libPatches:
      # Override Remoting by a locally built version
      - groupId: "org.jenkins-ci.main"
        artifactId: "remoting"
        source:
          dir: ../../..
ath:
  useLocalSnapshots: false
  tests:
    - "plugins.SshSlavesPluginTest"
    - "core.SlaveTest"
  categories:
    - "org.jenkinsci.test.acceptance.junit.SmokeTest"
pct:
  useLocalSnapshots: false
  jth:
    version: 2.38
    passCustomJenkinsWAR: true
  plugins:
    - "ssh-slaves"
    - "command-launcher"
    - "windows-slaves"
    # TODO: JTH/PCT does not work reliably against non-bundled plugins (if something else is bundled) - "compress-artifacts"
```

@reviewbybees @raul-arabaolaza 
