### PR TITLE
Added azure-incrementals mirror

### DIFF
--- a/resources/settings-azure.xml
+++ b/resources/settings-azure.xml
@@ -5,5 +5,10 @@
             <url>https://repo.azure.jenkins.io/public/</url> <!-- INFRA-1176 -->
             <mirrorOf>repo.jenkins-ci.org</mirrorOf>
         </mirror>
+        <mirror>
+            <id>azure-incrementals</id>
+            <url>https://repo.azure.jenkins.io/incrementals/</url> <!-- IEP-9, JEP-305 -->
+            <mirrorOf>incrementals</mirrorOf>
+        </mirror>
     </mirrors>
 </settings>


### PR DESCRIPTION
Not sure how to test this in context, though

```
$ curl -I https://repo.azure.jenkins.io/incrementals/org/jenkins-ci/main/jenkins-war/2.121-rc15727.3b61b96119b9/jenkins-war-2.121-rc15727.3b61b96119b9.war
HTTP/2 200 
…
content-length: 74618209
…
x-cache-status: MISS
…
```

works as expected. CC @raul-arabaolaza.