### PR TITLE
runMaven should always pass -B etc.

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -51,12 +51,9 @@ def call(Map params = [:]) {
                             if (isMaven) {
                                 m2repo = "${pwd tmp: true}/m2repo"
                                 List<String> mavenOptions = [
-                                        '--batch-mode',
-                                        '--errors',
                                         '--update-snapshots',
                                         "-Dmaven.repo.local=$m2repo",
                                         '-Dmaven.test.failure.ignore',
-                                        '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
                                 ]
                                 if (incrementals) { // set changelist and activate produce-incrementals profile
                                     mavenOptions += '-Dset.changelist'

--- a/vars/customWARPackager.groovy
+++ b/vars/customWARPackager.groovy
@@ -84,16 +84,13 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
     // Warm-up
     // TODO: Remove once JENKINS-51070 is fixed
     List<String> mavenWarmup = [
-        '--batch-mode', '--errors',
         "org.apache.maven.plugins:maven-dependency-plugin:3.0.2:get",
         "-Dartifact=io.jenkins.tools.custom-war-packager:custom-war-packager-cli:${cwpVersion}",
-        "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
     ]
     infra.runMaven(mavenWarmup, jdk, null, mvnSettingsFile)
 
     echo "Downloading Custom WAR Packager CLI ${cwpVersion}"
     List<String> mavenOptions = [
-        '--batch-mode', '--errors',
         "com.googlecode.maven-download-plugin:download-maven-plugin:1.4.0:artifact",
         "-DgroupId=io.jenkins.tools.custom-war-packager",
         "-DartifactId=custom-war-packager-cli",
@@ -101,7 +98,6 @@ def build(String metadataFile, String outputWAR, String outputBOM, String mvnSet
         "-Dversion=${cwpVersion}",
         "-DoutputDirectory=${pwd()}",
         "-DoutputFileName=cwp-cli.jar",
-        "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
     ]
     infra.runMaven(mavenOptions, jdk, null, mvnSettingsFile)
 

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -66,7 +66,11 @@ boolean retrieveMavenSettingsFile(String settingsXml, String jdk = 8) {
  * @see #retrieveMavenSettingsFile(String)
  */
 Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = null, String settingsFile = null) {
-    List<String> mvnOptions = [ ]
+    List<String> mvnOptions = [
+        '--batch-mode',
+        '--errors',
+        '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn',
+    ]
     if (settingsFile != null) {
         mvnOptions += "-s $settingsFile"
     } else if (jdk.toInteger() > 7 && isRunningOnJenkinsInfra()) {


### PR DESCRIPTION
Noticed [here](https://ci.jenkins.io/blue/rest/organizations/jenkins/pipelines/Plugins/pipelines/pipeline-githubnotify-step-plugin/branches/INFRA-1489/runs/48/nodes/4/steps/55/log/?start=0) that one of its call sites was producing a lot of noise:

```
+ mvn -s /mnt/agent-workspace/workspace/tify-step-plugin_INFRA-1489-XROG7IKXTQLJCJXIAHDMTMIRO55DVHGHFCDUQJYOO3XDML5EBWCQ@tmp/ath/deps@tmp/settings-azure.xml dependency:copy -Dartifact=org.jenkins-ci.main:jenkins-war:2.121-rc15727.3b61b96119b9:war -DoutputDirectory=. -Dmdep.stripVersion=true
[INFO] Scanning for projects...
Downloading from azure: https://repo.azure.jenkins.io/public/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.pom
Progress (1): 1.4/3.9 kB
Progress (1): 2.8/3.9 kB
Progress (1): 3.9 kB    
                    
Downloaded from azure: https://repo.azure.jenkins.io/public/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.pom (3.9 kB at 11 kB/s)
Downloading from azure: https://repo.azure.jenkins.io/public/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.jar
Progress (1): 2.8/25 kB
Progress (1): 6.9/25 kB
Progress (1): 7.0/25 kB
Progress (1): 9.9/25 kB
Progress (1): 11/25 kB 
Progress (1): 15/25 kB
Progress (1): 19/25 kB
Progress (1): 23/25 kB
Progress (1): 25 kB   
…
```

CC @raul-arabaolaza & @oleg-nenashev.