### PR TITLE
settings-azure: Do silent Artifact download by default

### DIFF
--- a/resources/settings-azure.xml
+++ b/resources/settings-azure.xml
@@ -32,6 +32,15 @@
                 </pluginRepository>
             </pluginRepositories>
         </profile>
+        <profile>
+            <id>silent-artifact-download</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>warn</org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>
+            </properties>
+        </profile>
     </profiles>
 
     <mirrors>


### PR DESCRIPTION
Added a new profile to the default settings file.
It enables silent download within all flows using this Settings file. `infra.runMaven()` will be also using these settings by default on common and trusted CI instances.

@reviewbybees @raul-arabaolaza @rtyler @jglick 
