### PR TITLE
Allow to override ATH Config with custom groovy scripts 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -111,7 +111,8 @@ The docker image used for the environment where to run the ATH. Defaults to "jen
  A String indicating the file path (relative to where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. *Defaults to `essentials.yml` at the location where this step is invoked*
 `jenkins`::
  URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. *Can be overriden from the metadata file*
-
+`configFile`::
+ (Optional) Relative (to the workspace) path of a groovy script to customize the ATH behaviour
 .Step call example
 [source,groovy]
 ----

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -10,6 +10,7 @@ def call(Map params = [:]) {
     def metadataFile = params.get('metadataFile', 'essentials.yml')
     def jenkins = params.get('jenkins', 'latest')
     def athContainerImageTag = params.get("athImage", "jenkins/ath");
+    def configFile = params.get("configFile", null)
 
     def mirror = "http://mirrors.jenkins.io/"
     def defaultCategory = "org.jenkinsci.test.acceptance.junit.SmokeTest"
@@ -123,6 +124,9 @@ def call(Map params = [:]) {
 
                     def currentBrowser = browser
                     def containerArgs = "-v /var/run/docker.sock:/var/run/docker.sock -e SHARED_DOCKER_SERVICE=true -e EXERCISEDPLUGINREPORTER=textfile -u ath-user"
+                    if(configFile) {
+                        containerArgs += " -e CONFIG=${configFile}"
+                    }
                     def commandBase = "./run.sh ${currentBrowser} ./jenkins.war -B -Dmaven.test.failure.ignore=true -DforkCount=1 -B -Dsurefire.rerunFailingTestsCount=${rerunCount} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
                     if (testsToRun) {

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -125,7 +125,7 @@ def call(Map params = [:]) {
                     def currentBrowser = browser
                     def containerArgs = "-v /var/run/docker.sock:/var/run/docker.sock -e SHARED_DOCKER_SERVICE=true -e EXERCISEDPLUGINREPORTER=textfile -u ath-user"
                     if(configFile) {
-                        containerArgs += " -e CONFIG=${configFile}"
+                        containerArgs += " -e CONFIG=../${configFile}" // ATH runs are executed in a subfolder, hence path needs to take that into account
                     }
                     def commandBase = "./run.sh ${currentBrowser} ./jenkins.war -B -Dmaven.test.failure.ignore=true -DforkCount=1 -B -Dsurefire.rerunFailingTestsCount=${rerunCount} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 

--- a/vars/runATH.txt
+++ b/vars/runATH.txt
@@ -17,6 +17,7 @@ The list of step's params and the related default values are:
     <li>athImage: The docker image used for the environment where to run the ATH. Defaults to "jenkins/ath". Use "local" to build the image directly from the ATH sources <b>Can be overridden from the metadata file</b></li>
     <li>metadataFile: A String indicating the file path (relative to the where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. <b>Defaults to <i>essentials.yml</i> at the location where this step is invoked</b></li>
     <li>jenkins: URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. <b>Can be overriden from the metadata file</b></li>
+    <li>configFile: (Optional) Relative (to the workspace) path of a groovy script to customize the ATH behaviour</li>
 </ul>
 
 <pre>


### PR DESCRIPTION
See [here](https://github.com/jenkinsci/acceptance-test-harness/blob/master/docs/WIRING.md) for a description of the functionality, the current runATH step does not offer the possibility to specify a custom config via a groovy file.

Example of use:
```
sh "echo 'uploadPlugins=false' > config.groovy"
runATH configFile: "config.groovy"
``` 

cc @oleg-nenashev 