### PR TITLE
[JENKINS-51489] Use ATH pre configured plugins mode from essentialsTest

### DIFF
--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -26,9 +26,7 @@ def call(Map params = [:]) {
             if (configData.ath != null && !configData.ath.disabled) {
                 stage("Run ATH") {
                     dir("ath") {
-                        def configFile = "ath-config.groovy"
-                        writeFile file: configFile, text: "pluginEvaluationOutcome='${testPluginResolution}'"
-                        runATH jenkins: customWarURI, metadataFile: metadataPath, configFile: configFile
+                        runATH jenkins: customWarURI, metadataFile: metadataPath, javaOptions: ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn", testPluginResolution]
                     }
                 }
             }

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -2,7 +2,7 @@ def call(Map params = [:]) {
     def baseDir = params.containsKey('baseDir') ? params.baseDir : "."
     def metadataFile = params.containsKey('metadataFile') ? params.metadataFile : "essentials.yml"
     def labels = params.containsKey('labels') ? params.labels : "docker && highmem"
-    def pluginEvaluationOutcome = params.get("pluginEvaluationOutcome") ?: "failOnInvalid"
+    def testPluginResolution
 
     node(labels) {
         stage("Checkout") {
@@ -11,7 +11,9 @@ def call(Map params = [:]) {
 
         dir(baseDir) {
             def metadataPath = "${pwd()}/${metadataFile}"
-            metadata = readYaml(file: metadataPath)
+            def configData = readYaml(file: metadataPath)
+            testPluginResolution = configData.metadata?.testPluginResolution?.skipOnUnmetDependencies ?  "skipOnInvalid" : "failOnInvalid"
+
 
             def customBOM = "${pwd tmp: true}/custom.bom.yml"
             def customWAR = "${pwd tmp: true}/custom.war"
@@ -21,17 +23,17 @@ def call(Map params = [:]) {
                 customWARPackager.build(metadataPath, customWAR, customBOM)
             }
 
-            if (metadata.ath != null && !metadata.ath.disabled) {
+            if (configData.ath != null && !configData.ath.disabled) {
                 stage("Run ATH") {
                     dir("ath") {
                         def configFile = "ath-config.groovy"
-                        writeFile file: configFile, text: "pluginEvaluationOutcome='${pluginEvaluationOutcome}'"
+                        writeFile file: configFile, text: "pluginEvaluationOutcome='${testPluginResolution}'"
                         runATH jenkins: customWarURI, metadataFile: metadataPath, configFile: configFile
                     }
                 }
             }
 
-            if (metadata.pct != null && !metadata.pct.disabled) {
+            if (configData.pct != null && !configData.pct.disabled) {
                 stage("Run PCT") {
                     runPCT jenkins: customWarURI, metadataFile: metadataPath
                 }

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -25,7 +25,7 @@ def call(Map params = [:]) {
                 stage("Run ATH") {
                     dir("ath") {
                         def configFile = "ath-config.groovy"
-                        writeFile file: configFile, text: "pluginEvaluationOutcome=${pluginEvaluationOutcome}"
+                        writeFile file: configFile, text: "pluginEvaluationOutcome='${pluginEvaluationOutcome}'"
                         runATH jenkins: customWarURI, metadataFile: metadataPath, configFile: configFile
                     }
                 }

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -12,7 +12,7 @@ def call(Map params = [:]) {
         dir(baseDir) {
             def metadataPath = "${pwd()}/${metadataFile}"
             def configData = readYaml(file: metadataPath)
-            testPluginResolution = configData.metadata?.testPluginResolution?.skipOnUnmetDependencies ?  "skipOnInvalid" : "failOnInvalid"
+            testPluginResolution = configData.flow?.ath?.testPluginResolution?.skipOnUnmetDependencies ?  "skipOnInvalid" : "failOnInvalid"
 
 
             def customBOM = "${pwd tmp: true}/custom.bom.yml"

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -2,6 +2,7 @@ def call(Map params = [:]) {
     def baseDir = params.containsKey('baseDir') ? params.baseDir : "."
     def metadataFile = params.containsKey('metadataFile') ? params.metadataFile : "essentials.yml"
     def labels = params.containsKey('labels') ? params.labels : "docker && highmem"
+    def pluginEvaluationOutcome = params.get("pluginEvaluationOutcome") ?: "failOnInvalid"
 
     node(labels) {
         stage("Checkout") {
@@ -23,7 +24,9 @@ def call(Map params = [:]) {
             if (metadata.ath != null && !metadata.ath.disabled) {
                 stage("Run ATH") {
                     dir("ath") {
-                        runATH jenkins: customWarURI, metadataFile: metadataPath
+                        def configFile = "ath-config.groovy"
+                        writeFile file: configFile, text: "pluginEvaluationOutcome=${pluginEvaluationOutcome}"
+                        runATH jenkins: customWarURI, metadataFile: metadataPath, configFile: configFile
                     }
                 }
             }


### PR DESCRIPTION
[JENKINS-51489](https://issues.jenkins-ci.org/browse/JENKINS-51489)

*Downstream of:*
* #64
* [ATH#433](https://github.com/jenkinsci/acceptance-test-harness/pull/433) 

Modify `essentialsTest` so it uses the new pre configured plugins mode introduced in [ATH#433](https://github.com/jenkinsci/acceptance-test-harness/pull/433)

@reviewbybees @oleg-nenashev @jglick 