### PR TITLE
[INFRA-1747] At least show in a build log if we got a 500

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -234,7 +234,7 @@ void maybePublishIncrementals() {
             node('linux') {
                 withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
                     sh '''
-curl -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://jenkins-incrementals.azurewebsites.net/api/incrementals-publisher?clientId=default&code=$FUNCTION_TOKEN" || echo 'Problem calling Incrementals deployment function'
+curl -i -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://jenkins-incrementals.azurewebsites.net/api/incrementals-publisher?clientId=default&code=$FUNCTION_TOKEN" || echo 'Problem calling Incrementals deployment function'
                     '''
                 }
             }


### PR DESCRIPTION
[INFRA-1747](https://issues.jenkins-ci.org/browse/INFRA-1747): we were just silently failing to print anything when there was a server error.