### PR TITLE
Make the plugin build timeout configurable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,6 +45,7 @@ buildPlugin()
 ** `pattern`: (default: `'**/target/checkstyle-result.xml'`) the file pattern for the report.
 ** `unstableTotalAll`: (default: `null`) the violations threshold for when to mark the build as unstable, see the `checkstyle` step for additional details.
 ** `unstableNewAll`:  (default: `null`) the new violations threshold for when to mark the build as unstable, see the `checkstyle` step for additional details.
+* `timeout`: (default: `60`) - the number of minutes for build timeout
 
 NOTE: `findbugs`  and `checkstyle` are only run/archived on the first platform/jdkVersion,jenkinsVersion combination. So in the example below it will run for `linux`/`jdk7` but not on `jdk8`.
 

--- a/README.adoc
+++ b/README.adoc
@@ -45,7 +45,7 @@ buildPlugin()
 ** `pattern`: (default: `'**/target/checkstyle-result.xml'`) the file pattern for the report.
 ** `unstableTotalAll`: (default: `null`) the violations threshold for when to mark the build as unstable, see the `checkstyle` step for additional details.
 ** `unstableNewAll`:  (default: `null`) the new violations threshold for when to mark the build as unstable, see the `checkstyle` step for additional details.
-* `timeout`: (default: `60`) - the number of minutes for build timeout
+* `timeout`: (default: `60`) - the number of minutes for build timeout, cannot be bigger than 180, i.e. 3 hours.
 
 NOTE: `findbugs`  and `checkstyle` are only run/archived on the first platform/jdkVersion,jenkinsVersion combination. So in the example below it will run for `linux`/`jdk7` but not on `jdk8`.
 

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -18,6 +18,10 @@ def call(Map params = [:]) {
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
     def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
+    if(timeoutValue > 180) {
+      echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
+      timeoutValue = 180
+    }
     Map tasks = [failFast: failFast]
     boolean publishingIncrementals = false
     for (int i = 0; i < platforms.size(); ++i) {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -17,6 +17,7 @@ def call(Map params = [:]) {
     def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
+    def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
     Map tasks = [failFast: failFast]
     boolean publishingIncrementals = false
     for (int i = 0; i < platforms.size(); ++i) {
@@ -35,7 +36,7 @@ def call(Map params = [:]) {
 
                 tasks[stageIdentifier] = {
                     node(label) {
-                        timeout(60) {
+                        timeout(timeoutValue) {
                         boolean isMaven
                         boolean doArchiveArtifacts = /* default platform */ label == platforms[0] && /* default baseline */ !jenkinsVersion
                         boolean incrementals // cf. JEP-305


### PR DESCRIPTION
Plan to use this for configuration-as-code build while working on [JENKINS-53687](https://issues.jenkins-ci.org/browse/JENKINS-53687).
Not aiming at leaving this there forever, but I think that some plugins with a lot of tests could need a bit more than one hour.

Or some could even do the contrary to get a faster feedback: lower the default timeout value to have the build fail faster in case something is wrong.

cc @ndeloof @ewelinawilkosz