### PR TITLE
[INFRA-1788] Remove duplicate options before executing maven command

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -81,6 +81,7 @@ Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = nu
         }
     }
     mvnOptions.addAll(options)
+    mvnOptions.unique()
     String command = "mvn ${mvnOptions.join(' ')}"
     runWithMaven(command, jdk, extraEnv)
 }


### PR DESCRIPTION
For https://issues.jenkins-ci.org/browse/INFRA-1788  This is a trivial change to remove duplicate options before executing maven commands, in order to make logs slightly more readable.
