### PR TITLE
Permit buildPlugin jdk/jenkins/label matrix to be sparse

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,9 +30,9 @@ buildPlugin()
     number jdk tool installed
 * `jenkinsVersions`: (default: `[null]`) - a matrix of Jenkins baseline versions to build/test against in parallel (null means default,
   only available for Maven projects)
-* `configurations`: An alternative to `platforms`, `'jdkVersions'` and `'jenkinsVersions'` arguments. Those 3 form a cartesian
-  product of maven invocations. While that is desirable in many cases, `configurations` permit to provide a specific combinations
-  of label and versions to use:
+* `configurations`: An alternative way to specify `platforms`, `jdkVersions` and `jenkinsVersions` (that can not be combined
+  with any of them). Those options will run the build for all combinations of their values. While that is desirable in
+  many cases, `configurations` permit to provide a specific combinations of label and java/jenkins versions to use:
 
 [source,groovy]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -22,14 +22,26 @@ buildPlugin()
 
 ==== Optional arguments
 
-* `jdkVersions` (default: `[8]`) - JDK version numbers, must match a version
-  number jdk tool installed
 * `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel
+* `jdkVersions` (default: `[8]`) - JDK version numbers, must match a version
+    number jdk tool installed
 * `jenkinsVersions`: (default: `[null]`) - a matrix of Jenkins baseline versions to build/test against in parallel (null means default,
   only available for Maven projects)
+* `configurations`: An alternative to `platforms`, `'jdkVersions'` and `'jenkinsVersions'` arguments. Those 3 form a cartesian
+  product of maven invocations. While that is desirable in many cases, `configurations` permit to provide a specific combinations
+  of label and versions to use:
+
+[source,groovy]
+----
+buildPlugin(/*...*/, configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "11", jenkins: "2.150" ]
+])
+----
 * `tests`: (default: `null`) - a map of parameters to run tests during the build
 ** `skip` - If `true`, skipp all the tests by setting the `-skipTests` profile.
   It will also skip FindBugs in modern Plugin POMs.

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -12,9 +12,6 @@ def call(Map params = [:]) {
         buildDiscarder(logRotator(numToKeepStr: '5')),
     ])
 
-    def platforms = params.containsKey('platforms') ? params.platforms : ['linux', 'windows']
-    def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : [8]
-    def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
     def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
@@ -22,145 +19,148 @@ def call(Map params = [:]) {
       echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
       timeoutValue = 180
     }
-    Map tasks = [failFast: failFast]
+
     boolean publishingIncrementals = false
-    for (int i = 0; i < platforms.size(); ++i) {
-        for (int j = 0; j < jdkVersions.size(); ++j) {
-            for (int k = 0; k < jenkinsVersions.size(); ++k) {
-                String label = platforms[i]
-                String jdk = jdkVersions[j]
-                String jenkinsVersion = jenkinsVersions[k]
-                String stageIdentifier = "${label}${jdkVersions.size() > 1 ? '-' + jdk : ''}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
-                boolean first = i == 0 && j == 0 && k == 0
-                boolean runFindbugs = first && params?.findbugs?.run
-                boolean runCheckstyle = first && params?.checkstyle?.run
-                boolean archiveFindbugs = first && params?.findbugs?.archive
-                boolean archiveCheckstyle = first && params?.checkstyle?.archive
-                boolean skipTests = params?.tests?.skip
+    boolean archivedArtifacts = false
+    Map tasks = [failFast: failFast]
+    getConfigurations(params).each { config ->
+        String label = config.platform
+        String jdk = config.jdk
+        String jenkinsVersion = config.jenkins
 
-                tasks[stageIdentifier] = {
-                    node(label) {
-                        timeout(timeoutValue) {
-                        boolean isMaven
-                        boolean doArchiveArtifacts = /* default platform */ label == platforms[0] && /* default baseline */ !jenkinsVersion
-                        boolean incrementals // cf. JEP-305
+        String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
+        boolean first = tasks.size() == 1
+        boolean runFindbugs = first && params?.findbugs?.run
+        boolean runCheckstyle = first && params?.checkstyle?.run
+        boolean archiveFindbugs = first && params?.findbugs?.archive
+        boolean archiveCheckstyle = first && params?.checkstyle?.archive
+        boolean skipTests = params?.tests?.skip
 
-                        stage("Checkout (${stageIdentifier})") {
-                            infra.checkout(repo)
-                            isMaven = fileExists('pom.xml')
-                            incrementals = fileExists('.mvn/extensions.xml') &&
-                                           readFile('.mvn/extensions.xml').contains('git-changelist-maven-extension')
-                        }
+        tasks[stageIdentifier] = {
+            node(label) {
+                timeout(timeoutValue) {
+                    boolean isMaven
+                    // Archive artifacts once with pom declared baseline
+                    boolean doArchiveArtifacts = !jenkinsVersion && !archivedArtifacts
+                    if (doArchiveArtifacts) {
+                        archivedArtifacts = true
+                    }
+                    boolean incrementals // cf. JEP-305
 
-                        String changelistF
-                        String m2repo
+                    stage("Checkout (${stageIdentifier})") {
+                        infra.checkout(repo)
+                        isMaven = fileExists('pom.xml')
+                        incrementals = fileExists('.mvn/extensions.xml') &&
+                                readFile('.mvn/extensions.xml').contains('git-changelist-maven-extension')
+                    }
 
-                        stage("Build (${stageIdentifier})") {
-                            String command
-                            if (isMaven) {
-                                m2repo = "${pwd tmp: true}/m2repo"
-                                List<String> mavenOptions = [
-                                        '--update-snapshots',
-                                        "-Dmaven.repo.local=$m2repo",
-                                        '-Dmaven.test.failure.ignore',
-                                ]
-                                if (incrementals) { // set changelist and activate produce-incrementals profile
-                                    mavenOptions += '-Dset.changelist'
-                                    if (doArchiveArtifacts) { // ask Maven for the value of -rc999.abc123def456
-                                        changelistF = "${pwd tmp: true}/changelist"
-                                        mavenOptions += "help:evaluate -Dexpression=changelist -Doutput=$changelistF"
-                                    }
-                                }
-                                if (jenkinsVersion) {
-                                    mavenOptions += "-Djenkins.version=${jenkinsVersion} -Daccess-modifier-checker.failOnError=false"
-                                }
-                                if (params?.findbugs?.run || params?.findbugs?.archive) {
-                                    mavenOptions += "-Dfindbugs.failOnError=false"
-                                }
-                                if (skipTests) {
-                                    mavenOptions += "-DskipTests"
-                                }
-                                if (params?.checkstyle?.run || params?.checkstyle?.archive) {
-                                    mavenOptions += "-Dcheckstyle.failOnViolation=false -Dcheckstyle.failsOnError=false"
-                                }
-                                mavenOptions += "clean install"
-                                if (runFindbugs) {
-                                    mavenOptions += "findbugs:findbugs"
-                                }
-                                if (runCheckstyle) {
-                                    mavenOptions += "checkstyle:checkstyle"
-                                }
-                                infra.runMaven(mavenOptions, jdk)
-                            } else {
-                                List<String> gradleOptions = [
-                                        '--no-daemon',
-                                        'cleanTest',
-                                        'build',
-                                ]
-                                command = "gradlew ${gradleOptions.join(' ')}"
-                                if (isUnix()) {
-                                    command = "./" + command
-                                }
-                                infra.runWithJava(command, jdk)
-                            }
-                        }
+                    String changelistF
+                    String m2repo
 
-                        stage("Archive (${stageIdentifier})") {
-                            if (!skipTests) {
-                                String testReports
-                                if (isMaven) {
-                                    testReports = '**/target/surefire-reports/**/*.xml'
-                                } else {
-                                    testReports = '**/build/test-results/**/*.xml'
-                                }
-                                junit testReports
-                                // TODO do this in a finally-block so we capture all test results even if one branch aborts early
-                            }
-                            if (isMaven && archiveFindbugs) {
-                                def fp = [pattern: params?.findbugs?.pattern ?: '**/target/findbugsXml.xml']
-                                if (params?.findbugs?.unstableNewAll) {
-                                    fp['unstableNewAll'] ="${params.findbugs.unstableNewAll}"
-                                }
-                                if (params?.findbugs?.unstableTotalAll) {
-                                    fp['unstableTotalAll'] ="${params.findbugs.unstableTotalAll}"
-                                }
-                                findbugs(fp)
-                            }
-                            if (isMaven && archiveCheckstyle) {
-                                def cp = [pattern: params?.checkstyle?.pattern ?: '**/target/checkstyle-result.xml']
-                                if (params?.checkstyle?.unstableNewAll) {
-                                    cp['unstableNewAll'] ="${params.checkstyle.unstableNewAll}"
-                                }
-                                if (params?.checkstyle?.unstableTotalAll) {
-                                    cp['unstableTotalAll'] ="${params.checkstyle.unstableTotalAll}"
-                                }
-                                checkstyle(cp)
-                            }
-                            if (failFast && currentBuild.result == 'UNSTABLE') {
-                                error 'There were test failures; halting early'
-                            }
-                            if (doArchiveArtifacts) {
-                                if (incrementals) {
-                                    String changelist = readFile(changelistF)
-                                    dir(m2repo) {
-                                        fingerprint '**/*-rc*.*/*-rc*.*' // includes any incrementals consumed
-                                        archiveArtifacts artifacts: "**/*$changelist/*$changelist*",
-                                                         excludes: '**/*.lastUpdated',
-                                                         allowEmptyArchive: true // in case we forgot to reincrementalify
-                                    }
-                                    publishingIncrementals = true
-                                } else {
-                                    String artifacts
-                                    if (isMaven) {
-                                        artifacts = '**/target/*.hpi,**/target/*.jpi'
-                                    } else {
-                                        artifacts = '**/build/libs/*.hpi,**/build/libs/*.jpi'
-                                    }
-                                    archiveArtifacts artifacts: artifacts, fingerprint: true
+                    stage("Build (${stageIdentifier})") {
+                        String command
+                        if (isMaven) {
+                            m2repo = "${pwd tmp: true}/m2repo"
+                            List<String> mavenOptions = [
+                                    '--update-snapshots',
+                                    "-Dmaven.repo.local=$m2repo",
+                                    '-Dmaven.test.failure.ignore',
+                            ]
+                            if (incrementals) { // set changelist and activate produce-incrementals profile
+                                mavenOptions += '-Dset.changelist'
+                                if (doArchiveArtifacts) { // ask Maven for the value of -rc999.abc123def456
+                                    changelistF = "${pwd tmp: true}/changelist"
+                                    mavenOptions += "help:evaluate -Dexpression=changelist -Doutput=$changelistF"
                                 }
                             }
+                            if (jenkinsVersion) {
+                                mavenOptions += "-Djenkins.version=${jenkinsVersion} -Daccess-modifier-checker.failOnError=false"
+                            }
+                            if (params?.findbugs?.run || params?.findbugs?.archive) {
+                                mavenOptions += "-Dfindbugs.failOnError=false"
+                            }
+                            if (skipTests) {
+                                mavenOptions += "-DskipTests"
+                            }
+                            if (params?.checkstyle?.run || params?.checkstyle?.archive) {
+                                mavenOptions += "-Dcheckstyle.failOnViolation=false -Dcheckstyle.failsOnError=false"
+                            }
+                            mavenOptions += "clean install"
+                            if (runFindbugs) {
+                                mavenOptions += "findbugs:findbugs"
+                            }
+                            if (runCheckstyle) {
+                                mavenOptions += "checkstyle:checkstyle"
+                            }
+                            infra.runMaven(mavenOptions, jdk)
+                        } else {
+                            List<String> gradleOptions = [
+                                    '--no-daemon',
+                                    'cleanTest',
+                                    'build',
+                            ]
+                            command = "gradlew ${gradleOptions.join(' ')}"
+                            if (isUnix()) {
+                                command = "./" + command
+                            }
+                            infra.runWithJava(command, jdk)
                         }
                     }
+
+                    stage("Archive (${stageIdentifier})") {
+                        if (!skipTests) {
+                            String testReports
+                            if (isMaven) {
+                                testReports = '**/target/surefire-reports/**/*.xml'
+                            } else {
+                                testReports = '**/build/test-results/**/*.xml'
+                            }
+                            junit testReports
+                            // TODO do this in a finally-block so we capture all test results even if one branch aborts early
+                        }
+                        if (isMaven && archiveFindbugs) {
+                            def fp = [pattern: params?.findbugs?.pattern ?: '**/target/findbugsXml.xml']
+                            if (params?.findbugs?.unstableNewAll) {
+                                fp['unstableNewAll'] = "${params.findbugs.unstableNewAll}"
+                            }
+                            if (params?.findbugs?.unstableTotalAll) {
+                                fp['unstableTotalAll'] = "${params.findbugs.unstableTotalAll}"
+                            }
+                            findbugs(fp)
+                        }
+                        if (isMaven && archiveCheckstyle) {
+                            def cp = [pattern: params?.checkstyle?.pattern ?: '**/target/checkstyle-result.xml']
+                            if (params?.checkstyle?.unstableNewAll) {
+                                cp['unstableNewAll'] = "${params.checkstyle.unstableNewAll}"
+                            }
+                            if (params?.checkstyle?.unstableTotalAll) {
+                                cp['unstableTotalAll'] = "${params.checkstyle.unstableTotalAll}"
+                            }
+                            checkstyle(cp)
+                        }
+                        if (failFast && currentBuild.result == 'UNSTABLE') {
+                            error 'There were test failures; halting early'
+                        }
+                        if (doArchiveArtifacts) {
+                            if (incrementals) {
+                                String changelist = readFile(changelistF)
+                                dir(m2repo) {
+                                    fingerprint '**/*-rc*.*/*-rc*.*' // includes any incrementals consumed
+                                    archiveArtifacts artifacts: "**/*$changelist/*$changelist*",
+                                            excludes: '**/*.lastUpdated',
+                                            allowEmptyArchive: true // in case we forgot to reincrementalify
+                                }
+                                publishingIncrementals = true
+                            } else {
+                                String artifacts
+                                if (isMaven) {
+                                    artifacts = '**/target/*.hpi,**/target/*.jpi'
+                                } else {
+                                    artifacts = '**/build/libs/*.hpi,**/build/libs/*.jpi'
+                                }
+                                archiveArtifacts artifacts: artifacts, fingerprint: true
+                            }
+                        }
                     }
                 }
             }
@@ -173,4 +173,44 @@ def call(Map params = [:]) {
             infra.maybePublishIncrementals()
         }
     }
+}
+
+static List<Map<String, String>> getConfigurations(Map params) {
+    boolean explicit = params.containsKey("configurations")
+    boolean implicit = params.containsKey('platforms') || params.containsKey('jdkVersions') || params.containsKey('jenkinsVersions')
+
+    if (explicit && implicit) {
+        error '"configurations" option can not be used with either "platforms", "jdkVersions" or "jenkinsVersions"'
+    }
+
+
+    def configs = params.configurations
+    configs.each { c ->
+        if (!c.platform) {
+            error("Configuration field \"platform\" must be specified: $c")
+        }
+        if (!c.jdk) {
+            error("Configuration filed \"jdk\" must be specified: $c")
+        }
+    }
+
+    if (explicit) return params.configurations
+
+    def platforms = params.containsKey('platforms') ? params.platforms : ['linux', 'windows']
+    def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : [8]
+    def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]
+
+    def ret = []
+    for (p in platforms) {
+        for (jdk in jdkVersions) {
+            for (jenkins in jenkinsVersions) {
+                ret << [
+                        "platform": p,
+                        "jdk": jdk,
+                        "jenkins": jenkins
+                ]
+            }
+        }
+    }
+    return ret
 }


### PR DESCRIPTION
This change provides an alternative way for specifying the environment for the build to run permitting to exclude combinations known not to work or not to make sense.

Thanks to @abayer for pairing while working on this.

Mostly whitespace change: https://github.com/jenkins-infra/pipeline-library/pull/76/files?w=1