### PR TITLE
[INFRA-1691] Add JDK 11 selection to run PCT

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -258,7 +258,7 @@ The PCT revision to use in case that pctUrl points to a github destination, can 
  List of extra Java options to be passed to the PCT executable. Defaults to empty list.
 `dockerOptions`::
  List of extra options to be passed to PCT containers ( e.g. `maven-repo:/root/.m2`)
-`useJDK11`::
+`jdkVersion`::
  The version of the JDK to use to run the tests. Should be `8` or `11`. Defaults to `8`.
 
 .Step call example

--- a/README.adoc
+++ b/README.adoc
@@ -252,6 +252,14 @@ The PCT revision to use in case that pctUrl points to a github destination, can 
  A String indicating the file path (relative to where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. *Defaults to `essentials.yml` at the location where this step is invoked*
 `jenkins`::
  URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. *Can be overriden from the metadata file*
+`pctExtraOptions`:: 
+ List of extra PCT options to be passed to the PCT executable. Defaults to empty list.
+`javaOptions`:: 
+ List of extra Java options to be passed to the PCT executable. Defaults to empty list.
+`dockerOptions`::
+ List of extra options to be passed to PCT containers ( e.g. `maven-repo:/root/.m2`)
+`useJDK11`::
+ Boolean to specified if the test should be run with JDK11.
 
 .Step call example
 [source,groovy]

--- a/README.adoc
+++ b/README.adoc
@@ -259,7 +259,7 @@ The PCT revision to use in case that pctUrl points to a github destination, can 
 `dockerOptions`::
  List of extra options to be passed to PCT containers ( e.g. `maven-repo:/root/.m2`)
 `useJDK11`::
- Boolean to specified if the test should be run with JDK11.
+ The version of the JDK to use to run the tests. Should be `8` or `11`. Defaults to `8`.
 
 .Step call example
 [source,groovy]

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -12,7 +12,7 @@ def call(Map params = [:]) {
     def pctExtraOptions = params.get('pctExtraOptions', [])
     def javaOptions = params.get('javaOptions', ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"])
     def dockerOptions = params.get('dockerOptions', [])
-    def useJDK11 = params.get('useJDK11', false)
+    def jdkVersion = params.get('jdkVersion', '8')
 
     def defaultCategory = "org.jenkinsci.test.acceptance.junit.SmokeTest"
     def metadata
@@ -143,9 +143,7 @@ def call(Map params = [:]) {
                             sh "cp tmp_settings.xml /pct/m2-settings.xml/settings.xml"
                             command = "M2_SETTINGS_FILE=/pct/m2-settings.xml/settings.xml ${command}"
                         }
-                        if(useJDK11) {
-                            command = "JDK11=true ${command}"
-                        }
+                        command = "JDK_VERSION=${jdkVersion} ${command}"
 
                         sh command
                         sh "mkdir reports${plugin} && cp /pct/tmp/work/*/target/surefire-reports/*.xml reports${plugin}"

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -12,6 +12,7 @@ def call(Map params = [:]) {
     def pctExtraOptions = params.get('pctExtraOptions', [])
     def javaOptions = params.get('javaOptions', ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"])
     def dockerOptions = params.get('dockerOptions', [])
+    def useJDK11 = params.get('useJDK11', false)
 
     def defaultCategory = "org.jenkinsci.test.acceptance.junit.SmokeTest"
     def metadata
@@ -142,6 +143,9 @@ def call(Map params = [:]) {
                             sh "cp tmp_settings.xml /pct/m2-settings.xml/settings.xml"
                             command = "M2_SETTINGS_FILE=/pct/m2-settings.xml/settings.xml ${command}"
                         }
+                        if(useJDK11) {
+                            command = "JDK11=true ${command}"
+                        }
 
                         sh command
                         sh "mkdir reports${plugin} && cp /pct/tmp/work/*/target/surefire-reports/*.xml reports${plugin}"
@@ -149,7 +153,7 @@ def call(Map params = [:]) {
                     }
                 }
             }
-            // TODO provide a mechanism for HTML repor archiving and aggregation
+            // TODO provide a mechanism for HTML report archiving and aggregation
             parallel testingBranches
         }
 

--- a/vars/runPCT.txt
+++ b/vars/runPCT.txt
@@ -19,7 +19,8 @@ The list of step's params and the related default values are:
     <li>jenkins: URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. <b>Can be overriden from the metadata file</b></li>
     <li>pctExtraOptions: List of extra PCT options to be passed to the PCT executable. Defaults to empty list</li>
     <li>javaOptions: List of extra Java options to be passed to the PCT executable. Defaults to empty list</li>
-    <li>dockerOptions: List of extra options to be passed to PCT containers ( e.g. &qt;-v maven-repo:/root/.m2&qt;)</p>
+    <li>dockerOptions: List of extra options to be passed to PCT containers ( e.g. &qt;-v maven-repo:/root/.m2&qt;)</li>
+    <li>useJDK11: Boolean to specified if the test should be run with JDK11</li>
 </ul>
 
 <pre>

--- a/vars/runPCT.txt
+++ b/vars/runPCT.txt
@@ -20,7 +20,7 @@ The list of step's params and the related default values are:
     <li>pctExtraOptions: List of extra PCT options to be passed to the PCT executable. Defaults to empty list</li>
     <li>javaOptions: List of extra Java options to be passed to the PCT executable. Defaults to empty list</li>
     <li>dockerOptions: List of extra options to be passed to PCT containers ( e.g. &qt;-v maven-repo:/root/.m2&qt;)</li>
-    <li>useJDK11: Boolean to specified if the test should be run with JDK11</li>
+    <li>jdkVersion: The version of the JDK to use to run the tests. Should be `8` or `11`. Defaults to `8`</li>
 </ul>
 
 <pre>


### PR DESCRIPTION
[INFRA-1691](https://issues.jenkins-ci.org/browse/INFRA-1691)

I updated the `README.adoc` to list all the parameters for `runPCT`.
I added a parameter to trigger the usage of the JDK 11. 