### PR TITLE
Add support of ci.jenkins.io-runner + introduce `PIPELINE_LIBRARY_SKIP_WINDOWS`, `PIPELINE_LIBRARY_USE_DEFAULT_MAVEN_REPO` and `JFR_LOCAL_WORKSPACE` variables

### DIFF
--- a/src/it/Makefile
+++ b/src/it/Makefile
@@ -1,0 +1,20 @@
+# Just a Makefile for automatic testing
+.PHONY: all
+
+#TODO needs productization
+JFR_IMAGE=onenashev/ci.jenkins.io-runner:latest
+JFR_TEST_FRAMEWORK_VERSION=4ed3c35650fe880345b77ee4776b29bd00944fb3
+
+all: clean init test
+
+clean:
+	rm -rf .jenkinsfile-runner-test-framework
+
+init:
+	# TODO replace with first version of the test framework
+	git clone https://github.com/jenkinsci/jenkinsfile-runner-test-framework .jenkinsfile-runner-test-framework && cd .jenkinsfile-runner-test-framework && git checkout ${JFR_TEST_FRAMEWORK_VERSION}
+	rsync -avq --exclude-from='exclude-rsync.txt' $(shell pwd)/../ $(shell pwd)/.jenkinsfile-runner-test-framework/source
+	$(MAKE) -C .jenkinsfile-runner-test-framework
+
+test:
+	./test-buildPlugin.sh

--- a/src/it/README.md
+++ b/src/it/README.md
@@ -1,0 +1,11 @@
+Jenkins Pipeline Library integration tests
+==========================================
+
+This directory contains integration tests for the Pipeline library,
+which are powered by [Jenkinsfile Runner](https://github.com/jenkinsci/jenkinsfile-runner) and
+[Jenkinsfile Runner Test Framework](https://github.com/jenkinsci/jenkinsfile-runner-test-framework).
+To emulate the ci.jenkins.io environment,
+this test suite uses the [ci.jenkins.io-runner](https://github.com/jenkinsci/ci.jenkins.io-runner)
+package based on Jenkinsfile Runner.
+
+

--- a/src/it/exclude-rsync.txt
+++ b/src/it/exclude-rsync.txt
@@ -1,0 +1,3 @@
+demo
+tests/jenkinsfile-runner-test-framework
+**/.git*

--- a/src/it/test-buildPlugin.sh
+++ b/src/it/test-buildPlugin.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+current_directory=$(pwd)
+test_framework_directory="$current_directory/.jenkinsfile-runner-test-framework"
+working_directory="$test_framework_directory/work-test-buildPlugin"
+src_directory="$test_framework_directory/source"
+
+. $test_framework_directory/init-jfr-test-framework.inc
+
+oneTimeSetUp() {
+  rm -rf "$working_directory"
+  mkdir -p "$working_directory"
+  cd "$current_directory"
+}
+
+# Test https://github.com/jenkinsci/extended-read-permission-plugin
+test_Smoke() {
+  #TODO: Move to arguments
+  local JFR_IMAGE=onenashev/ci.jenkins.io-runner:latest
+  local pluginName=extended-read-permission
+  local pluginRepo=${pluginName}-plugin
+  local pluginVersion=6e8e27d2623d22d456b32e81878411c8f696f5a6
+  git clone https://github.com/jenkinsci/${pluginRepo}.git && cd ${pluginRepo} && git checkout ${pluginVersion}
+  docker run --rm -v "$current_directory/${pluginRepo}":/workspace -v "$current_directory/../..":/var/jenkins_home/pipeline-library "$JFR_IMAGE"
+  #jenkinsfile_execution_should_succeed "$?" "$result"
+}
+
+init_framework

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -27,8 +27,13 @@ def call(Map params = [:]) {
         String label = config.platform
         String jdk = config.jdk
         String jenkinsVersion = config.jenkins
-
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
+
+        if ("windows".equals(label) && "true".equals(env.PIPELINE_LIBRARY_SKIP_WINDOWS)) {
+            echo "Skipping ${stageIdentifier}, because `PIPELINE_LIBRARY_SKIP_WINDOWS` environment variable is set"
+            return;
+        }
+
         boolean first = tasks.size() == 1
         boolean runFindbugs = first && params?.findbugs?.run
         boolean runCheckstyle = first && params?.checkstyle?.run

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -68,9 +68,14 @@ def call(Map params = [:]) {
                             m2repo = "${pwd tmp: true}/m2repo"
                             List<String> mavenOptions = [
                                     '--update-snapshots',
-                                    "-Dmaven.repo.local=$m2repo",
                                     '-Dmaven.test.failure.ignore',
                             ]
+                            if ("true".equals(env.PIPELINE_LIBRARY_USE_DEFAULT_MAVEN_REPO)) {
+                                echo "Using the default Maven local repo, because 'PIPELINE_LIBRARY_USE_DEFAULT_MAVEN_REPO' is set"
+                            } else {
+                                mavenOptions += "-Dmaven.repo.local=$m2repo"
+                            }
+
                             if (incrementals) { // set changelist and activate produce-incrementals profile
                                 mavenOptions += '-Dset.changelist'
                                 if (doArchiveArtifacts) { // ask Maven for the value of -rc999.abc123def456

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -24,8 +24,10 @@ Object checkout(String repo = null) {
         checkout scm
     } else if ((env.BRANCH_NAME == null) && (repo)) {
         git repo
+    } else if (env.JFR_LOCAL_WORKSPACE != null) {
+        sh "cp -R ${env.JFR_LOCAL_WORKSPACE}/* ."
     } else {
-        error 'buildPlugin must be used as part of a Multibranch Pipeline *or* a `repo` argument must be provided'
+        error 'buildPlugin must be used as part of a Multibranch Pipeline *or* a `repo` argument must be provided. For Jenkinsfile Runner the JFR_LOCAL_WORKSPACE can be set to pass the path to the source code'
     }
 }
 


### PR DESCRIPTION
These patches reflect changes needed in order to run this library inside Jenkinsfile Runner.

Here is my sandbox project for such mode: https://github.com/oleg-nenashev/ci.jenkins.io-runner

