### PR TITLE
buildPlugin(): Allow passing Java level as a configuration argument

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ buildPlugin()
 buildPlugin(/*...*/, configurations: [
   [ platform: "linux", jdk: "8", jenkins: null ],
   [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: "2.150" ]
+  [ platform: "linux", jdk: "11", jenkins: "2.150", javaLevel: 8 ]
 ])
 ----
 * `tests`: (default: `null`) - a map of parameters to run tests during the build

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -27,6 +27,7 @@ def call(Map params = [:]) {
         String label = config.platform
         String jdk = config.jdk
         String jenkinsVersion = config.jenkins
+        String javaLevel = config.javaLevel
 
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
         boolean first = tasks.size() == 1
@@ -75,6 +76,9 @@ def call(Map params = [:]) {
                             }
                             if (jenkinsVersion) {
                                 mavenOptions += "-Djenkins.version=${jenkinsVersion} -Daccess-modifier-checker.failOnError=false"
+                            }
+                            if (javaLevel) {
+                                mavenOptions += "-Djava.level=${javaLevel}"
                             }
                             if (params?.findbugs?.run || params?.findbugs?.archive) {
                                 mavenOptions += "-Dfindbugs.failOnError=false"
@@ -207,7 +211,8 @@ static List<Map<String, String>> getConfigurations(Map params) {
                 ret << [
                         "platform": p,
                         "jdk": jdk,
-                        "jenkins": jenkins
+                        "jenkins": jenkins,
+                        "javaLevel": null   // not supported in the old format
                 ]
             }
         }


### PR DESCRIPTION
While testing configuration support patches from @olivergondza in https://github.com/jenkins-infra/pipeline-library/pull/76 , I tried to run the test automation against a plugin which still targets Java 7: https://github.com/jenkinsci/label-verifier-plugin/pull/4 . It failed, because the new Jenkins core version uses Bytecode Compatibility Transformer which is no longer compatible with Java 7.

Other static checkers may fail in various way as well. In order to prevent it, I propose to add an escape hatch to the library so that a custom `java.level` can be passed alongside a custom Jenkins version.
