### PR TITLE
--show-version aka -V should be default

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -68,6 +68,7 @@ boolean retrieveMavenSettingsFile(String settingsXml, String jdk = 8) {
 Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = null, String settingsFile = null) {
     List<String> mvnOptions = [
         '--batch-mode',
+        '--show-version',
         '--errors',
         '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn',
     ]


### PR DESCRIPTION
It will show Maven and Java versions all the time, which is IMO much more than a nice to have in a CI env :).

Will be especially useful when we start getting more Java 11 around.

cc @oleg-nenashev @mramonleon @alecharp 