### PR TITLE
Allow withDockerCredentials from jenkins infrastructure

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -10,9 +10,10 @@ Boolean isTrusted() {
 
 Object withDockerCredentials(Closure body) {
     if (isRunningOnJenkinsInfra()) {
-        withCredentials([[$class: 'ZipFileBinding', credentialsId: 'jenkins-dockerhub', variable: 'DOCKER_CONFIG']]) {
-            return body.call()
-        }
+      env.DOCKERHUB_ORGANISATION =  ( isTrusted() ? 'jenkins' : 'jenkins4eval')
+      withCredentials([[$class: 'ZipFileBinding', credentialsId: 'jenkins-dockerhub', variable: 'DOCKER_CONFIG']]) {
+          return body.call()
+      }
     }
     else {
         echo 'Cannot use Docker credentials outside of jenkins infra environment'

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -9,13 +9,13 @@ Boolean isTrusted() {
 }
 
 Object withDockerCredentials(Closure body) {
-    if (isTrusted()) {
+    if (isRunningOnJenkinsInfra()) {
         withCredentials([[$class: 'ZipFileBinding', credentialsId: 'jenkins-dockerhub', variable: 'DOCKER_CONFIG']]) {
             return body.call()
         }
     }
     else {
-        echo 'Cannot use Docker credentials outside of the trusted environment'
+        echo 'Cannot use Docker credentials outside of jenkins infra environment'
     }
 }
 


### PR DESCRIPTION
This PR is part of "Experimental Jenkins organization on DockerHub".
I configured ci.jenkins.io with an account that have write permission to the jenkins4eval dockerhub organisation. Note that currently Credentials is set for packaging folder on ci.jenkins.io

I also propose to define a environment variable which can be used from the different Jenkinsfile in order to know where they can push docker images based on the jenkins instance.

The next step is to configure each specific git repository that contain a docker image definition to push 
on 'jenkins4eval' if not build from trusted otherwise push to 'jenkins'