### PR TITLE
[INFRA-1690] Allow selecting JDK in pipeline - runATH

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -128,7 +128,7 @@ The docker image used for the environment where to run the ATH. Defaults to "jen
 `jenkins`::
  URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. *Can be overriden from the metadata file*
  `jdks`::
- Java versions to use when running ATH. Defaults to 8. Only 8, 10 and 11 are supported. *Can be overridden from the metadata file*
+ Java versions to use when running ATH. Defaults to 8. Only 8 and 11 are supported. *Can be overridden from the metadata file*
 `configFile`::
  (Optional) Relative (to the workspace) path of a groovy script to customize the ATH behaviour
 .Step call example
@@ -212,7 +212,6 @@ ath:
     - Category2
   jdks:
     - 8
-    - 10
     - 11
 ----
 
@@ -239,7 +238,7 @@ Where:
 `categories`::
  The list of Categories to run. Defaults to nothing
 `jdks`::
- The list of jdks to use when running ATH. Defaults to 8. *Note that currently only 8, 10 and 11 are supported, any other will be ignored*
+ The list of jdks to use when running ATH. Defaults to 8. *Note that currently only 8 and 11 are supported, any other will be ignored*
 
 In case you want to use the defaults for all properties you can use
 

--- a/README.adoc
+++ b/README.adoc
@@ -127,6 +127,8 @@ The docker image used for the environment where to run the ATH. Defaults to "jen
  A String indicating the file path (relative to where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. *Defaults to `essentials.yml` at the location where this step is invoked*
 `jenkins`::
  URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. *Can be overriden from the metadata file*
+ `jdks`::
+ Java versions to use when running ATH. Defaults to 8. Only 8, 10 and 11 are supported. *Can be overridden from the metadata file*
 `configFile`::
  (Optional) Relative (to the workspace) path of a groovy script to customize the ATH behaviour
 .Step call example
@@ -208,6 +210,10 @@ ath:
   categories:
     - Category1
     - Category2
+  jdks:
+    - 8
+    - 10
+    - 11
 ----
 
 Where:
@@ -232,6 +238,8 @@ Where:
  The list of tests to run for the component that calls the step. If no particular set of tests or categories is defined the SmokeTest Category of the ATH will be run
 `categories`::
  The list of Categories to run. Defaults to nothing
+`jdks`::
+ The list of jdks to use when running ATH. Defaults to 8. *Note that currently only 8, 10 and 11 are supported, any other will be ignored*
 
 In case you want to use the defaults for all properties you can use
 

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -1,8 +1,7 @@
 #!/usr/bin/env groovy
 
 Boolean isRunningOnJenkinsInfra() {
-    //return env.JENKINS_URL == 'https://ci.jenkins.io/' || isTrusted()
-    return true;
+    return env.JENKINS_URL == 'https://ci.jenkins.io/' || isTrusted()
 }
 
 Boolean isTrusted() {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -1,7 +1,8 @@
 #!/usr/bin/env groovy
 
 Boolean isRunningOnJenkinsInfra() {
-    return env.JENKINS_URL == 'https://ci.jenkins.io/' || isTrusted()
+    //return env.JENKINS_URL == 'https://ci.jenkins.io/' || isTrusted()
+    return true;
 }
 
 Boolean isTrusted() {

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -24,7 +24,7 @@ def call(Map params = [:]) {
     def athSourcesFolder = "athSources"
 
     def supportedBrowsers = ["firefox"]
-    def supportedJdks = [8, 10, 11]
+    def supportedJdks = [8, 11]
 
     def skipExecution = false
 

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -142,12 +142,10 @@ def call(Map params = [:]) {
                         commandBaseWithFutureJava = "JENKINS_OPTS=\"--enable-future-java\" "
                         containerArgs += " -e java_version=${currentJdk}"
 
-                        if (currentJdk >= 11) {
-                            // Add modules removed
-                            javaOptions << "-p /home/ath-user/jdk11-libs/jaxb-api.jar:/home/ath-user/jdk11-libs/javax.activation.jar"
-                            javaOptions << "--add-modules java.xml.bind,java.activation"
-                            javaOptions << "-cp /home/ath-user/jdk11-libs/jaxb-impl.jar:/home/ath-user/jdk11-libs/jaxb-core.jar"
-                        }
+                        // Add modules removed
+                        javaOptions << "-p /home/ath-user/jdk11-libs/jaxb-api.jar:/home/ath-user/jdk11-libs/javax.activation.jar"
+                        javaOptions << "--add-modules java.xml.bind,java.activation"
+                        javaOptions << "-cp /home/ath-user/jdk11-libs/jaxb-impl.jar:/home/ath-user/jdk11-libs/jaxb-core.jar"
                     }
 
                     for (browser in browsers) {

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -9,9 +9,10 @@ def call(Map params = [:]) {
     def athRevision = params.get('athRevision', 'master')
     def metadataFile = params.get('metadataFile', 'essentials.yml')
     def jenkins = params.get('jenkins', 'latest')
+    def jdks = params.get('jdks', [8])
     def athContainerImageTag = params.get("athImage", "jenkins/ath");
     def configFile = params.get("configFile", null)
-    def javaOptions = params.get('javaOptions', ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"])
+    def defaultJavaOptions = params.get('javaOptions', ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"])
 
     def mirror = "http://mirrors.jenkins.io/"
     def defaultCategory = "org.jenkinsci.test.acceptance.junit.SmokeTest"
@@ -23,6 +24,7 @@ def call(Map params = [:]) {
     def athSourcesFolder = "athSources"
 
     def supportedBrowsers = ["firefox"]
+    def supportedJdks = [8, 10, 11]
 
     def skipExecution = false
 
@@ -59,6 +61,9 @@ def call(Map params = [:]) {
             jenkins = metadata.jenkins ?: jenkins
             isVersionNumber = (jenkins =~ /^\d+([.]\d+)*$/).matches()
 
+            // Allow override of JDK version from metadata file
+            jdks = metadata.jdks ?: jdks
+            
             if (!isLocalATH) {
                 echo 'Checking connectivity to ATH sources…'
                 sh "git ls-remote --exit-code -h ${athUrl}"
@@ -120,48 +125,73 @@ def call(Map params = [:]) {
             }
 
             def testingbranches = ["failFast": failFast]
-            for (browser in browsers) {
-                if (supportedBrowsers.contains(browser)) {
-
-                    def currentBrowser = browser
+            for (jdk in jdks) {
+                if (supportedJdks.contains(jdk)) {
+                    def currentJdk = jdk
+                    def javaOptions = defaultJavaOptions.clone()
+                    def commandBaseWithFutureJava = ""
                     def containerArgs = "-v /var/run/docker.sock:/var/run/docker.sock -u ath-user"
+                    
                     if(configFile) {
                         containerArgs += " -e CONFIG=../${configFile}" // ATH runs are executed in a subfolder, hence path needs to take that into account
                     }
-                    def commandBase = "./run.sh ${currentBrowser} ./jenkins.war -B -Dmaven.test.failure.ignore=true -DforkCount=1 -B -Dsurefire.rerunFailingTestsCount=${rerunCount}"
+                    
+                    // Add options for jdks
+                    if ( currentJdk  > 8) {
+                        // Add environment variable to 
+                        commandBaseWithFutureJava = "JENKINS_OPTS=\"--enable-future-java\" "
+                        containerArgs += " -e java_version=${currentJdk}"
 
-                    if (testsToRun) {
-                        testingbranches["ATH individual tests-${currentBrowser}"] = {
-                            dir("test${currentBrowser}") {
-                                def discriminator = "-Dtest=${testsToRun}"
-                                test(discriminator, commandBase, localSnapshots, localPluginsStashName, containerArgs, athContainerImage, javaOptions)
-                            }
+                        if (currentJdk >= 11) {
+                            // Add modules removed
+                            javaOptions << "-p /home/ath-user/jdk11-libs/jaxb-api.jar:/home/ath-user/jdk11-libs/javax.activation.jar"
+                            javaOptions << "--add-modules java.xml.bind,java.activation"
+                            javaOptions << "-cp /home/ath-user/jdk11-libs/jaxb-impl.jar:/home/ath-user/jdk11-libs/jaxb-core.jar"
                         }
                     }
-                    if (categoriesToRun) {
-                        testingbranches["ATH categories-${currentBrowser}"] = {
-                            dir("categories${currentBrowser}") {
-                                def discriminator = "-Dgroups=${categoriesToRun}"
-                                test(discriminator, commandBase, localSnapshots, localPluginsStashName, containerArgs, athContainerImage, javaOptions)
+
+                    for (browser in browsers) {
+                        if (supportedBrowsers.contains(browser)) {
+                            def currentBrowser = browser
+
+                            def commandBase = "${commandBaseWithFutureJava} ./run.sh ${currentBrowser} ./jenkins.war -B -Dmaven.test.failure.ignore=true -DforkCount=1 -B -Dsurefire.rerunFailingTestsCount=${rerunCount}"
+
+                            if (testsToRun) {
+                                testingbranches["ATH individual tests-${currentBrowser}-jdk${currentJdk}"] = {
+                                    dir("test${currentBrowser}jdk${currentJdk}") {
+                                        def discriminator = "-Dtest=${testsToRun}"
+                                        test(discriminator, commandBase, localSnapshots, localPluginsStashName, containerArgs, athContainerImage, javaOptions)
+                                    }
+                                }
                             }
-                        }
-                    }
-                    if (testsToRun == null && categoriesToRun == null) {
-                        testingbranches["ATH ${currentBrowser}"] = {
-                            dir("ath${currentBrowser}") {
-                                def discriminator = ""
-                                test(discriminator, commandBase, localSnapshots, localPluginsStashName, containerArgs, athContainerImage, javaOptions)
+                            if (categoriesToRun) {
+                                testingbranches["ATH categories-${currentBrowser}-jdk${currentJdk}"] = {
+                                    dir("categories${currentBrowser}jdk${currentJdk}") {
+                                        def discriminator = "-Dgroups=${categoriesToRun}"
+                                        test(discriminator, commandBase, localSnapshots, localPluginsStashName, containerArgs, athContainerImage, javaOptions)
+                                    }
+                                }
                             }
+                            if (testsToRun == null && categoriesToRun == null) {
+                                testingbranches["ATH ${currentBrowser}-jdk${currentJdk}"] = {
+                                    dir("ath${currentBrowser}${currentJdk}") {
+                                        def discriminator = ""
+                                        test(discriminator, commandBase, localSnapshots, localPluginsStashName, containerArgs, athContainerImage, javaOptions)
+                                    }
+                                }
+                            }
+
+                        } else {
+                            echo "${browser} is not yet supported"
                         }
                     }
                 } else {
-                    echo "${browser} is not yet supported"
+                    echo "${jdk} is not yet supported"
                 }
             }
 
-            parallel testingbranches
+        parallel testingbranches
         }
-
     })
 }
 
@@ -169,7 +199,7 @@ private void test(discriminator, commandBase, localSnapshots, localPluginsStashN
     unstashResources(localSnapshots, localPluginsStashName)
     athContainerImage.inside(containerArgs) {
         realtimeJUnit(testResults: 'target/surefire-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]) {
-            def command = 'eval "$(./vnc.sh)" && export DISPLAY=$BROWSER_DISPLAY && export SHARED_DOCKER_SERVICE=true && export EXERCISEDPLUGINREPORTER=textfile && ' + prepareCommand(commandBase, discriminator, localSnapshots, localPluginsStashName)
+            def command = './set-java.sh $java_version && eval "$(./vnc.sh)" && export DISPLAY=$BROWSER_DISPLAY && export SHARED_DOCKER_SERVICE=true && export EXERCISEDPLUGINREPORTER=textfile && ' + prepareCommand(commandBase, discriminator, localSnapshots, localPluginsStashName)
             if (!javaOptions.isEmpty()) {
                 command = """export JAVA_OPTS="${javaOptions.join(' ')}" && ${command}"""
             }

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -63,7 +63,7 @@ def call(Map params = [:]) {
 
             // Allow override of JDK version from metadata file
             jdks = metadata.jdks ?: jdks
-            
+
             if (!isLocalATH) {
                 echo 'Checking connectivity to ATH sources…'
                 sh "git ls-remote --exit-code -h ${athUrl}"
@@ -131,14 +131,14 @@ def call(Map params = [:]) {
                     def javaOptions = defaultJavaOptions.clone()
                     def commandBaseWithFutureJava = ""
                     def containerArgs = "-v /var/run/docker.sock:/var/run/docker.sock -u ath-user"
-                    
+
                     if(configFile) {
                         containerArgs += " -e CONFIG=../${configFile}" // ATH runs are executed in a subfolder, hence path needs to take that into account
                     }
-                    
+
                     // Add options for jdks
                     if ( currentJdk  > 8) {
-                        // Add environment variable to 
+                        // Add environment variable
                         commandBaseWithFutureJava = "JENKINS_OPTS=\"--enable-future-java\" "
                         containerArgs += " -e java_version=${currentJdk}"
 
@@ -190,7 +190,7 @@ def call(Map params = [:]) {
                 }
             }
 
-        parallel testingbranches
+            parallel testingbranches
         }
     })
 }

--- a/vars/runATH.txt
+++ b/vars/runATH.txt
@@ -18,7 +18,7 @@ The list of step's params and the related default values are:
     <li>metadataFile: A String indicating the file path (relative to the where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. <b>Defaults to <i>essentials.yml</i> at the location where this step is invoked</b></li>
     <li>jenkins: URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. <b>Can be overriden from the metadata file</b></li>
     <li>configFile: (Optional) Relative (to the workspace) path of a groovy script to customize the ATH behaviour</li>
-    <li>jdks: Java versions to use when running ATH. Defaults to 8. Only 8, 10 and 11 are supported. <b>Can be overridden from the metadata file</b></li>
+    <li>jdks: Java versions to use when running ATH. Defaults to 8. Only 8 and 11 are supported. <b>Can be overridden from the metadata file</b></li>
 </ul>
 
 <pre>
@@ -106,7 +106,6 @@ ath:
     - Category2
   jdks:
     - 8
-    - 10
     - 11
 </pre>
 
@@ -125,7 +124,7 @@ ath:
     <li>browsers: The list of browsers to use when running ATH Defaults to firefox. <b>Note that currently only firefox browser is supported, any other will be ignored</b></li>
     <li>tests: The list of tests to run for the component that calls the step. If no particular set of tests or categories is defined the SmokeTest Category of the ATH will be run</li>
     <li>categories: The list of Categories to run. Defaults to nothing</li>
-    <li>jdks: The list of jdks to use when running ATH. Defaults to 8. <b>Note that currently only 8, 10 and 11 are supported, any other will be ignored<b></li>
+    <li>jdks: The list of jdks to use when running ATH. Defaults to 8. <b>Note that currently only 8 and 11 are supported, any other will be ignored<b></li>
 </ul>
 
 <p>

--- a/vars/runATH.txt
+++ b/vars/runATH.txt
@@ -18,7 +18,7 @@ The list of step's params and the related default values are:
     <li>metadataFile: A String indicating the file path (relative to the where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. <b>Defaults to <i>essentials.yml</i> at the location where this step is invoked</b></li>
     <li>jenkins: URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. <b>Can be overriden from the metadata file</b></li>
     <li>configFile: (Optional) Relative (to the workspace) path of a groovy script to customize the ATH behaviour</li>
-    <li>jdks: Java versions to use when running ATH. Defaults to 8. Only 8 and 11 are supported. <b>Can be overridden from the metadata file</b></li>
+    <li>jdks: Java versions to use when running ATH. Defaults to 8. Only 8, 10 and 11 are supported. <b>Can be overridden from the metadata file</b></li>
 </ul>
 
 <pre>
@@ -106,6 +106,7 @@ ath:
     - Category2
   jdks:
     - 8
+    - 10
     - 11
 </pre>
 
@@ -124,7 +125,7 @@ ath:
     <li>browsers: The list of browsers to use when running ATH Defaults to firefox. <b>Note that currently only firefox browser is supported, any other will be ignored</b></li>
     <li>tests: The list of tests to run for the component that calls the step. If no particular set of tests or categories is defined the SmokeTest Category of the ATH will be run</li>
     <li>categories: The list of Categories to run. Defaults to nothing</li>
-    <li>jdks: The list of jdks to use when running ATH. Defaults to 8. <b>Note that currently only 8 and 11 are supported, any other will be igonred<b></li>
+    <li>jdks: The list of jdks to use when running ATH. Defaults to 8. <b>Note that currently only 8, 10 and 11 are supported, any other will be ignored<b></li>
 </ul>
 
 <p>

--- a/vars/runATH.txt
+++ b/vars/runATH.txt
@@ -18,6 +18,7 @@ The list of step's params and the related default values are:
     <li>metadataFile: A String indicating the file path (relative to the where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. <b>Defaults to <i>essentials.yml</i> at the location where this step is invoked</b></li>
     <li>jenkins: URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. <b>Can be overriden from the metadata file</b></li>
     <li>configFile: (Optional) Relative (to the workspace) path of a groovy script to customize the ATH behaviour</li>
+    <li>jdks: Java versions to use when running ATH. Defaults to 8. Only 8 and 11 are supported. <b>Can be overridden from the metadata file</b></li>
 </ul>
 
 <pre>
@@ -103,6 +104,9 @@ ath:
   categories:
     - Category1
     - Category2
+  jdks:
+    - 8
+    - 11
 </pre>
 
 <p>
@@ -120,6 +124,7 @@ ath:
     <li>browsers: The list of browsers to use when running ATH Defaults to firefox. <b>Note that currently only firefox browser is supported, any other will be ignored</b></li>
     <li>tests: The list of tests to run for the component that calls the step. If no particular set of tests or categories is defined the SmokeTest Category of the ATH will be run</li>
     <li>categories: The list of Categories to run. Defaults to nothing</li>
+    <li>jdks: The list of jdks to use when running ATH. Defaults to 8. <b>Note that currently only 8 and 11 are supported, any other will be igonred<b></li>
 </ul>
 
 <p>


### PR DESCRIPTION
See [[INFRA-1690] DevTools: Add support of Specifying Java Level for Test in runATH()](https://issues.jenkins-ci.org/browse/INFRA-1690)

**TL;DR**
Allow to select jdks to use when running the ATH tests

* JDKs supported: 8, 10 and 11

Added _modules_ and _enable-future-java_. Using the new _set-java.sh_ script. This PR is *blocked by* https://github.com/jenkinsci/acceptance-test-harness/pull/464 where we change the way the docker image is created.

@olivergondza @raul-arabaolaza @reviewbybees (@oleg-nenashev, @batmat, @alecharp) reviews welcome