### PR TITLE
Add shm-size to avoid selenium webdriver exceptions

### DIFF
--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -130,7 +130,8 @@ def call(Map params = [:]) {
                     def currentJdk = jdk
                     def javaOptions = defaultJavaOptions.clone()
                     def commandBaseWithFutureJava = ""
-                    def containerArgs = "-v /var/run/docker.sock:/var/run/docker.sock -u ath-user"
+                    //Add shm-size to avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed
+                    def containerArgs = "-v /var/run/docker.sock:/var/run/docker.sock -u ath-user --shm-size 2g"
 
                     if(configFile) {
                         containerArgs += " -e CONFIG=../${configFile}" // ATH runs are executed in a subfolder, hence path needs to take that into account


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/3818 and related PRs on [pipeline-library](https://github.com/jenkins-infra/pipeline-library), [jenkins](https://github.com/jenkinsci/jenkins) and [acceptance-test-harness](https://github.com/jenkinsci/acceptance-test-harness) to get context.

I managed to reproduce the environment locally and got  the exception _Failed to decode response from marionette_. After a lot of research and looking for the failures over internet, I think we have the fix. It's just **--shm-size 2g** when running the docker container. It was set in _ath-container.sh_ and _Jenkinsfile_ on ATH, but not in _runATH.groovy_ here. I saw it but I thought it was due to Jenkins OSS CI restrictions, but it fix the problem actually.

In addition, we can revert the change on https://github.com/jenkinsci/acceptance-test-harness/pull/469, I tested in my local environment without this catch and it still works. But as it seems to be innocuous, we can leave it there.

I've added a comment to avoid forgetting the reason. As Jenkins CI gets the latest library, I think we don't need to change the _essentials.yml_ of Jenkins.

@olivergondza @batmat @oleg-nenashev @alecharp @raul-arabaolaza