### PR TITLE
[INFRA-1953] Make pipeline-library#runATH step runs with old ATH sources and images

### DIFF
--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -131,11 +131,12 @@ def call(Map params = [:]) {
                     def javaOptions = defaultJavaOptions.clone()
                     def commandBaseWithFutureJava = ""
                     //Add shm-size to avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed
-                    def containerargs = "-v /var/run/docker.sock:/var/run/docker.sock -u ath-user --shm-size 2g"
+                    def containerArgs = "-v /var/run/docker.sock:/var/run/docker.sock -u ath-user --shm-size 2g"
 
                     if(configFile) {
                         containerArgs += " -e CONFIG=../${configFile}" // ATH runs are executed in a subfolder, hence path needs to take that into account
                     }
+
                     // Add options for jdks
                     if ( currentJdk  > 8) {
                         // Add environment variable

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -132,16 +132,15 @@ def call(Map params = [:]) {
                     def commandBaseWithFutureJava = ""
                     //Add shm-size to avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed
                     def containerArgs = "-v /var/run/docker.sock:/var/run/docker.sock -u ath-user --shm-size 2g"
+                    containerArgs += " -e java_version=${currentJdk}"
 
                     if(configFile) {
                         containerArgs += " -e CONFIG=../${configFile}" // ATH runs are executed in a subfolder, hence path needs to take that into account
                     }
-
                     // Add options for jdks
                     if ( currentJdk  > 8) {
                         // Add environment variable
                         commandBaseWithFutureJava = "JENKINS_OPTS=\"--enable-future-java\" "
-                        containerArgs += " -e java_version=${currentJdk}"
 
                         // Add modules removed
                         javaOptions << "-p /home/ath-user/jdk11-libs/jaxb-api.jar:/home/ath-user/jdk11-libs/javax.activation.jar"
@@ -198,10 +197,51 @@ private void test(discriminator, commandBase, localSnapshots, localPluginsStashN
     unstashResources(localSnapshots, localPluginsStashName)
     athContainerImage.inside(containerArgs) {
         realtimeJUnit(testResults: 'target/surefire-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]) {
-            def command = './set-java.sh $java_version && eval "$(./vnc.sh)" && export DISPLAY=$BROWSER_DISPLAY && export SHARED_DOCKER_SERVICE=true && export EXERCISEDPLUGINREPORTER=textfile && ' + prepareCommand(commandBase, discriminator, localSnapshots, localPluginsStashName)
+<<<<<<< HEAD
+            /*
+            If you want to compile with java > 8 and have all needed, do it
+            If you want to compile with java > 8 and you lack the set-java script, FAILURE
+            If other case (java8 and lack set-java), write a message in the log
+             */
+            def command = '''
+            if [ -x ./set-java.sh ] && [ -n "$java_version" ] && [ "$java_version" -gt "8" ]; then
+                ./set-java.sh $java_version;
+            elif [ -n "$java_version" ] && [ "$java_version" -gt "8" ] && [ ! -x ./set-java.sh ]; then
+                echo "ERROR: ./set-java.sh not found because you are using old ATH sources and \\$java_version = $java_version specified. We cannot run on this JDK";
+                exit 1;
+            elif [ ! -x ./set-java.sh ]; then
+                echo "INFO: ./set-java.sh not found because you are using old ATH sources, please consider to update ATH sources and docker image";
+            fi
+=======
+            // Allow call old images without the set-java.sh script. A message is showed if it doesn't exist to alert
+            // that you are using a new pipeline-library with an old ATH source/image (... type: ./set-java.sh: not found)
+            def command = '''
+            if [ -x ./set-java.sh ]; then
+                ./set-java.sh $java_version;
+            else
+                if [ $java_version -gt 8 ]; then
+                    echo "Info: ./set-java.sh not found because you are using old ATH sources, $java_version cannot be used, instead java 8 will be used"
+                else
+                    echo "Info: ./set-java.sh not found because you are using old ATH sources, please consider to update ATH sources and docker image"
+                fi;
+            fi;
+>>>>>>> d2f20dc... [INFRA-1953] using -x as propose, improve message and java variable
+
+            eval "$(./vnc.sh)" \
+            && export DISPLAY=$BROWSER_DISPLAY \
+            && export SHARED_DOCKER_SERVICE=true \
+            && export EXERCISEDPLUGINREPORTER=textfile \
+            && \
+            '''
+
+            command += prepareCommand(commandBase, discriminator, localSnapshots, localPluginsStashName)
+<<<<<<< HEAD
+=======
             if (!javaOptions.isEmpty()) {
+>>>>>>> d2f20dc... [INFRA-1953] using -x as propose, improve message and java variable
                 command = """export JAVA_OPTS="${javaOptions.join(' ')}" && ${command}"""
             }
+
             sh command
         }
     }


### PR DESCRIPTION
See [Make pipeline-library#runATH step runs with old ATH sources and images](https://issues.jenkins-ci.org/browse/INFRA-1953)

This PR allows you to use the runATH step with old ATH sources and images. With this, your builds will not fail if the pipeline-library is not on sync with the ATH sources and images used. 

@batmat @alecharp @raul-arabaolaza @olivergondza 