### PR TITLE
Offer recommended configurations for buildPlugin()

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,9 +31,10 @@ buildPlugin()
 * `jenkinsVersions`: (default: `[null]`) - a matrix of Jenkins baseline versions to build/test against in parallel (null means default,
   only available for Maven projects)
 * `configurations`: An alternative way to specify `platforms`, `jdkVersions` and `jenkinsVersions` (that can not be combined
-  with any of them). Those options will run the build for all combinations of their values. While that is desirable in
+  with any of them).   
+** Those options will run the build for all combinations of their values. While that is desirable in
   many cases, `configurations` permit to provide a specific combinations of label and java/jenkins versions to use:
-
+  
 [source,groovy]
 ----
 buildPlugin(/*...*/, configurations: [
@@ -42,6 +43,17 @@ buildPlugin(/*...*/, configurations: [
   [ platform: "linux", jdk: "11", jenkins: "2.150", javaLevel: 8 ]
 ])
 ----
+
+** It is also possible to use a  `buildPlugin.recommendedConfigurations()` method to get recommended configurations for testing. 
+Note that the recommended configuration may change over time, 
+and hence your CI may break if the new recommended configuration is not compatible
+
+[source,groovy]
+----
+buildPlugin(/*...*/, configurations: buildPlugin.recommendedConfigurations())
+----
+
+
 * `tests`: (default: `null`) - a map of parameters to run tests during the build
 ** `skip` - If `true`, skipp all the tests by setting the `-skipTests` profile.
   It will also skip FindBugs in modern Plugin POMs.

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -219,3 +219,21 @@ static List<Map<String, String>> getConfigurations(Map params) {
     }
     return ret
 }
+
+/**
+ * Get recommended configurations for testing.
+ * Includes testing Java 8 and 11 on the newest LTS.
+ */
+static List<Map<String, String>> recommendedConfigurations() {
+    //TODO: replace by 2.164.1 once it is released
+    def recentLTS = "2.164"
+    def configurations = [
+        [ platform: "linux", jdk: "8", jenkins: null ],
+        [ platform: "windows", jdk: "8", jenkins: null ],
+        [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+        [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+        [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
+        [ platform: "windows", jdk: "11", jenkins: recentLTS, javaLevel: "8" ]
+    ]
+    return configurations
+}


### PR DESCRIPTION
I am a bit tired of copy-pasting configurations for Java 11 between plugins, and I would like to add a utility method for it to the Pipeline library.

Question to reviewers:

*  Is it fine to use a generic `recommendedConfigurations()` method with a disclaimer that the configurations may change at any moment and break CI?
* If no, what would be your recommendations?

CC @batmat @alecharp @MRamonLeon @MarkEWaite @olivergondza @raul-arabaolaza 
