### PR TITLE
Always collect test results after running the build

### DIFF
--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -63,17 +63,18 @@ def call(Map params = [:]) {
                         if (isUnix()) {
                             command = "./" + command
                         }
-                        infra.runWithJava(command, jdk)
+                        try {
+                            infra.runWithJava(command, jdk)
+                        } finally {
+                            if (!skipTests) {
+                                junit('**/build/test-results/**/*.xml')
+                            }
+                        }
                     }
 
                     stage("Archive (${stageIdentifier})") {
-                        if (!skipTests) {
-                            junit '**/build/test-results/**/*.xml'
-                        }
-                        
                         //TODO(oleg-nenashev): Add static analysis results publishing like in buildPlugin() for Maven 
-                        
-                        // TODO do this in a finally-block so we capture all test results even if one branch aborts early
+
                         if (failFast && currentBuild.result == 'UNSTABLE') {
                             error 'There were test failures; halting early'
                         }


### PR DESCRIPTION
This should especially fix test results collection for Gradle, where it's not possible to set [test.ignoreFailures][1] from the commandline.

I put this for discussion here as I am not 100% sure if it doesn't brake something in the case of errors. E.g. that archiving is triggered but not working as expected.

[1]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:ignoreFailures