### PR TITLE
[INFRA-2028] `buildPlugin()` - Remove the timestamps step which is no longer necessary

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -171,11 +171,9 @@ def call(Map params = [:]) {
         }
     }
 
-    timestamps {
-        parallel(tasks)
-        if (publishingIncrementals) {
-            infra.maybePublishIncrementals()
-        }
+    parallel(tasks)
+    if (publishingIncrementals) {
+        infra.maybePublishIncrementals()
     }
 }
 


### PR DESCRIPTION
[INFRA-2028](https://issues.jenkins-ci.org/browse/INFRA-2028)