### PR TITLE
Update the recommended LTS version from 2.164.1 to 2.176.1 in `buildPlugin.recommendedConfigurations`

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -225,7 +225,7 @@ static List<Map<String, String>> getConfigurations(Map params) {
  * Includes testing Java 8 and 11 on the newest LTS.
  */
 static List<Map<String, String>> recommendedConfigurations() {
-    def recentLTS = "2.176.1"
+    def recentLTS = "2.176.3"
     def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
         [ platform: "windows", jdk: "8", jenkins: null ],

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -225,7 +225,7 @@ static List<Map<String, String>> getConfigurations(Map params) {
  * Includes testing Java 8 and 11 on the newest LTS.
  */
 static List<Map<String, String>> recommendedConfigurations() {
-    def recentLTS = "2.176.3"
+    def recentLTS = "2.222.3"
     def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
         [ platform: "windows", jdk: "8", jenkins: null ],

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -225,7 +225,7 @@ static List<Map<String, String>> getConfigurations(Map params) {
  * Includes testing Java 8 and 11 on the newest LTS.
  */
 static List<Map<String, String>> recommendedConfigurations() {
-    def recentLTS = "2.164.1"
+    def recentLTS = "2.176.1"
     def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
         [ platform: "windows", jdk: "8", jenkins: null ],


### PR DESCRIPTION
See https://github.com/jenkinsci/kubernetes-plugin/pull/461/commits/e71a5c5950ee976da51bf3046775ff2b22e4c170 for example: cannot use `recommendedConfigurations()` if your `jenkins.baseline` is _newer_ than the `recentLTS`! (If it were the _same_, it would be possible, though wasteful.)

In general I am not a fan of `recommendedConfigurations`. It means that a critical aspect of a plugin’s build is controlled by a library it consumes in a `master` revision, making the build nondeterministic. See https://github.com/jenkins-infra/pipeline-library/pull/86#discussion_r263697425 for discussion. It would be OK if the `recentLTS` were a parameter passed to the method, `null` meaning skip those branches, so you could begin testing against a new LTS line in a controlled fashion in a PR. @oleg-nenashev @batmat