### PR TITLE
Use ACI agents for Linux based builds.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,6 +23,7 @@ buildPlugin()
 ==== Optional arguments
 
 * `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
+* `useAci` (default: `false`) - uses link:https://azure.microsoft.com/en-us/services/container-instances/[Azure Container Instances] for build instead of link:https://azure.microsoft.com/en-us/services/virtual-machines/[Azure Virtual Machines].
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -15,7 +15,7 @@ def call(Map params = [:]) {
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
     def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
-    def useAci = params.containsKey('useAci') ? params.useAci : true
+    def useAci = params.containsKey('useAci') ? params.useAci : false
     if(timeoutValue > 180) {
       echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
       timeoutValue = 180

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -15,6 +15,7 @@ def call(Map params = [:]) {
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
     def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
+    def useAci = params.containsKey('useAci') ? params.useAci : true
     if(timeoutValue > 180) {
       echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
       timeoutValue = 180
@@ -38,7 +39,7 @@ def call(Map params = [:]) {
         boolean skipTests = params?.tests?.skip
 
         tasks[stageIdentifier] = {
-            node(label) {
+            node((useAci && label == 'linux') ? (jdk == 8 ? 'maven' : 'maven-11') : label) {
                 timeout(timeoutValue) {
                     boolean isMaven
                     // Archive artifacts once with pom declared baseline
@@ -96,7 +97,7 @@ def call(Map params = [:]) {
                             if (runCheckstyle) {
                                 mavenOptions += "checkstyle:checkstyle"
                             }
-                            infra.runMaven(mavenOptions, jdk)
+                            infra.runMaven(mavenOptions, jdk, null, null, !useAci)
                         } else {
                             List<String> gradleOptions = [
                                     '--no-daemon',
@@ -107,7 +108,7 @@ def call(Map params = [:]) {
                             if (isUnix()) {
                                 command = "./" + command
                             }
-                            infra.runWithJava(command, jdk)
+                            infra.runWithJava(command, jdk, null, !useAci)
                         }
                     }
 

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -66,7 +66,7 @@ boolean retrieveMavenSettingsFile(String settingsXml, String jdk = 8) {
  * @return nothing
  * @see #retrieveMavenSettingsFile(String)
  */
-Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = null, String settingsFile = null) {
+Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = true) {
     List<String> mvnOptions = [
         '--batch-mode',
         '--show-version',
@@ -85,7 +85,7 @@ Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = nu
     mvnOptions.addAll(options)
     mvnOptions.unique()
     String command = "mvn ${mvnOptions.join(' ')}"
-    runWithMaven(command, jdk, extraEnv)
+    runWithMaven(command, jdk, extraEnv, addToolEnv)
 }
 
 /**
@@ -96,15 +96,19 @@ Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = nu
  * @param extraEnv Extra environment variables to be passed
  * @return nothing
  */
-Object runWithMaven(String command, String jdk = 8, List<String> extraEnv = null) {
-    List<String> env = [
+Object runWithMaven(String command, String jdk = 8, List<String> extraEnv = null, Boolean addToolEnv = true) {
+    List<String> env = [];
+    if(addToolEnv) {
+        env = [
         "PATH+MAVEN=${tool 'mvn'}/bin"
-    ]
+        ]
+    }
+
     if (extraEnv != null) {
         env.addAll(extraEnv)
     }
 
-    runWithJava(command, jdk, env)
+    runWithJava(command, jdk, env, addToolEnv)
 }
 
 /**
@@ -116,12 +120,16 @@ Object runWithMaven(String command, String jdk = 8, List<String> extraEnv = null
  * @param extraEnv Extra environment variables to be passed
  * @return nothing
  */
-Object runWithJava(String command, String jdk = 8, List<String> extraEnv = null) {
-    String jdkTool = "jdk${jdk}"
-    List<String> env = [
-        "JAVA_HOME=${tool jdkTool}",
-        'PATH+JAVA=${JAVA_HOME}/bin',
-    ]
+Object runWithJava(String command, String jdk = 8, List<String> extraEnv = null, Boolean addToolEnv = true) {
+    List<String> env = [];
+    if(addToolEnv) {
+        String jdkTool = "jdk${jdk}"
+        List<String> env = [
+            "JAVA_HOME=${tool jdkTool}",
+            'PATH+JAVA=${JAVA_HOME}/bin',
+        ]
+    }
+
     if (extraEnv != null) {
         env.addAll(extraEnv)
     }


### PR DESCRIPTION
This will use ACI (Azure Container Instances) agents instead of VM's. The default is to use ACI agents, with the ability to override in the plugin configuration.

CC @rtyler, @jglick, @daniel-beck 