### PR TITLE
Fix jdk version check

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -40,7 +40,7 @@ def call(Map params = [:]) {
         boolean addToolEnv = !(useAci && label == 'linux')
 
         tasks[stageIdentifier] = {
-            node((useAci && label == 'linux') ? (jdk == 8 ? 'maven' : 'maven-11') : label) {
+            node((useAci && label == 'linux') ? (jdk == "8" ? 'maven' : 'maven-11') : label) {
                 timeout(timeoutValue) {
                     boolean isMaven
                     // Archive artifacts once with pom declared baseline

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -40,7 +40,7 @@ def call(Map params = [:]) {
         boolean addToolEnv = !(useAci && label == 'linux')
 
         tasks[stageIdentifier] = {
-            node((useAci && label == 'linux') ? (jdk == "8" ? 'maven' : 'maven-11') : label) {
+            node((useAci && label == 'linux') ? (jdk == '8' ? 'maven' : 'maven-11') : label) {
                 timeout(timeoutValue) {
                     boolean isMaven
                     // Archive artifacts once with pom declared baseline


### PR DESCRIPTION
Currently, the jdk version check is failing and always selects JDK11 because I was using an int 8 instead of a string '8' to compare.