### PR TITLE
Remove static modifer

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -187,7 +187,7 @@ def call(Map params = [:]) {
     }
 }
 
-static boolean hasDockerLabel() {
+boolean hasDockerLabel() {
     env?.NODE_LABELS?.contains("docker")
 }
 

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -188,7 +188,7 @@ def call(Map params = [:]) {
 }
 
 boolean hasDockerLabel() {
-    env?.NODE_LABELS?.contains("docker")
+    env.NODE_LABELS?.contains("docker")
 }
 
 static List<Map<String, String>> getConfigurations(Map params) {


### PR DESCRIPTION
https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fslack-plugin/detail/PR-603/5/pipeline

```
[2019-08-13T15:56:15.967Z] org.jenkinsci.plugins.workflow.cps.CpsCompilationErrorsException: startup failed:

[2019-08-13T15:56:15.967Z] /var/jenkins_home/jobs/Plugins/jobs/slack-plugin/branches/PR-603/builds/5/libs/pipeline-library/vars/buildPlugin.groovy: 191: Apparent variable 'env' was found in a static scope but doesn't refer to a local variable, static field or class. Possible causes:

[2019-08-13T15:56:15.967Z] You attempted to reference a variable in the binding or an instance variable from a static context.

[2019-08-13T15:56:15.967Z] You misspelled a classname or statically imported field. Please check the spelling.

[2019-08-13T15:56:15.967Z] You attempted to use a method 'env' but left out brackets in a place not allowed by the grammar.

[2019-08-13T15:56:15.967Z]  @ line 191, column 5.

[2019-08-13T15:56:15.967Z]        env?.NODE_LABELS?.contains("docker")

```

cc @olblak @oleg-nenashev 