### PR TITLE
Add Unit Tests for `buildPlugin` and `runBenchmarks`

### DIFF
--- a/src/test/groovy/BuildPluginStepTests.groovy
+++ b/src/test/groovy/BuildPluginStepTests.groovy
@@ -1,0 +1,162 @@
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotNull
+
+class BuildPluginStepTests extends BasePipelineTest {
+  static final String scriptName = 'vars/buildPlugin.groovy'
+  Map env = [:]
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    env.NODE_LABELS = 'docker'
+    binding.setVariable('env', env)
+    binding.setProperty('scm', new String())
+    binding.setProperty('mvnSettingsFile', 'settings.xml')
+
+    helper.registerAllowedMethod('node', [String.class], { s -> s })
+    helper.registerAllowedMethod('timeout', [String.class], { s -> s })
+    helper.registerAllowedMethod('stage', [String.class], { s -> s })
+    helper.registerAllowedMethod('fileExists', [String.class], { s -> s })
+    helper.registerAllowedMethod('readFile', [String.class], { s -> s })
+    helper.registerAllowedMethod('checkstyle', [Map.class], { true })
+    helper.registerAllowedMethod('fingerprint', [String.class], { s -> s })
+    helper.registerAllowedMethod('archiveArtifacts', [Map.class], { true })
+    helper.registerAllowedMethod('deleteDir', [], { true })
+    helper.registerAllowedMethod('isUnix', [], { true })
+    helper.registerAllowedMethod('hasDockerLabel', [], { true })
+    helper.registerAllowedMethod('sh', [String.class], { s -> s })
+    helper.registerAllowedMethod('parallel', [Map.class], { true })
+
+//infra.runMaven
+//infra.runWithJava
+//infra.maybePublishIncrementals()
+
+    helper.registerAllowedMethod('echo', [String.class], { s -> s })
+    helper.registerAllowedMethod('error', [String.class], { s ->
+      updateBuildStatus('FAILURE')
+      throw new Exception(s)
+    })
+  }
+
+  @Test
+  void test_recommendedConfigurations() throws Exception {
+    def script = loadScript(scriptName)
+    def configurations = script.recommendedConfigurations()
+    printCallStack()
+    assertFalse(configurations.isEmpty())
+  }
+
+  @Test
+  void test_getConfigurations_with_implicit_and_explicit() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      // parameters are set to random values
+      script.getConfigurations(configurations: true, platforms: true)
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'error'
+    }.any { call ->
+      callArgsToString(call).contains('can not be used')
+    })
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_getConfigurations_explicit_without_platform() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.getConfigurations(configurations: [[ jdk: '1.8' ]])
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'error'
+    }.any { call ->
+      callArgsToString(call).contains('Configuration field "platform" must be specified: [jdk:1.8]')
+    })
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_getConfigurations_explicit_without_jdk() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.getConfigurations(configurations: [[ platform: 'linux' ]])
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'error'
+    }.any { call ->
+      callArgsToString(call).contains('Configuration filed "jdk" must be specified: [platform:linux]')
+    })
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_getConfigurations_without_parameters() throws Exception {
+    def script = loadScript(scriptName)
+    def configurations = script.getConfigurations([:])
+
+    def expected = [['platform': 'linux', 'jdk': 8, 'jenkins': null, 'javaLevel': null],
+                    ['platform': 'windows', 'jdk': 8, 'jenkins': null, 'javaLevel': null]]
+    assertEquals(expected, configurations)
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_getConfigurations_implicit_with_platforms() throws Exception {
+    def script = loadScript(scriptName)
+    def configurations = script.getConfigurations(platforms: ['bar', 'foo'])
+    println configurations
+    assertEquals(configurations.size, 2)
+    assertNotNull(configurations.find {it.platform.equals('bar')})
+    assertNotNull(configurations.find {it.platform.equals('foo')})
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_getConfigurations_implicit_with_jenkinsVersions() throws Exception {
+    def script = loadScript(scriptName)
+    def configurations = script.getConfigurations(jenkinsVersions: ['1.x', '2.x'])
+    assertEquals(configurations.size, 4)
+    assertNotNull(configurations.find{it.jenkins.equals('1.x')})
+    assertNotNull(configurations.find{it.jenkins.equals('2.x')})
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_getConfigurations_implicit_with_jdkVersions() throws Exception {
+    def script = loadScript(scriptName)
+    def configurations = script.getConfigurations(jdkVersions: ['1.4', '1.3'])
+    assertEquals(configurations.size, 4)
+    assertNotNull(configurations.find{it.jdk.equals('1.4')})
+    assertNotNull(configurations.find{it.jdk.equals('1.3')})
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_hasDockerLabel() throws Exception {
+    def script = loadScript(scriptName)
+    def value = script.hasDockerLabel()
+    printCallStack()
+    assertTrue(value)
+  }
+
+}

--- a/src/test/groovy/CustomWARPackagerStepTests.groovy
+++ b/src/test/groovy/CustomWARPackagerStepTests.groovy
@@ -1,4 +1,5 @@
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import mock.Infra
 import org.junit.Before
 import org.junit.Test
 import org.yaml.snakeyaml.Yaml
@@ -48,15 +49,6 @@ class CustomWARPackagerStepTests extends BasePipelineTest {
       version: "foo"
       artifactId: "barId"
   '''
-
-  /**
-   * Mock Infra step
-   */
-  class Infra implements Serializable {
-    public String retrieveMavenSettingsFile(String location) { return location }
-    public String runWithMaven(String cmd) { return cmd }
-    public String runMaven(mvn, jdk, foo, settings) { return 'OK' }
-  }
 
   @Override
   @Before

--- a/src/test/groovy/EssentialsTestStepTests.groovy
+++ b/src/test/groovy/EssentialsTestStepTests.groovy
@@ -1,4 +1,6 @@
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import mock.CustomWARPackager
+import mock.Infra
 import org.yaml.snakeyaml.Yaml
 import org.junit.Before
 import org.junit.Test
@@ -9,20 +11,6 @@ import static org.junit.Assert.assertFalse
 class EssentialsTestStepTests extends BasePipelineTest {
   static final String scriptName = 'vars/essentialsTest.groovy'
   Map env = [:]
-
-  /**
-   * Mock Infra step
-   */
-  class Infra implements Serializable {
-    public void checkout() { }
-  }
-
-  /**
-   * Mock customWARPackager step
-   */
-  class CustomWARPackager implements Serializable {
-    public void build(String path, String war, String bom) { }
-  }
 
   static final String  essentials = '''
 flow:

--- a/src/test/groovy/PublishReportsStepTests.groovy
+++ b/src/test/groovy/PublishReportsStepTests.groovy
@@ -1,4 +1,6 @@
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import mock.Docker
+import mock.Infra
 import org.junit.Before
 import org.junit.Test
 import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
@@ -8,26 +10,6 @@ import static org.junit.Assert.assertTrue
 class PublishReportsStepTests extends BasePipelineTest {
   static final String scriptName = 'vars/publishReports.groovy'
   Map env = [:]
-
-  /**
-   * Mock Infra step
-   */
-  class Infra implements Serializable {
-    private final boolean result
-    public Infra(boolean result) { this.result = result }
-    public boolean isTrusted() { return result }
-  }
-
-  /**
-   * Mock Docker class from docker-workflow plugin.
-   */
-  class Docker implements Serializable {
-    public Image image(String id) { new Image(this, id) }
-    public class Image implements Serializable {
-      private Image(Docker docker, String id) {}
-      public <V> V inside(String args = '', Closure<V> body) { body() }
-    }
-  }
 
   @Override
   @Before

--- a/src/test/groovy/RunBenchmarksStepTests.groovy
+++ b/src/test/groovy/RunBenchmarksStepTests.groovy
@@ -1,0 +1,63 @@
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import mock.Infra
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.junit.Assert.assertTrue
+
+class RunBenchmarksStepTests extends BasePipelineTest {
+  static final String scriptName = 'vars/runBenchmarks.groovy'
+  Map env = [:]
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+
+    binding.setVariable('env', env)
+    binding.setProperty('infra', new Infra(true))
+
+    helper.registerAllowedMethod('archiveArtifacts', [Map.class], { m -> m })
+    helper.registerAllowedMethod('echo', [String.class], { s -> s })
+    helper.registerAllowedMethod('lock', [String.class, Closure.class], { s, body -> body() })
+    helper.registerAllowedMethod('node', [String.class, Closure.class], { s, body -> body() })
+    helper.registerAllowedMethod('sh', [String.class], { s -> s })
+    helper.registerAllowedMethod('stage', [String.class, Closure.class], { s, body -> body() })
+  }
+
+  @Test
+  void test_without_parameters() throws Exception {
+    def script = loadScript(scriptName)
+    // when running without parameters
+    script.call()
+    printCallStack()
+    // then echo
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'echo'
+    }.any { call ->
+      callArgsToString(call).contains('No artifacts to archive')
+    })
+    // then run in the highmem node
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'node'
+    }.any { call ->
+      callArgsToString(call).contains('highmem')
+    })
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_artifacts() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with artifacts
+    script.call('foo')
+    printCallStack()
+    // then archiveArtifacts
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'archiveArtifacts'
+    }.any { call ->
+      callArgsToString(call).contains('foo')
+    })
+    assertJobStatusSuccess()
+  }
+}

--- a/src/test/groovy/mock/CurrentBuild.groovy
+++ b/src/test/groovy/mock/CurrentBuild.groovy
@@ -1,0 +1,9 @@
+package mock
+
+/**
+ * Mock currentBuild
+ */
+class CurrentBuild implements Serializable {
+  String result
+  public CurrentBuild(String result) { this.result = result }
+}

--- a/src/test/groovy/mock/CustomWARPackager.groovy
+++ b/src/test/groovy/mock/CustomWARPackager.groovy
@@ -1,0 +1,9 @@
+package mock
+
+
+/**
+ * Mock customWARPackager step
+ */
+class CustomWARPackager implements Serializable {
+  public void build(String path, String war, String bom) { }
+}

--- a/src/test/groovy/mock/Docker.groovy
+++ b/src/test/groovy/mock/Docker.groovy
@@ -1,0 +1,12 @@
+package mock
+
+/**
+ * Mock Docker class from docker-workflow plugin.
+ */
+class Docker implements Serializable {
+  public Image image(String id) { new Image(this, id) }
+  public class Image implements Serializable {
+    private Image(Docker docker, String id) {}
+    public <V> V inside(String args = '', Closure<V> body) { body() }
+  }
+}

--- a/src/test/groovy/mock/Infra.groovy
+++ b/src/test/groovy/mock/Infra.groovy
@@ -9,9 +9,12 @@ class Infra implements Serializable {
   public Infra(boolean result) { this.result = result }
   public Infra() { this.result = false }
   public void checkout() { }
+  public void checkout(repo) { }
   public String retrieveMavenSettingsFile(String location) { return location }
   public String runWithMaven(String cmd) { return cmd }
   public String runMaven(mvn, jdk, foo, settings) { return 'OK' }
+  public String runMaven(mvn, jdk, foo, settings, toolEnv) { return mvn }
+  public String runWithJava(command, jdk, foo, toolEnv) { return command }
   public boolean isTrusted() { return result }
-
+  public void maybePublishIncrementals() { }
 }

--- a/src/test/groovy/mock/Infra.groovy
+++ b/src/test/groovy/mock/Infra.groovy
@@ -12,6 +12,7 @@ class Infra implements Serializable {
   public void checkout(repo) { }
   public String retrieveMavenSettingsFile(String location) { return location }
   public String runWithMaven(String cmd) { return cmd }
+  public String runMaven(mvn) { return mvn }
   public String runMaven(mvn, jdk, foo, settings) { return 'OK' }
   public String runMaven(mvn, jdk, foo, settings, toolEnv) { return mvn }
   public String runWithJava(command, jdk, foo, toolEnv) { return command }

--- a/src/test/groovy/mock/Infra.groovy
+++ b/src/test/groovy/mock/Infra.groovy
@@ -1,0 +1,17 @@
+package mock
+
+/**
+ * Mock Infra step
+ */
+class Infra implements Serializable {
+
+  private final boolean result
+  public Infra(boolean result) { this.result = result }
+  public Infra() { this.result = false }
+  public void checkout() { }
+  public String retrieveMavenSettingsFile(String location) { return location }
+  public String runWithMaven(String cmd) { return cmd }
+  public String runMaven(mvn, jdk, foo, settings) { return 'OK' }
+  public boolean isTrusted() { return result }
+
+}

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -191,7 +191,7 @@ boolean hasDockerLabel() {
     env.NODE_LABELS?.contains("docker")
 }
 
-static List<Map<String, String>> getConfigurations(Map params) {
+List<Map<String, String>> getConfigurations(Map params) {
     boolean explicit = params.containsKey("configurations")
     boolean implicit = params.containsKey('platforms') || params.containsKey('jdkVersions') || params.containsKey('jenkinsVersions')
 


### PR DESCRIPTION
### Highlights
- Add UTs for `buildPlugin` and `runBenchmarks`
- Refactor mock classes to be reused
- Required to remove the `static` for the method `getConfigurations` otherwise the UTs won't run as expected

### Actions
- [ ] Confirm whether `static` is mandatory or no.