### PR TITLE
Stop `buildPlugin` cleanup error log on ACI (regression in 1.1.0)

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -173,7 +173,7 @@ def call(Map params = [:]) {
                 } finally {
                     deleteDir()
 
-                    if (isUnix() || hasDockerLabel()) {
+                    if (hasDockerLabel()) {
                         sh 'docker system prune --force --all || echo "Failed to cleanup docker images"'
                     }
                 }


### PR DESCRIPTION
ACI has linux label but not docker

Currently the cleanup script is running on ACI and failing, exception is ignored but it is red in blue ocean which confused me for a bit before I scrolled up and saw the actual build failure

cc @oleg-nenashev 