### PR TITLE
[INFRA-2243] - Introduce new buildPluginWithGradle() step and deprecate Gradle Support in buildPlugin()

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -106,11 +106,11 @@ and it may not work for other use-cases.
 ** It is also possible to use a  `buildPlugin.recommendedConfigurations()` method to get recommended configurations for testing. 
 Note that the recommended configuration may change over time, 
 and hence your CI may break if the new recommended configuration is not compatible
-
+* `timeout`: (default: `60`) - the number of minutes for build timeout, cannot be bigger than 180, i.e. 3 hours.
 [source,groovy]
 ----
-buildPlugin(/*...*/, configurations: [
-  [ platform: "linux", jdk: "8"],
+buildPluginWithGradle(/*...*/, configurations: [
+  [ platform: "linux", jdk: "8" ],
   [ platform: "windows", jdk: "8"],
 ])
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,10 @@ Check link:https://github.com/jenkins-infra/documentation/blob/master/ci.adoc[th
 
 === buildPlugin
 
-Applies the appropriate defaults for building a Maven- or Gradle-based plugin project on
+| WARNING: Gradle support in `buildPlugin()` is deprecated and will be eventually removed. Please use `buildPluginWithGradle()` |
+| --- |
+
+Applies the appropriate defaults for building a Maven-based plugin project on
 Linux and Windows.
 
 You are advised to be using a link:https://github.com/jenkinsci/plugin-pom/blob/master/README.md[2.x parent POM].

--- a/README.adoc
+++ b/README.adoc
@@ -132,7 +132,7 @@ The interface is similar to `buildPlugin()`, but some features are not supported
 Examples of not supported features:
 
 * [JEP-305](https://github.com/jenkinsci/jep/tree/master/jep/305)
-* Publushing of static analysis and coverage reports (Checkstyle, SpotBugs, JaCoCo)
+* Publishing of static analysis and coverage reports (Checkstyle, SpotBugs, JaCoCo)
 * Configuring `jenkinsVersion` and `javaLevel` for the build flow
 
 === runATH

--- a/README.adoc
+++ b/README.adoc
@@ -121,6 +121,20 @@ see the step doc for more documentation about he allowed versions
 infra.stashJenkinsWar("2.110")
 ----
 
+=== buildPluginWithGradle()
+
+Builds a Jenkins plugin using Gradle.
+The implementation follows the standard build/test/archive pattern. 
+The method targets compatibility with [Gradle JPI Plugin](https://github.com/jenkinsci/gradle-jpi-plugin),
+and it may not work for other use-cases.
+
+The interface is similar to `buildPlugin()`, but some features are not supported.
+Examples of not supported features:
+
+* [JEP-305](https://github.com/jenkinsci/jep/tree/master/jep/305)
+* Publushing of static analysis and coverage reports (Checkstyle, SpotBugs, JaCoCo)
+* Configuring `jenkinsVersion` and `javaLevel` for the build flow
+
 === runATH
 
 Runs the link:https://github.com/jenkinsci/acceptance-test-harness[Acceptance Test Harness] in a configurable way.

--- a/README.adoc
+++ b/README.adoc
@@ -9,8 +9,7 @@ Check link:https://github.com/jenkins-infra/documentation/blob/master/ci.adoc[th
 
 === buildPlugin
 
-| WARNING: Gradle support in `buildPlugin()` is deprecated and will be eventually removed. Please use `buildPluginWithGradle()` |
-| --- |
+WARNING: Gradle support in `buildPlugin()` is deprecated and will be eventually removed. Please use `buildPluginWithGradle()`
 
 Applies the appropriate defaults for building a Maven-based plugin project on
 Linux and Windows.
@@ -85,6 +84,20 @@ Usage:
 buildPlugin(platforms: ['linux'], jdkVersions: [7, 8], findbugs: [archive: true, unstableTotalAll: '0'], checkstyle: [run: true, archive: true])
 ----
 
+=== buildPluginWithGradle()
+
+Builds a Jenkins plugin using Gradle.
+The implementation follows the standard build/test/archive pattern. 
+The method targets compatibility with link:https://github.com/jenkinsci/gradle-jpi-plugin[Gradle JPI Plugin],
+and it may not work for other use-cases.
+
+The interface is similar to `buildPlugin()`, but some features are not supported.
+Examples of not supported features:
+
+* Deployment of incremental versions (link:https://github.com/jenkinsci/jep/tree/master/jep/305[JEP-305])
+* Publishing of static analysis and coverage reports (Checkstyle, SpotBugs, JaCoCo)
+* Configuring `jenkinsVersion` and `javaLevel` for the build flow
+
 === infra.isTrusted()
 
 Determine whether the Pipeline is executing in an internal "trusted" Jenkins
@@ -120,20 +133,6 @@ see the step doc for more documentation about he allowed versions
 ----
 infra.stashJenkinsWar("2.110")
 ----
-
-=== buildPluginWithGradle()
-
-Builds a Jenkins plugin using Gradle.
-The implementation follows the standard build/test/archive pattern. 
-The method targets compatibility with [Gradle JPI Plugin](https://github.com/jenkinsci/gradle-jpi-plugin),
-and it may not work for other use-cases.
-
-The interface is similar to `buildPlugin()`, but some features are not supported.
-Examples of not supported features:
-
-* [JEP-305](https://github.com/jenkinsci/jep/tree/master/jep/305)
-* Publishing of static analysis and coverage reports (Checkstyle, SpotBugs, JaCoCo)
-* Configuring `jenkinsVersion` and `javaLevel` for the build flow
 
 === runATH
 

--- a/README.adoc
+++ b/README.adoc
@@ -91,12 +91,39 @@ The implementation follows the standard build/test/archive pattern.
 The method targets compatibility with link:https://github.com/jenkinsci/gradle-jpi-plugin[Gradle JPI Plugin],
 and it may not work for other use-cases.
 
-The interface is similar to `buildPlugin()`, but some features are not supported.
+==== Optional arguments
+
+* `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
+* `failFast` (default: `true`) - instruct the build to fail fast when one of the configurations fail
+* `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
+  execute the steps against in parallel
+* `jdkVersions` (default: `[8]`) - JDK version numbers, must match a version
+    number jdk tool installed
+* `configurations`: An alternative way to specify `platforms`, `jdkVersions` (that can not be combined
+  with any of them)
+** Those options will run the build for all combinations of their values. While that is desirable in
+  many cases, `configurations` permit to provide a specific combinations of label and java/jenkins versions to use
+** It is also possible to use a  `buildPlugin.recommendedConfigurations()` method to get recommended configurations for testing. 
+Note that the recommended configuration may change over time, 
+and hence your CI may break if the new recommended configuration is not compatible
+
+[source,groovy]
+----
+buildPlugin(/*...*/, configurations: [
+  [ platform: "linux", jdk: "8"],
+  [ platform: "windows", jdk: "8"],
+])
+----
+
+==== Limitations
+
+Not all features of `buildPlugin()` for Maven are supported in the gradle flow. 
 Examples of not supported features:
 
 * Deployment of incremental versions (link:https://github.com/jenkinsci/jep/tree/master/jep/305[JEP-305])
 * Publishing of static analysis and coverage reports (Checkstyle, SpotBugs, JaCoCo)
-* Configuring `jenkinsVersion` and `javaLevel` for the build flow
+* Configuring `jenkinsVersion` and `javaLevel` for the build flow (as standalone arguments or as `configurations`)
+* Usage of link:https://azure.microsoft.com/en-us/services/container-instances/[Azure Container Instances] as agents (only Maven agents are configured)
 
 === infra.isTrusted()
 

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -101,6 +101,7 @@ def call(Map params = [:]) {
                                 }
                                 infra.runMaven(mavenOptions, jdk, null, null, addToolEnv)
                             } else {
+                                echo "WARNING: Gradle mode for buildPlugin() is deprecated, please use buildPluginWithGradle()"
                                 List<String> gradleOptions = [
                                         '--no-daemon',
                                         'cleanTest',

--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -21,7 +21,7 @@ def call(Map params = [:]) {
     boolean publishingIncrementals = false
     boolean archivedArtifacts = false
     Map tasks = [failFast: failFast]
-    buildPlugin.getConfigurations(params, true).each { config ->
+    buildPlugin.getConfigurations(params).each { config ->
         String label = config.platform
         String jdk = config.jdk
         String jenkinsVersion = config.jenkins

--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -80,7 +80,5 @@ def call(Map params = [:]) {
         }
     }
 
-    timestamps {
-        parallel(tasks)
-    }
+   parallel(tasks)
 }

--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -13,7 +13,7 @@ def call(Map params = [:]) {
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
     def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
-    if(timeoutValue > 180) {
+    if (timeoutValue > 180) {
       echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
       timeoutValue = 180
     }
@@ -44,11 +44,11 @@ def call(Map params = [:]) {
 
                     stage("Build (${stageIdentifier})") {
                         if (javaLevel != null) {
-                            echo "WARNING: java.level is not supported in the  buildGradlePlugin(). This parmeter will be ignored"
+                            echo "WARNING: 'javaLevel' parameter is not supported in buildPluginWithGradle(). It will be ignored"
                         }
                         //TODO(oleg-nenashev): Once supported by Gradle JPI Plugin, pass jenkinsVersion
                         if (jenkinsVersion != null) {
-                            echo "WARNING: Jenkins version is not supported in buildGradlePlugin(). This parmeter will be ignored"
+                            echo "WARNING: 'jenkinsVersion' parameter is not supported in buildPluginWithGradle(). It will be ignored"
                         }
                         List<String> gradleOptions = [
                                 '--no-daemon',

--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -1,0 +1,86 @@
+#!/usr/bin/env groovy
+
+/**
+ * Simple wrapper step for building a plugin with Gradle.
+ */
+def call(Map params = [:]) {
+    // Faster build and reduces IO needs
+    properties([
+        durabilityHint('PERFORMANCE_OPTIMIZED'),
+        buildDiscarder(logRotator(numToKeepStr: '5')),
+    ])
+
+    def repo = params.containsKey('repo') ? params.repo : null
+    def failFast = params.containsKey('failFast') ? params.failFast : true
+    def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
+    if(timeoutValue > 180) {
+      echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
+      timeoutValue = 180
+    }
+
+    boolean publishingIncrementals = false
+    boolean archivedArtifacts = false
+    Map tasks = [failFast: failFast]
+    buildPlugin.getConfigurations(params, true).each { config ->
+        String label = config.platform
+        String jdk = config.jdk
+        String jenkinsVersion = config.jenkins
+        String javaLevel = config.javaLevel
+
+        String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
+        
+        tasks[stageIdentifier] = {
+            node(label) {
+                timeout(timeoutValue) {
+                    // Archive artifacts once with pom declared baseline
+                    boolean doArchiveArtifacts = !jenkinsVersion && !archivedArtifacts
+                    if (doArchiveArtifacts) {
+                        archivedArtifacts = true
+                    }
+
+                    stage("Checkout (${stageIdentifier})") {
+                        infra.checkout(repo)
+                    }
+
+                    stage("Build (${stageIdentifier})") {
+                        if (javaLevel != null) {
+                            echo "WARNING: java.level is not supported in the  buildGradlePlugin(). This parmeter will be ignored"
+                        }
+                        //TODO(oleg-nenashev): Once supported by Gradle JPI Plugin, pass jenkinsVersion
+                        if (jenkinsVersion != null) {
+                            echo "WARNING: Jenkins version is not supported in buildGradlePlugin(). This parmeter will be ignored"
+                        }
+                        List<String> gradleOptions = [
+                                '--no-daemon',
+                                'cleanTest',
+                                'build',
+                        ]
+                        String command = "gradlew ${gradleOptions.join(' ')}"
+                        if (isUnix()) {
+                            command = "./" + command
+                        }
+                        infra.runWithJava(command, jdk)
+                    }
+
+                    stage("Archive (${stageIdentifier})") {
+                        junit testReports '**/build/test-results/**/*.xml'
+                        
+                        //TODO(oleg-nenashev): Add static analysis results publishing like in buildPlugin() for Maven 
+                        
+                        // TODO do this in a finally-block so we capture all test results even if one branch aborts early
+                        if (failFast && currentBuild.result == 'UNSTABLE') {
+                            error 'There were test failures; halting early'
+                        }
+                        if (doArchiveArtifacts) {
+                            archiveArtifacts artifacts: '**/build/libs/*.hpi,**/build/libs/*.jpi', fingerprint: true
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    timestamps {
+        parallel(tasks)
+    }
+}

--- a/vars/buildPluginWithGradle.txt
+++ b/vars/buildPluginWithGradle.txt
@@ -1,0 +1,19 @@
+<p>
+    Builds a Jenkins plugin using Gradle.
+</p>
+<p>
+    The implementation follows the standard build/test/archive pattern. 
+    Note that the Gradle flow for Jenkins plugins offers less functionality than the Maven flow,
+    some key features are not supported: Incrementals - JEP-305, standard static analysis flows, etc.
+    The current version also does not allow configuring the <code>jenkinsVersion</code>.
+</p>
+
+<p>
+    <b>Usage.</b> The method can be used in the same way as <code>buildPlugin()</code> for Maven projects.
+    See the documentation in the README of the Pipeline Library repository.
+    Some parameters may not be supported at the moment, see the Pipeline code.
+</p>
+
+<!--
+vim: ft=html
+-->

--- a/vars/buildPluginWithGradle.txt
+++ b/vars/buildPluginWithGradle.txt
@@ -11,7 +11,6 @@
 <p>
     <b>Usage.</b> The method can be used in the same way as <code>buildPlugin()</code> for Maven projects.
     See the documentation in the README of the Pipeline Library repository.
-    Some parameters may not be supported at the moment, see the Pipeline code.
 </p>
 
 <!--


### PR DESCRIPTION
Follow-up on my proposal in #88 . It should give Jenkins Gradle flow users more freedom to add specific features without worrying about the impact on the Maven flow. Vice-versa, we can also extend Maven flows by adding Maven-only features without confusing gradle users.

- [x] Introduce a new  buildPluginWithGradle() step. Maven-only logic was removed from it
- [x] Deprecate Gradle support in `buildPlugin()`. We will be able to remove it once all Gradle plugins move to the new step
- [x] Document the changes
- [x] Some tests: https://github.com/jenkinsci/gradle-plugin/pull/76

CC @darxriggs @sghill 