### PR TITLE
Switch `infra.maybePublishIncrementals()` to use an Azure Container Instance agent

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -242,7 +242,7 @@ void ensureInNode(env, nodeLabels, body) {
 void maybePublishIncrementals() {
     if (isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
-            node('linux') {
+            node('maven') {
                 withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
                     sh '''
 curl -i -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://jenkins-incrementals.azurewebsites.net/api/incrementals-publisher?clientId=default&code=$FUNCTION_TOKEN" || echo 'Problem calling Incrementals deployment function'


### PR DESCRIPTION
To allow https://github.com/jenkinsci/jenkins/pull/4153#discussion_r314395511 to be reverted.

(Why `maven`? Well, because it has `curl` installed, and plain `alpine` does not.)

@oleg-nenashev @rtyler