### PR TITLE
Revert "`buildPlugin()` - Temporarily disable Windows builds and force ACI"

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -15,13 +15,7 @@ def call(Map params = [:]) {
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
     def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
-    //TODO: revert once https://groups.google.com/forum/#!topic/jenkinsci-dev/v9d-XosOp2s is fixed
     def useAci = params.containsKey('useAci') ? params.useAci : false
-    if (!useAci) {
-      echo "WARNING: Forcing Azure Container Instance, because standard agents are not stable at the moment. See INFRA-2210"
-      useAci = true
-    }
-    
     if(timeoutValue > 180) {
       echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
       timeoutValue = 180
@@ -37,14 +31,6 @@ def call(Map params = [:]) {
         String javaLevel = config.javaLevel
 
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
-        
-        //TODO: revert once https://groups.google.com/forum/#!topic/jenkinsci-dev/v9d-XosOp2s is fixed
-        if ("windows".equals(label)) {
-            echo "WARNING: Skipping ${stageIdentifier}, because Windows agents are not stable at the moment. See INFRA-2210"
-            return;
-        }
-        
-        
         boolean first = tasks.size() == 1
         boolean runFindbugs = first && params?.findbugs?.run
         boolean runCheckstyle = first && params?.checkstyle?.run


### PR DESCRIPTION
Reverts jenkins-infra/pipeline-library#106 since the INFRA is stabilized according to @olblak 
See https://groups.google.com/forum/#!topic/jenkinsci-dev/v9d-XosOp2s

CC @timja 



