### PR TITLE
Support Windows agents in the `buildPlugin()` Docker prune logic

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -174,7 +174,11 @@ def call(Map params = [:]) {
                     deleteDir()
 
                     if (hasDockerLabel()) {
-                        sh 'docker system prune --force --all || echo "Failed to cleanup docker images"'
+                        if(isUnix()) {
+                            sh 'docker system prune --force --all || echo "Failed to cleanup docker images"'
+                        } else {
+                            bat 'docker system prune --force --all || echo "Failed to cleanup docker images"'
+                        }
                     }
                 }
             }


### PR DESCRIPTION
We may have Windows docker agents in the future, prepare now for this possibility.