### PR TITLE
Add forceAci parameter to `buildPlugin()`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,6 +24,7 @@ buildPlugin()
 
 * `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
 * `useAci` (default: `false`) - uses link:https://azure.microsoft.com/en-us/services/container-instances/[Azure Container Instances] for build instead of link:https://azure.microsoft.com/en-us/services/virtual-machines/[Azure Virtual Machines].
+* `forceAci` (default: `false`) - forces usage of ACI (see `useAci` above) even on platforms that are not enabled when `useAci` is set to `true` (Windows).
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -16,6 +16,7 @@ def call(Map params = [:]) {
     def failFast = params.containsKey('failFast') ? params.failFast : true
     def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
     def useAci = params.containsKey('useAci') ? params.useAci : false
+    def forceAci = params.containsKey('forceAci') ? params.forceAci : false
     if(timeoutValue > 180) {
       echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
       timeoutValue = 180
@@ -37,10 +38,17 @@ def call(Map params = [:]) {
         boolean archiveFindbugs = first && params?.findbugs?.archive
         boolean archiveCheckstyle = first && params?.checkstyle?.archive
         boolean skipTests = params?.tests?.skip
-        boolean addToolEnv = !(useAci && label == 'linux')
+        boolean addToolEnv = !((useAci && label == 'linux') || forceAci)
+        if((useAci && label == 'linux') || forceAci) {
+            if(label == 'windows') {
+                label = jdk == '8' ? 'maven' : 'maven-11'
+            } else {
+                label = jdk == '8' ? 'maven-windows' : 'maven-11-windows'
+            }            
+        }
 
         tasks[stageIdentifier] = {
-            node((useAci && label == 'linux') ? (jdk == '8' ? 'maven' : 'maven-11') : label) {
+            node(label) {
                 try {
                     timeout(timeoutValue) {
                         boolean isMaven

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -39,7 +39,7 @@ def call(Map params = [:]) {
         boolean archiveCheckstyle = first && params?.checkstyle?.archive
         boolean skipTests = params?.tests?.skip
         boolean reallyUseAci = (useAci && label == 'linux') || forceAci
-        boolean addToolEnv = !reallyuseAci
+        boolean addToolEnv = !reallyUseAci
         
         if(reallyUseAci) {
             String aciLabel = jdk == '8' ? 'maven' : 'maven-11'

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -38,13 +38,15 @@ def call(Map params = [:]) {
         boolean archiveFindbugs = first && params?.findbugs?.archive
         boolean archiveCheckstyle = first && params?.checkstyle?.archive
         boolean skipTests = params?.tests?.skip
-        boolean addToolEnv = !((useAci && label == 'linux') || forceAci)
-        if((useAci && label == 'linux') || forceAci) {
+        boolean reallyUseAci = (useAci && label == 'linux') || forceAci
+        boolean addToolEnv = !reallyuseAci
+        
+        if(reallyUseAci) {
+            String aciLabel = jdk == '8' ? 'maven' : 'maven-11'
             if(label == 'windows') {
-                label = jdk == '8' ? 'maven' : 'maven-11'
-            } else {
-                label = jdk == '8' ? 'maven-windows' : 'maven-11-windows'
-            }            
+                aciLabel += "-windows"
+            }
+            label = aciLabel
         }
 
         tasks[stageIdentifier] = {


### PR DESCRIPTION
Adds a forceAci parameter to allow testing on Windows ACI agents. Setting forceAci to true will override the label check for `== 'linux'`