### PR TITLE
[INFRA-2243] - JUnit archiver was taking a non-existent property in `buildPluginWithGradle()`

### DIFF
--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -63,7 +63,7 @@ def call(Map params = [:]) {
                     }
 
                     stage("Archive (${stageIdentifier})") {
-                        junit testReports '**/build/test-results/**/*.xml'
+                        junit '**/build/test-results/**/*.xml'
                         
                         //TODO(oleg-nenashev): Add static analysis results publishing like in buildPlugin() for Maven 
                         


### PR DESCRIPTION
My mistake during the last rounds of refactoring