### PR TITLE
feat: archive tests even when the build failed

### DIFF
--- a/src/test/groovy/BuildPluginStepTests.groovy
+++ b/src/test/groovy/BuildPluginStepTests.groovy
@@ -188,6 +188,12 @@ class BuildPluginStepTests extends BasePipelineTest {
     }.any { call ->
       callArgsToString(call).contains('windows')
     })
+    // then the archive stage happens
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'stage'
+    }.any { call ->
+      callArgsToString(call).contains('Archive')
+    })
     // then it runs the junit step by default
     assertTrue(helper.callStack.any { call ->
       call.methodName == 'junit'
@@ -302,5 +308,26 @@ class BuildPluginStepTests extends BasePipelineTest {
     }.any { call ->
       callArgsToString(call).contains('**/*-rc*.*/*-rc*.*')
     })
+  }
+
+  @Test
+  void test_buildPlugin_with_build_error_should_run_the_archive_stage() throws Exception {
+    def script = loadScript(scriptName)
+    binding.setProperty('infra', new Infra(false, true))
+    try {
+      script.call(tests: [skip: false])
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    // then the archive stage happens
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'stage'
+    }.any { call ->
+      callArgsToString(call).contains('Archive')
+    })
+    // and the junit step is enabled
+    assertTrue(helper.callStack.any { call -> call.methodName == 'stage' })
+    assertJobStatusFailure()
   }
 }

--- a/src/test/groovy/mock/Infra.groovy
+++ b/src/test/groovy/mock/Infra.groovy
@@ -5,17 +5,27 @@ package mock
  */
 class Infra implements Serializable {
 
-  private final boolean result
-  public Infra(boolean result) { this.result = result }
-  public Infra() { this.result = false }
+  private final boolean trusted
+  private final boolean error
+  public Infra(boolean trusted) { this(trusted, false) }
+  public Infra() { this(false) }
+  public Infra(boolean trusted, boolean error) {
+    this.trusted = trusted
+    this.error = error
+  }
   public void checkout() { }
   public void checkout(repo) { }
   public String retrieveMavenSettingsFile(String location) { return location }
   public String runWithMaven(String cmd) { return cmd }
   public String runMaven(mvn) { return mvn }
   public String runMaven(mvn, jdk, foo, settings) { return 'OK' }
-  public String runMaven(mvn, jdk, foo, settings, toolEnv) { return mvn }
+  public String runMaven(mvn, jdk, foo, settings, toolEnv) {
+    if (this.error) {
+      throw new Exception('There was a build error')
+    }
+    return mvn
+  }
   public String runWithJava(command, jdk, foo, toolEnv) { return command }
-  public boolean isTrusted() { return result }
+  public boolean isTrusted() { return this.trusted }
   public void maybePublishIncrementals() { }
 }


### PR DESCRIPTION
## Highlights
- I've found the JUnit step doesn't happen when there is a build error.
- The `Archive` stage has been moved within the finally block as suggested in https://github.com/jenkins-infra/pipeline-library/blob/478d9a971e23d8ec5ca57019cd3f478f42b6968e/vars/buildPlugin.groovy#L137
- Add UTs to validate whether a build failure triggers the `Archive` stage.
