### PR TITLE
Enable ACI for Linux by default

### DIFF
--- a/src/test/groovy/BuildPluginStepTests.groovy
+++ b/src/test/groovy/BuildPluginStepTests.groovy
@@ -181,7 +181,7 @@ class BuildPluginStepTests extends BasePipelineTest {
       call.methodName == 'node'
     }.any { call ->
       def args = callArgsToString(call)
-      args.contains('linux') || args.contains('jdk')
+      args.contains('linux') || args.contains('maven')
     })
     // then it runs in a windows node
     assertTrue(helper.callStack.findAll { call ->

--- a/src/test/groovy/BuildPluginStepTests.groovy
+++ b/src/test/groovy/BuildPluginStepTests.groovy
@@ -180,7 +180,8 @@ class BuildPluginStepTests extends BasePipelineTest {
     assertTrue(helper.callStack.findAll { call ->
       call.methodName == 'node'
     }.any { call ->
-      callArgsToString(call).contains('linux')
+      def args = callArgsToString(call)
+      args.contains('linux') || args.contains('jdk')
     })
     // then it runs in a windows node
     assertTrue(helper.callStack.findAll { call ->

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -15,7 +15,7 @@ def call(Map params = [:]) {
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
     def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
-    def useAci = params.containsKey('useAci') ? params.useAci : false
+    def useAci = params.containsKey('useAci') ? params.useAci : true
     def forceAci = params.containsKey('forceAci') ? params.forceAci : false
     if(timeoutValue > 180) {
       echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"


### PR DESCRIPTION
This enables using ACI agents for Linux by default, there is still the ability to opt out by setting `useAci: false` in the call to `buildPlugin`