### PR TITLE
Stop trying to deleteDir in buildPlugin

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -182,8 +182,6 @@ def call(Map params = [:]) {
                         }
                     }            
                 } finally {
-                    deleteDir()
-
                     if (hasDockerLabel()) {
                         if(isUnix()) {
                             sh 'docker system prune --force --all || echo "Failed to cleanup docker images"'


### PR DESCRIPTION
See https://github.com/jenkins-infra/pipeline-library/pull/99#discussion_r313400182 by @timja. Seems to cause [errors](https://ci.jenkins.io/job/Plugins/job/pam-auth-plugin/job/PR-12/2/console) such as

```
java.nio.file.FileSystemException: C:\Jenkins\workspace\Plugins_pam-auth-plugin_PR-12\.git\objects\pack\pack-5e6e1b080765685b35cce003cf48670eaea3a58e.pack: The process cannot access the file because it is being used by another process.
```

Since I do not see a compelling reason to delete the workspace after a build—pointless on a one-off agent, possibly harmful to performance on a reused agent—and it can apparently fail, better to just revert this aspect.