### PR TITLE
Try and debug Windows file locking

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -192,7 +192,7 @@ Add-Type -Assembly System.IO.Compression.FileSystem
 $zip = [System.IO.Compression.ZipFile]::OpenRead([System.IO.Path]::Combine($PSScriptRoot, "Handle.zip"))
 $zip.Entries | ForEach-Object { [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, [System.IO.Path]::Combine($PSScriptRoot, $_.FullName), $true)}
 $zip.Dispose()
-& (Join-Path $PSScriptRoot "handle.exe") -accepteula -u "$env:WORKSPACE/.git"
+& (Join-Path $PSScriptRoot "handle64.exe") -accepteula -u "$env:WORKSPACE/.git"
 '''                             
                         }
                     }


### PR DESCRIPTION
Currently, there are issues with deleteDir() on ci.j.io which is causing builds to fail. In the case that deleteDir() fails, we download handle.exe and run it on the .git directory to see what has the directory open. This is mainly a debug step to determine what is going on.