### PR TITLE
Speed up deploy

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -40,7 +40,7 @@ def call(Map params = [:]) {
         boolean skipTests = params?.tests?.skip
         boolean reallyUseAci = (useAci && label == 'linux') || forceAci
         boolean addToolEnv = !reallyUseAci
-        
+
         if(reallyUseAci) {
             String aciLabel = jdk == '8' ? 'maven' : 'maven-11'
             if(label == 'windows') {
@@ -180,7 +180,10 @@ def call(Map params = [:]) {
                                 }
                             }
                         }
-                    }            
+                        if (publishingIncrementals) {
+                            infra.maybePublishIncrementals()
+                        }
+                    }
                 } finally {
                     deleteDir()
 
@@ -197,9 +200,6 @@ def call(Map params = [:]) {
     }
 
     parallel(tasks)
-    if (publishingIncrementals) {
-        infra.maybePublishIncrementals()
-    }
 }
 
 boolean hasDockerLabel() {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -259,12 +259,10 @@ void prepareToPublishIncrementals() {
 void maybePublishIncrementals() {
     if (isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
-            node('maven') {
-                withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
-                    sh '''
+            withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
+                sh '''
 curl -i -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://jenkins-incrementals.azurewebsites.net/api/incrementals-publisher?clientId=default&code=$FUNCTION_TOKEN" || echo 'Problem calling Incrementals deployment function'
-                    '''
-                }
+                '''
             }
         }
     } else {


### PR DESCRIPTION
This maybe fail on Windows agent but 🤷‍♂

Why do we have to wait for incremental for plus 50 minutes?

![image](https://user-images.githubusercontent.com/1661688/66436385-36787980-ea27-11e9-8c4b-abad0be6fca5.png)

Perhaps using something like https://github.com/jenkinsci/http-request-plugin or some better alternative?

Just for reference the build took 5 minutes, however been waiting for deploy for 1 hour and 20 minutes.

```
23:07:44  Pull request #57 updated
21:07:44 [2019-10-08T21:07:44.178Z] Connecting to https://api.github.com using jenkinsadmin/****** (GitHub access token for jenkinsadmin)
23:07:44  Connecting to https://api.github.com to check permissions of obtain list of casz for jenkinsci/hashicorp-vault-plugin
23:07:45  Obtained Jenkinsfile from b8e767fa3e9ef07170697919036aa204bfb6f167+d06a570038e145d5bc335bfe594a997958430530 (bb531da180ff4ae68b091dddb0549cab459e1d1f)
23:07:45  Running in Durability level: PERFORMANCE_OPTIMIZED
23:07:45  Loading library pipeline-library@master
23:07:45  Attempting to resolve master from remote references...
23:07:45  Found match: refs/heads/master revision 478d9a971e23d8ec5ca57019cd3f478f42b6968e
23:07:45  No credentials specified
23:07:45  Fetching changes from the remote Git repository
23:07:45  Fetching without tags
23:07:45  Checking out Revision 478d9a971e23d8ec5ca57019cd3f478f42b6968e (master)
23:07:45  Commit message: "Merge pull request #112 from jenkins-infra/INFRA-2243-fix"
23:07:45  [Pipeline] Start of Pipeline
23:07:46  [Pipeline] properties
23:07:46  [Pipeline] parallel
23:07:46  [Pipeline] { (Branch: linux-8)
23:07:46  [Pipeline] { (Branch: linux-8-2.164.1)
23:07:46  [Pipeline] { (Branch: linux-11-2.164.1)
23:07:46  [Pipeline] node
23:07:46  [Pipeline] node
23:07:46  [Pipeline] node
23:07:46  Running on ubuntu-jenkinsinfra493cb0 in /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57
23:07:46  [Pipeline] {
23:07:46  Running on ubuntu-jenkinsinfra921110 in /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57
23:07:46  [Pipeline] {
23:07:46  [Pipeline] timeout
23:07:46  Timeout set to expire in 1 hr 0 min
23:07:46  [Pipeline] {
23:07:46  [Pipeline] timeout
23:07:46  Timeout set to expire in 1 hr 0 min
23:07:46  [Pipeline] {
23:07:46  [Pipeline] stage
23:07:46  [Pipeline] { (Checkout (linux-8))
23:07:46  [Pipeline] stage
23:07:46  [Pipeline] { (Checkout (linux-8-2.164.1))
23:07:46  Running on ubuntu-jenkinsinfra47c890 in /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57
23:07:46  [Pipeline] checkout
23:07:46  [Pipeline] checkout
23:07:46  [Pipeline] {
23:07:46  [Pipeline] timeout
23:07:46  Timeout set to expire in 1 hr 0 min
23:07:46  [Pipeline] {
23:07:46  [Pipeline] stage
23:07:46  [Pipeline] { (Checkout (linux-11-2.164.1))
23:07:46  using credential github-access-token
23:07:46  [Pipeline] checkout
23:07:46  using credential github-access-token
23:07:46  using credential github-access-token
23:07:46  Cloning the remote Git repository
23:07:46  Cloning with configured refspecs honoured and without tags
23:07:46  Cloning the remote Git repository
23:07:46  Cloning with configured refspecs honoured and without tags
23:07:46  Cloning the remote Git repository
23:07:46  Cloning with configured refspecs honoured and without tags
23:07:46  Fetching without tags
23:07:46  Merging remotes/origin/master commit d06a570038e145d5bc335bfe594a997958430530 into PR head commit b8e767fa3e9ef07170697919036aa204bfb6f167
23:07:46  Fetching without tags
23:07:46  Merge succeeded, producing b8e767fa3e9ef07170697919036aa204bfb6f167
23:07:46  Checking out Revision b8e767fa3e9ef07170697919036aa204bfb6f167 (PR-57)
23:07:46  Merging remotes/origin/master commit d06a570038e145d5bc335bfe594a997958430530 into PR head commit b8e767fa3e9ef07170697919036aa204bfb6f167
23:07:46  Fetching without tags
23:07:46  Commit message: "fix assertion"
23:07:46  Merging remotes/origin/master commit d06a570038e145d5bc335bfe594a997958430530 into PR head commit b8e767fa3e9ef07170697919036aa204bfb6f167
23:07:46  Merge succeeded, producing b8e767fa3e9ef07170697919036aa204bfb6f167
23:07:46  Checking out Revision b8e767fa3e9ef07170697919036aa204bfb6f167 (PR-57)
23:07:47  Commit message: "fix assertion"
23:07:47  Merge succeeded, producing b8e767fa3e9ef07170697919036aa204bfb6f167
23:07:47  Checking out Revision b8e767fa3e9ef07170697919036aa204bfb6f167 (PR-57)
23:07:47  Commit message: "fix assertion"
23:07:46  remote: Enumerating objects
23:07:46  remote: Counting objects
23:07:46  remote: Compressing objects
23:07:46  Receiving objects
23:07:46  Resolving deltas
23:07:46  Updating references
23:07:46  remote: Enumerating objects
23:07:46  remote: Counting objects
23:07:46  remote: Compressing objects
23:07:46  Receiving objects
23:07:46  Resolving deltas
23:07:46  Updating references
23:07:46  remote: Enumerating objects
23:07:46  remote: Counting objects
23:07:46  remote: Compressing objects
23:07:46  Receiving objects
23:07:46  Resolving deltas
23:07:46  Updating references
23:07:47  [Pipeline] fileExists
23:07:47  [Pipeline] fileExists
23:07:47  [Pipeline] readFile
23:07:47  [Pipeline] }
23:07:47  [Pipeline] // stage
23:07:47  [Pipeline] stage
23:07:47  [Pipeline] { (Build (linux-8-2.164.1))
23:07:47  [Pipeline] pwd
23:07:47  [Pipeline] pwd
23:07:47  [Pipeline] fileExists
23:07:47  [Pipeline] libraryResource
23:07:47  [Pipeline] writeFile
23:07:47  [Pipeline] fileExists
23:07:47  [Pipeline] tool
23:07:47  [Pipeline] readFile
23:07:47  [Pipeline] }
23:07:47  [Pipeline] tool
23:07:47  [Pipeline] // stage
23:07:47  [Pipeline] stage
23:07:47  [Pipeline] { (Build (linux-8))
23:07:47  [Pipeline] withEnv
23:07:47  [Pipeline] {
23:07:47  [Pipeline] pwd
23:07:47  [Pipeline] pwd
23:07:47  [Pipeline] pwd
23:07:47  [Pipeline] isUnix
23:07:47  [Pipeline] sh
23:07:47  [Pipeline] libraryResource
23:07:47  [Pipeline] writeFile
23:07:47  [Pipeline] tool
23:07:47  [Pipeline] tool
23:07:47  [Pipeline] withEnv
23:07:47  [Pipeline] {
23:07:47  [Pipeline] isUnix
23:07:47  [Pipeline] sh
23:07:47  [Pipeline] fileExists
23:07:47  [Pipeline] fileExists
23:07:47  [Pipeline] readFile
23:07:47  [Pipeline] }
23:07:47  [Pipeline] // stage
23:07:47  [Pipeline] stage
23:07:47  [Pipeline] { (Build (linux-11-2.164.1))
23:07:47  [Pipeline] pwd
23:07:47  [Pipeline] pwd
23:07:47  [Pipeline] libraryResource
23:07:47  [Pipeline] writeFile
23:07:47  [Pipeline] tool
23:07:47  [Pipeline] tool
23:07:47  + mvn --batch-mode --show-version --errors -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -s /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/settings-azure.xml --update-snapshots -Dmaven.repo.local=/home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo -Dmaven.test.failure.ignore -Dset.changelist -Djenkins.version=2.164.1 -Daccess-modifier-checker.failOnError=false -Djava.level=8 -Dfindbugs.failOnError=false clean install
23:07:47  Apache Maven 3.5.4 (1edded0938998edf8bf061f1ceb3cfdeccf443fe; 2018-06-17T18:33:14Z)
23:07:47  Maven home: /home/jenkins/tools/hudson.tasks.Maven_MavenInstallation/mvn
23:07:47  Java version: 1.8.0_162, vendor: Oracle Corporation, runtime: /home/jenkins/tools/hudson.model.JDK/jdk8/jre
23:07:47  Default locale: en, platform encoding: UTF-8
23:07:47  OS name: "linux", version: "5.0.0-1018-azure", arch: "amd64", family: "unix"
23:07:47  + mvn --batch-mode --show-version --errors -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -s /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/settings-azure.xml --update-snapshots -Dmaven.repo.local=/home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo -Dmaven.test.failure.ignore -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=/home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/changelist -Dfindbugs.failOnError=false clean install
23:07:47  Apache Maven 3.5.4 (1edded0938998edf8bf061f1ceb3cfdeccf443fe; 2018-06-17T18:33:14Z)
23:07:47  Maven home: /home/jenkins/tools/hudson.tasks.Maven_MavenInstallation/mvn
23:07:47  Java version: 1.8.0_162, vendor: Oracle Corporation, runtime: /home/jenkins/tools/hudson.model.JDK/jdk8/jre
23:07:47  Default locale: en, platform encoding: UTF-8
23:07:47  OS name: "linux", version: "5.0.0-1018-azure", arch: "amd64", family: "unix"
23:07:47  Unpacking https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.3_7.tar.gz to /home/jenkins/tools/hudson.model.JDK/jdk11 on ubuntu-jenkinsinfra47c890
23:07:49  [INFO] Error stacktraces are turned on.
23:07:50  [INFO] Setting: -Dchangelist=-rc263.b8e767fa3e9e -DscmTag=b8e767fa3e9ef07170697919036aa204bfb6f167
23:07:50  [INFO] Scanning for projects...
23:07:50  [INFO] Error stacktraces are turned on.
23:07:50  [INFO] Setting: -Dchangelist=-rc263.b8e767fa3e9e -DscmTag=b8e767fa3e9ef07170697919036aa204bfb6f167
23:07:50  [INFO] Scanning for projects...
23:07:51  [INFO] 
23:07:51  [INFO] --------< com.datapipe.jenkins.plugins:hashicorp-vault-plugin >---------
23:07:51  [INFO] Building HashiCorp Vault Plugin 2.5.1-rc263.b8e767fa3e9e
23:07:51  [INFO] --------------------------------[ hpi ]---------------------------------
23:07:52  [INFO] 
23:07:52  [INFO] --------< com.datapipe.jenkins.plugins:hashicorp-vault-plugin >---------
23:07:52  [INFO] Building HashiCorp Vault Plugin 2.5.1-rc263.b8e767fa3e9e
23:07:52  [INFO] --------------------------------[ hpi ]---------------------------------
23:07:52  [INFO] 
23:07:52  [INFO] --- maven-help-plugin:3.2.0:evaluate (default-cli) @ hashicorp-vault-plugin ---
23:07:53  [INFO] No artifact parameter specified, using 'com.datapipe.jenkins.plugins:hashicorp-vault-plugin:hpi:2.5.1-rc263.b8e767fa3e9e' as project.
23:07:53  [INFO] Result of evaluation written to: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/changelist
23:07:53  [INFO] 
23:07:53  [INFO] --------< com.datapipe.jenkins.plugins:hashicorp-vault-plugin >---------
23:07:53  [INFO] Building HashiCorp Vault Plugin 2.5.1-rc263.b8e767fa3e9e
23:07:53  [INFO] --------------------------------[ hpi ]---------------------------------
23:07:53  [INFO] 
23:07:53  [INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ hashicorp-vault-plugin ---
23:07:53  [INFO] 
23:07:53  [INFO] --- maven-hpi-plugin:3.6:validate (default-validate) @ hashicorp-vault-plugin ---
23:07:53  [INFO] 
23:07:53  [INFO] --- maven-enforcer-plugin:3.0.0-M2:display-info (display-info) @ hashicorp-vault-plugin ---
23:07:53  [INFO] Maven Version: 3.5.4
23:07:53  [INFO] JDK Version: 1.8.0_162 normalized as: 1.8.0-162
23:07:53  [INFO] OS Info: Arch: amd64 Family: unix Name: linux Version: 5.0.0-1018-azure
23:07:53  [INFO] 
23:07:53  [INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (display-info) @ hashicorp-vault-plugin ---
23:07:53  [INFO] 
23:07:53  [INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ hashicorp-vault-plugin ---
23:07:53  [INFO] 
23:07:53  [INFO] --- maven-hpi-plugin:3.6:validate (default-validate) @ hashicorp-vault-plugin ---
23:07:53  [INFO] 
23:07:53  [INFO] --- maven-enforcer-plugin:3.0.0-M2:display-info (display-info) @ hashicorp-vault-plugin ---
23:07:53  [INFO] artifact junit:junit-dep: checking for updates from azure-incrementals
23:07:53  [INFO] Maven Version: 3.5.4
23:07:53  [INFO] JDK Version: 1.8.0_162 normalized as: 1.8.0-162
23:07:53  [INFO] OS Info: Arch: amd64 Family: unix Name: linux Version: 5.0.0-1018-azure
23:07:53  [INFO] 
23:07:53  [INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (display-info) @ hashicorp-vault-plugin ---
23:07:54  [INFO] artifact junit:junit-dep: checking for updates from azure
23:07:54  [INFO] artifact junit:junit-dep: checking for updates from central
23:07:54  [INFO] artifact junit:junit: checking for updates from azure-incrementals
23:07:54  [INFO] artifact junit:junit: checking for updates from azure
23:07:54  [INFO] artifact junit:junit-dep: checking for updates from azure-incrementals
23:07:54  [INFO] artifact junit:junit-dep: checking for updates from azure
23:07:54  [INFO] artifact junit:junit: checking for updates from central
23:07:54  [INFO] artifact junit:junit-dep: checking for updates from central
23:07:54  [INFO] artifact junit:junit: checking for updates from azure-incrementals
23:07:54  [INFO] artifact junit:junit: checking for updates from azure
23:07:54  [Pipeline] withEnv
23:07:54  [Pipeline] {
23:07:54  [Pipeline] isUnix
23:07:54  [Pipeline] sh
23:07:54  [INFO] artifact junit:junit: checking for updates from central
23:07:54  + mvn --batch-mode --show-version --errors -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -s /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/settings-azure.xml --update-snapshots -Dmaven.repo.local=/home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo -Dmaven.test.failure.ignore -Dset.changelist -Djenkins.version=2.164.1 -Daccess-modifier-checker.failOnError=false -Djava.level=8 -Dfindbugs.failOnError=false clean install
23:07:55  Apache Maven 3.5.4 (1edded0938998edf8bf061f1ceb3cfdeccf443fe; 2018-06-17T18:33:14Z)
23:07:55  Maven home: /home/jenkins/tools/hudson.tasks.Maven_MavenInstallation/mvn
23:07:55  Java version: 11.0.3, vendor: AdoptOpenJDK, runtime: /home/jenkins/tools/hudson.model.JDK/jdk11/jdk-11.0.3+7
23:07:55  Default locale: en, platform encoding: UTF-8
23:07:55  OS name: "linux", version: "5.0.0-1018-azure", arch: "amd64", family: "unix"
23:07:55  [INFO] Adding ignore: module-info
23:07:55  [INFO] artifact junit:junit-dep: checking for updates from azure-incrementals
23:07:55  [INFO] artifact junit:junit-dep: checking for updates from azure
23:07:56  [INFO] artifact junit:junit-dep: checking for updates from central
23:07:56  [INFO] artifact junit:junit: checking for updates from azure-incrementals
23:07:56  [INFO] artifact junit:junit: checking for updates from azure
23:07:56  [INFO] artifact junit:junit: checking for updates from central
23:07:56  [INFO] Adding ignore: module-info
23:07:56  [INFO] Ignoring requireUpperBoundDeps in net.java.dev.jna:jna
23:07:56  [INFO] 
23:07:56  [INFO] --- maven-localizer-plugin:1.26:generate (default) @ hashicorp-vault-plugin ---
23:07:56  [INFO] 
23:07:56  [INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ hashicorp-vault-plugin ---
23:07:56  [INFO] Using 'UTF-8' encoding to copy filtered resources.
23:07:56  [INFO] Copying 27 resources
23:07:56  [INFO] 
23:07:56  [INFO] --- flatten-maven-plugin:1.1.0:flatten (flatten) @ hashicorp-vault-plugin ---
23:07:56  [INFO] Generating flattened POM of project com.datapipe.jenkins.plugins:hashicorp-vault-plugin:hpi:2.5.1-rc263.b8e767fa3e9e...
23:07:56  [INFO] 
23:07:56  [INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ hashicorp-vault-plugin ---
23:07:56  [INFO] Changes detected - recompiling the module!
23:07:56  [INFO] Compiling 29 source files to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/classes
23:07:57  [INFO] artifact junit:junit-dep: checking for updates from azure-incrementals
23:07:57  [INFO] artifact junit:junit-dep: checking for updates from azure
23:07:57  [INFO] artifact junit:junit-dep: checking for updates from central
23:07:57  [INFO] artifact junit:junit: checking for updates from azure-incrementals
23:07:57  [INFO] artifact junit:junit: checking for updates from azure
23:07:57  [INFO] artifact junit:junit: checking for updates from central
23:07:57  [INFO] Ignoring requireUpperBoundDeps in net.java.dev.jna:jna
23:07:57  [INFO] 
23:07:57  [INFO] --- maven-localizer-plugin:1.26:generate (default) @ hashicorp-vault-plugin ---
23:07:57  [INFO] 
23:07:57  [INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ hashicorp-vault-plugin ---
23:07:57  [INFO] Using 'UTF-8' encoding to copy filtered resources.
23:07:57  [INFO] Copying 27 resources
23:07:57  [INFO] 
23:07:57  [INFO] --- flatten-maven-plugin:1.1.0:flatten (flatten) @ hashicorp-vault-plugin ---
23:07:57  [INFO] Generating flattened POM of project com.datapipe.jenkins.plugins:hashicorp-vault-plugin:hpi:2.5.1-rc263.b8e767fa3e9e...
23:07:58  [INFO] 
23:07:58  [INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ hashicorp-vault-plugin ---
23:07:58  [INFO] Changes detected - recompiling the module!
23:07:58  [INFO] Compiling 29 source files to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/classes
23:07:58  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenFileCredential.java: Some input files use or override a deprecated API.
23:07:58  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenFileCredential.java: Recompile with -Xlint:deprecation for details.
23:07:58  [INFO] 
23:07:58  [INFO] --- access-modifier-checker:1.16:enforce (default-enforce) @ hashicorp-vault-plugin ---
23:07:58  [INFO] 
23:07:58  [INFO] --- animal-sniffer-maven-plugin:1.17:check (check) @ hashicorp-vault-plugin ---
23:07:58  [INFO] Resolved signature org.codehaus.mojo.signature:java18 version as 1.0 from dependencyManagement
23:07:58  [INFO] Checking unresolved references to org.codehaus.mojo.signature:java18:1.0
23:07:59  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java uses or overrides a deprecated API.
23:07:59  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java: Recompile with -Xlint:deprecation for details.
23:07:59  [INFO] 
23:07:59  [INFO] --- access-modifier-checker:1.16:enforce (default-enforce) @ hashicorp-vault-plugin ---
23:08:00  [INFO] 
23:08:00  [INFO] --- animal-sniffer-maven-plugin:1.17:check (check) @ hashicorp-vault-plugin ---
23:08:00  [INFO] Resolved signature org.codehaus.mojo.signature:java18 version as 1.0 from dependencyManagement
23:08:00  [INFO] Checking unresolved references to org.codehaus.mojo.signature:java18:1.0
23:08:00  [INFO] Error stacktraces are turned on.
23:08:00  [INFO] Setting: -Dchangelist=-rc263.b8e767fa3e9e -DscmTag=b8e767fa3e9ef07170697919036aa204bfb6f167
23:08:00  [INFO] Scanning for projects...
23:08:01  [INFO] 
23:08:01  [INFO] --- maven-hpi-plugin:3.6:insert-test (default-insert-test) @ hashicorp-vault-plugin ---
23:08:01  [INFO] 
23:08:01  [INFO] --- gmaven-plugin:1.5-jenkins-3:generateTestStubs (test-in-groovy) @ hashicorp-vault-plugin ---
23:08:01  [INFO] No sources found for Java stub generation
23:08:01  [INFO] 
23:08:01  [INFO] --- maven-antrun-plugin:1.3:run (createTempDir) @ hashicorp-vault-plugin ---
23:08:01  [INFO] Executing tasks
23:08:01      [mkdir] Created dir: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/tmp
23:08:01  [INFO] Executed tasks
23:08:01  [INFO] 
23:08:01  [INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ hashicorp-vault-plugin ---
23:08:01  [INFO] Using 'UTF-8' encoding to copy filtered resources.
23:08:01  [INFO] Copying 7 resources
23:08:01  [INFO] 
23:08:01  [INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ hashicorp-vault-plugin ---
23:08:01  [INFO] Changes detected - recompiling the module!
23:08:01  [INFO] Compiling 14 source files to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/test-classes
23:08:02  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java: Some input files use or override a deprecated API.
23:08:02  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java: Recompile with -Xlint:deprecation for details.
23:08:02  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfigurationSpec.java: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfigurationSpec.java uses unchecked or unsafe operations.
23:08:02  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfigurationSpec.java: Recompile with -Xlint:unchecked for details.
23:08:02  [INFO] 
23:08:02  [INFO] --- maven-hpi-plugin:3.6:test-hpl (default-test-hpl) @ hashicorp-vault-plugin ---
23:08:02  [INFO] Generating /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/test-classes/the.hpl
23:08:02  [INFO] 
23:08:02  [INFO] --- maven-hpi-plugin:3.6:insert-test (default-insert-test) @ hashicorp-vault-plugin ---
23:08:02  [INFO] 
23:08:02  [INFO] --- gmaven-plugin:1.5-jenkins-3:generateTestStubs (test-in-groovy) @ hashicorp-vault-plugin ---
23:08:02  [INFO] No sources found for Java stub generation
23:08:02  [INFO] 
23:08:02  [INFO] --- maven-antrun-plugin:1.3:run (createTempDir) @ hashicorp-vault-plugin ---
23:08:02  [INFO] Executing tasks
23:08:02      [mkdir] Created dir: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/tmp
23:08:02  [INFO] Executed tasks
23:08:02  [INFO] 
23:08:02  [INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ hashicorp-vault-plugin ---
23:08:02  [INFO] Using 'UTF-8' encoding to copy filtered resources.
23:08:02  [INFO] Copying 7 resources
23:08:02  [INFO] 
23:08:02  [INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ hashicorp-vault-plugin ---
23:08:02  [INFO] Changes detected - recompiling the module!
23:08:02  [INFO] Compiling 14 source files to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/test-classes
23:08:03  [INFO] 
23:08:03  [INFO] --- maven-hpi-plugin:3.6:resolve-test-dependencies (default-resolve-test-dependencies) @ hashicorp-vault-plugin ---
23:08:03  [INFO] 
23:08:03  [INFO] --- gmaven-plugin:1.5-jenkins-3:testCompile (test-in-groovy) @ hashicorp-vault-plugin ---
23:08:03  [INFO] No sources found to compile
23:08:03  [INFO] 
23:08:03  [INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ hashicorp-vault-plugin ---
23:08:04  [INFO] Surefire report directory: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/surefire-reports
23:08:04  [INFO] 
23:08:04  [INFO] -------------------------------------------------------
23:08:04  [INFO]  T E S T S
23:08:04  [INFO] -------------------------------------------------------
23:08:04  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java: Some input files use or override a deprecated API.
23:08:04  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java: Recompile with -Xlint:deprecation for details.
23:08:04  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfigurationSpec.java: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfigurationSpec.java uses unchecked or unsafe operations.
23:08:04  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfigurationSpec.java: Recompile with -Xlint:unchecked for details.
23:08:04  [INFO] 
23:08:04  [INFO] --- maven-hpi-plugin:3.6:test-hpl (default-test-hpl) @ hashicorp-vault-plugin ---
23:08:04  [INFO] Generating /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/test-classes/the.hpl
23:08:04  [INFO] Running InjectedTest
23:08:04  [INFO] 
23:08:04  [INFO] --- maven-hpi-plugin:3.6:resolve-test-dependencies (default-resolve-test-dependencies) @ hashicorp-vault-plugin ---
23:08:05  [INFO] 
23:08:05  [INFO] --- gmaven-plugin:1.5-jenkins-3:testCompile (test-in-groovy) @ hashicorp-vault-plugin ---
23:08:05  [INFO] No sources found to compile
23:08:05  [INFO] 
23:08:05  [INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ hashicorp-vault-plugin ---
23:08:05  [INFO] Surefire report directory: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/surefire-reports
23:08:05  [INFO] 
23:08:05  [INFO] -------------------------------------------------------
23:08:05  [INFO]  T E S T S
23:08:05  [INFO] -------------------------------------------------------
23:08:06  [INFO] Running InjectedTest
23:08:06  [INFO] 
23:08:06  [INFO] --------< com.datapipe.jenkins.plugins:hashicorp-vault-plugin >---------
23:08:06  [INFO] Building HashiCorp Vault Plugin 2.5.1-rc263.b8e767fa3e9e
23:08:06  [INFO] --------------------------------[ hpi ]---------------------------------
23:08:19  [INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 13.845 s - in InjectedTest
23:08:19  [INFO] Running com.datapipe.jenkins.vault.VaultBuildWrapperTest
23:08:19  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.909 s - in com.datapipe.jenkins.vault.VaultBuildWrapperTest
23:08:19  [INFO] Running com.datapipe.jenkins.vault.configuration.FolderVaultConfigurationSpec
23:08:20  [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.587 s - in com.datapipe.jenkins.vault.configuration.FolderVaultConfigurationSpec
23:08:20  [INFO] Running com.datapipe.jenkins.vault.configuration.VaultConfigurationSpec
23:08:20  [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in com.datapipe.jenkins.vault.configuration.VaultConfigurationSpec
23:08:20  [INFO] Running com.datapipe.jenkins.vault.it.VaultConfigurationIT
23:08:21  [INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.684 s - in InjectedTest
23:08:21  [INFO] Running com.datapipe.jenkins.vault.VaultBuildWrapperTest
23:08:21  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.953 s - in com.datapipe.jenkins.vault.VaultBuildWrapperTest
23:08:21  [INFO] Running com.datapipe.jenkins.vault.configuration.FolderVaultConfigurationSpec
23:08:21  [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.587 s - in com.datapipe.jenkins.vault.configuration.FolderVaultConfigurationSpec
23:08:21  [INFO] Running com.datapipe.jenkins.vault.configuration.VaultConfigurationSpec
23:08:21  [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.datapipe.jenkins.vault.configuration.VaultConfigurationSpec
23:08:21  [INFO] Running com.datapipe.jenkins.vault.it.VaultConfigurationIT
23:08:21  [INFO] 
23:08:21  [INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ hashicorp-vault-plugin ---
23:08:21  [INFO] 
23:08:21  [INFO] --- maven-hpi-plugin:3.6:validate (default-validate) @ hashicorp-vault-plugin ---
23:08:21  [INFO] 
23:08:21  [INFO] --- maven-enforcer-plugin:3.0.0-M2:display-info (display-info) @ hashicorp-vault-plugin ---
23:08:22  [INFO] Maven Version: 3.5.4
23:08:22  [INFO] JDK Version: 11.0.3 normalized as: 11.0.3
23:08:22  [INFO] OS Info: Arch: amd64 Family: unix Name: linux Version: 5.0.0-1018-azure
23:08:22  [INFO] 
23:08:22  [INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (display-info) @ hashicorp-vault-plugin ---
23:08:22  [INFO] artifact junit:junit-dep: checking for updates from azure-incrementals
23:08:22  [INFO] artifact junit:junit-dep: checking for updates from azure
23:08:27  [INFO] artifact junit:junit-dep: checking for updates from central
23:08:29  [INFO] artifact junit:junit: checking for updates from azure-incrementals
23:08:29  [INFO] artifact junit:junit: checking for updates from azure
23:08:29  [INFO] artifact junit:junit: checking for updates from central
23:08:30  [INFO] Adding ignore: module-info
23:08:31  [INFO] artifact junit:junit-dep: checking for updates from azure-incrementals
23:08:31  [INFO] artifact junit:junit-dep: checking for updates from azure
23:08:31  [INFO] artifact junit:junit-dep: checking for updates from central
23:08:31  [INFO] artifact junit:junit: checking for updates from azure-incrementals
23:08:31  [INFO] artifact junit:junit: checking for updates from azure
23:08:31  [INFO] artifact junit:junit: checking for updates from central
23:08:31  [INFO] Ignoring requireUpperBoundDeps in net.java.dev.jna:jna
23:08:31  [INFO] 
23:08:31  [INFO] --- maven-localizer-plugin:1.26:generate (default) @ hashicorp-vault-plugin ---
23:08:32  [INFO] 
23:08:32  [INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ hashicorp-vault-plugin ---
23:08:32  [INFO] Using 'UTF-8' encoding to copy filtered resources.
23:08:32  [INFO] Copying 27 resources
23:08:32  [INFO] 
23:08:32  [INFO] --- flatten-maven-plugin:1.1.0:flatten (flatten) @ hashicorp-vault-plugin ---
23:08:32  [INFO] Generating flattened POM of project com.datapipe.jenkins.plugins:hashicorp-vault-plugin:hpi:2.5.1-rc263.b8e767fa3e9e...
23:08:32  [INFO] 
23:08:32  [INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ hashicorp-vault-plugin ---
23:08:33  [INFO] Changes detected - recompiling the module!
23:08:33  [INFO] Compiling 29 source files to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/classes
23:08:35  [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.351 s - in com.datapipe.jenkins.vault.it.VaultConfigurationIT
23:08:35  [INFO] Running com.datapipe.jenkins.vault.it.VaultTokenCredentialBindingIT
23:08:35  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenFileCredential.java: Some input files use or override a deprecated API.
23:08:35  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenFileCredential.java: Recompile with -Xlint:deprecation for details.
23:08:35  [INFO] 
23:08:35  [INFO] --- access-modifier-checker:1.16:enforce (default-enforce) @ hashicorp-vault-plugin ---
23:08:36  [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 13.049 s - in com.datapipe.jenkins.vault.it.VaultConfigurationIT
23:08:36  [INFO] Running com.datapipe.jenkins.vault.it.VaultTokenCredentialBindingIT
23:08:36  [INFO] 
23:08:36  [INFO] --- animal-sniffer-maven-plugin:1.17:check (check) @ hashicorp-vault-plugin ---
23:08:36  [INFO] Resolved signature org.codehaus.mojo.signature:java18 version as 1.0 from dependencyManagement
23:08:36  [INFO] Checking unresolved references to org.codehaus.mojo.signature:java18:1.0
23:08:39  [INFO] 
23:08:39  [INFO] --- maven-hpi-plugin:3.6:insert-test (default-insert-test) @ hashicorp-vault-plugin ---
23:08:39  [INFO] 
23:08:39  [INFO] --- gmaven-plugin:1.5-jenkins-3:generateTestStubs (test-in-groovy) @ hashicorp-vault-plugin ---
23:08:39  [INFO] No sources found for Java stub generation
23:08:39  [INFO] 
23:08:39  [INFO] --- maven-antrun-plugin:1.3:run (createTempDir) @ hashicorp-vault-plugin ---
23:08:39  [INFO] Executing tasks
23:08:40      [mkdir] Created dir: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/tmp
23:08:40  [INFO] Executed tasks
23:08:40  [INFO] 
23:08:40  [INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ hashicorp-vault-plugin ---
23:08:40  [INFO] Using 'UTF-8' encoding to copy filtered resources.
23:08:40  [INFO] Copying 7 resources
23:08:40  [INFO] 
23:08:40  [INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ hashicorp-vault-plugin ---
23:08:40  [INFO] Changes detected - recompiling the module!
23:08:40  [INFO] Compiling 14 source files to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/test-classes
23:08:41  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java: Some input files use or override a deprecated API.
23:08:41  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java: Recompile with -Xlint:deprecation for details.
23:08:41  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfigurationSpec.java: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfigurationSpec.java uses unchecked or unsafe operations.
23:08:41  [INFO] /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/src/test/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfigurationSpec.java: Recompile with -Xlint:unchecked for details.
23:08:41  [INFO] 
23:08:41  [INFO] --- maven-hpi-plugin:3.6:test-hpl (default-test-hpl) @ hashicorp-vault-plugin ---
23:08:41  [INFO] Generating /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/test-classes/the.hpl
23:08:42  [INFO] 
23:08:42  [INFO] --- maven-hpi-plugin:3.6:resolve-test-dependencies (default-resolve-test-dependencies) @ hashicorp-vault-plugin ---
23:08:45  [INFO] 
23:08:45  [INFO] --- gmaven-plugin:1.5-jenkins-3:testCompile (test-in-groovy) @ hashicorp-vault-plugin ---
23:08:45  [INFO] No sources found to compile
23:08:45  [INFO] 
23:08:45  [INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ hashicorp-vault-plugin ---
23:08:45  [INFO] Surefire report directory: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/surefire-reports
23:08:45  [INFO] 
23:08:45  [INFO] -------------------------------------------------------
23:08:45  [INFO]  T E S T S
23:08:45  [INFO] -------------------------------------------------------
23:08:46  [INFO] Running InjectedTest
23:08:51  [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.018 s - in com.datapipe.jenkins.vault.it.VaultTokenCredentialBindingIT
23:08:51  [INFO] Running com.datapipe.jenkins.vault.it.VaultUsernamePasswordCredentialIT
23:08:53  [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.63 s - in com.datapipe.jenkins.vault.it.VaultTokenCredentialBindingIT
23:08:53  [INFO] Running com.datapipe.jenkins.vault.it.VaultUsernamePasswordCredentialIT
23:08:58  [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.504 s - in com.datapipe.jenkins.vault.it.VaultUsernamePasswordCredentialIT
23:08:58  [INFO] Running com.datapipe.jenkins.vault.it.folder.FolderIT
23:08:59  [INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.346 s - in InjectedTest
23:08:59  [INFO] Running com.datapipe.jenkins.vault.VaultBuildWrapperTest
23:08:59  [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.046 s - in com.datapipe.jenkins.vault.it.VaultUsernamePasswordCredentialIT
23:08:59  [INFO] Running com.datapipe.jenkins.vault.it.folder.FolderIT
23:09:00  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.115 s - in com.datapipe.jenkins.vault.VaultBuildWrapperTest
23:09:00  [INFO] Running com.datapipe.jenkins.vault.configuration.FolderVaultConfigurationSpec
23:09:01  [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.76 s - in com.datapipe.jenkins.vault.configuration.FolderVaultConfigurationSpec
23:09:01  [INFO] Running com.datapipe.jenkins.vault.configuration.VaultConfigurationSpec
23:09:01  [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in com.datapipe.jenkins.vault.configuration.VaultConfigurationSpec
23:09:01  [INFO] Running com.datapipe.jenkins.vault.it.VaultConfigurationIT
23:09:06  [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.717 s - in com.datapipe.jenkins.vault.it.folder.FolderIT
23:09:06  [INFO] Running com.datapipe.jenkins.vault.jcasc.secrets.VaultSecretSourceTest
23:09:07  [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.742 s - in com.datapipe.jenkins.vault.it.folder.FolderIT
23:09:07  [INFO] Running com.datapipe.jenkins.vault.jcasc.secrets.VaultSecretSourceTest
23:09:15  [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.863 s - in com.datapipe.jenkins.vault.it.VaultConfigurationIT
23:09:15  [INFO] Running com.datapipe.jenkins.vault.it.VaultTokenCredentialBindingIT
23:09:37  [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.39 s - in com.datapipe.jenkins.vault.it.VaultTokenCredentialBindingIT
23:09:37  [INFO] Running com.datapipe.jenkins.vault.it.VaultUsernamePasswordCredentialIT
23:09:40  [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.179 s - in com.datapipe.jenkins.vault.it.VaultUsernamePasswordCredentialIT
23:09:40  [INFO] Running com.datapipe.jenkins.vault.it.folder.FolderIT
23:09:46  [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.846 s - in com.datapipe.jenkins.vault.it.folder.FolderIT
23:09:46  [INFO] Running com.datapipe.jenkins.vault.jcasc.secrets.VaultSecretSourceTest
23:10:15  [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 66.744 s - in com.datapipe.jenkins.vault.jcasc.secrets.VaultSecretSourceTest
23:10:15  [INFO] Running com.datapipe.jenkins.vault.log.MaskingConsoleLogFilterSpec
23:10:15  [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.15 s - in com.datapipe.jenkins.vault.log.MaskingConsoleLogFilterSpec
23:10:15  [INFO] 
23:10:15  [INFO] Results:
23:10:15  [INFO] 
23:10:15  [INFO] Tests run: 69, Failures: 0, Errors: 0, Skipped: 0
23:10:15  [INFO] 
23:10:15  [INFO] 
23:10:15  [INFO] --- maven-license-plugin:1.8:process (default) @ hashicorp-vault-plugin ---
23:10:15  [INFO] Generated /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin/WEB-INF/licenses.xml
23:10:15  [INFO] 
23:10:15  [INFO] --- maven-hpi-plugin:3.6:hpi (default-hpi) @ hashicorp-vault-plugin ---
23:10:15  [INFO] Generating /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin/META-INF/MANIFEST.MF
23:10:16  [INFO] Checking for attached .jar artifact ...
23:10:16  [INFO] Generating jar /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.jar
23:10:16  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.jar
23:10:16  [INFO] Exploding webapp...
23:10:16  [INFO] Copy webapp webResources to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin
23:10:16  [INFO] Assembling webapp hashicorp-vault-plugin in /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin
23:10:16  [INFO] Generating hpi /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.hpi
23:10:16  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.hpi
23:10:16  [INFO] 
23:10:16  [INFO] --- maven-jar-plugin:3.1.2:test-jar (maybe-test-jar) @ hashicorp-vault-plugin ---
23:10:16  [INFO] Skipping packaging of the test-jar
23:10:16  [INFO] 
23:10:16  [INFO] --- maven-source-plugin:3.1.0:jar-no-fork (attach-sources) @ hashicorp-vault-plugin ---
23:10:16  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-sources.jar
23:10:16  [INFO] 
23:10:16  [INFO] --- maven-source-plugin:3.1.0:test-jar-no-fork (attach-test-sources) @ hashicorp-vault-plugin ---
23:10:16  [INFO] Skipping source per configuration.
23:10:16  [INFO] 
23:10:16  [INFO] --- maven-javadoc-plugin:3.1.1:jar (attach-javadocs) @ hashicorp-vault-plugin ---
23:10:20  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-javadoc.jar
23:10:20  [INFO] 
23:10:20  [INFO] >>> spotbugs-maven-plugin:3.1.12.1:check (spotbugs) > :spotbugs @ hashicorp-vault-plugin >>>
23:10:20  [INFO] 
23:10:20  [INFO] --- spotbugs-maven-plugin:3.1.12.1:spotbugs (spotbugs) @ hashicorp-vault-plugin ---
23:10:22  [INFO] Fork Value is true
23:10:28  [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 70.413 s - in com.datapipe.jenkins.vault.jcasc.secrets.VaultSecretSourceTest
23:10:28  [INFO] Running com.datapipe.jenkins.vault.log.MaskingConsoleLogFilterSpec
23:10:28  [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.144 s - in com.datapipe.jenkins.vault.log.MaskingConsoleLogFilterSpec
23:10:28  [INFO] 
23:10:28  [INFO] Results:
23:10:28  [INFO] 
23:10:28  [INFO] Tests run: 69, Failures: 0, Errors: 0, Skipped: 0
23:10:28  [INFO] 
23:10:28  [INFO] 
23:10:28  [INFO] --- maven-license-plugin:1.8:process (default) @ hashicorp-vault-plugin ---
23:10:28  [INFO] Generated /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin/WEB-INF/licenses.xml
23:10:28  [INFO] 
23:10:28  [INFO] --- maven-hpi-plugin:3.6:hpi (default-hpi) @ hashicorp-vault-plugin ---
23:10:28  [INFO] Generating /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin/META-INF/MANIFEST.MF
23:10:28  [INFO] Checking for attached .jar artifact ...
23:10:28  [INFO] Generating jar /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.jar
23:10:28  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.jar
23:10:28  [INFO] Exploding webapp...
23:10:28  [INFO] Copy webapp webResources to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin
23:10:28  [INFO] Assembling webapp hashicorp-vault-plugin in /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin
23:10:28  [INFO] Generating hpi /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.hpi
23:10:28  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.hpi
23:10:28  [INFO] 
23:10:28  [INFO] --- maven-jar-plugin:3.1.2:test-jar (maybe-test-jar) @ hashicorp-vault-plugin ---
23:10:28  [INFO] Skipping packaging of the test-jar
23:10:28  [INFO] 
23:10:28  [INFO] --- maven-source-plugin:3.1.0:jar-no-fork (attach-sources) @ hashicorp-vault-plugin ---
23:10:28  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-sources.jar
23:10:28  [INFO] 
23:10:28  [INFO] --- maven-source-plugin:3.1.0:test-jar-no-fork (attach-test-sources) @ hashicorp-vault-plugin ---
23:10:28  [INFO] Skipping source per configuration.
23:10:28  [INFO] 
23:10:28  [INFO] --- maven-javadoc-plugin:3.1.1:jar (attach-javadocs) @ hashicorp-vault-plugin ---
23:10:28  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-javadoc.jar
23:10:28  [INFO] 
23:10:28  [INFO] >>> spotbugs-maven-plugin:3.1.12.1:check (spotbugs) > :spotbugs @ hashicorp-vault-plugin >>>
23:10:28  [INFO] 
23:10:28  [INFO] --- spotbugs-maven-plugin:3.1.12.1:spotbugs (spotbugs) @ hashicorp-vault-plugin ---
23:10:28  [INFO] Fork Value is true
23:10:32  [INFO] Done SpotBugs Analysis....
23:10:32  [INFO] Done SpotBugs Analysis....
23:10:32  [INFO] 
23:10:32  [INFO] <<< spotbugs-maven-plugin:3.1.12.1:check (spotbugs) < :spotbugs @ hashicorp-vault-plugin <<<
23:10:32  [INFO] 
23:10:32  [INFO] 
23:10:32  [INFO] --- spotbugs-maven-plugin:3.1.12.1:check (spotbugs) @ hashicorp-vault-plugin ---
23:10:32  [INFO] BugInstance size is 0
23:10:32  [INFO] Error size is 0
23:10:32  [INFO] No errors/warnings found
23:10:32  [INFO] 
23:10:32  [INFO] --- maven-checkstyle-plugin:3.0.0:check (default) @ hashicorp-vault-plugin ---
23:10:32  [INFO] 
23:10:32  [INFO] <<< spotbugs-maven-plugin:3.1.12.1:check (spotbugs) < :spotbugs @ hashicorp-vault-plugin <<<
23:10:32  [INFO] 
23:10:32  [INFO] 
23:10:32  [INFO] --- spotbugs-maven-plugin:3.1.12.1:check (spotbugs) @ hashicorp-vault-plugin ---
23:10:32  [INFO] BugInstance size is 0
23:10:32  [INFO] Error size is 0
23:10:32  [INFO] No errors/warnings found
23:10:32  [INFO] 
23:10:32  [INFO] --- maven-checkstyle-plugin:3.0.0:check (default) @ hashicorp-vault-plugin ---
23:10:34  [INFO] 
23:10:34  [INFO] --- maven-install-plugin:3.0.0-M1:install (default-install) @ hashicorp-vault-plugin ---
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.hpi to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.hpi
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.pom to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.pom
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.jar to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.jar
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-sources.jar to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e-sources.jar
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-javadoc.jar to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e-javadoc.jar
23:10:34  [INFO] ------------------------------------------------------------------------
23:10:34  [INFO] BUILD SUCCESS
23:10:34  [INFO] ------------------------------------------------------------------------
23:10:34  [INFO] Total time: 02:44 min
23:10:34  [INFO] Finished at: 2019-10-08T21:10:33Z
23:10:34  [INFO] ------------------------------------------------------------------------
23:10:34  [INFO] 
23:10:34  [INFO] --- maven-install-plugin:3.0.0-M1:install (default-install) @ hashicorp-vault-plugin ---
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.hpi to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.hpi
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.pom to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.pom
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.jar to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.jar
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-sources.jar to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e-sources.jar
23:10:34  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-javadoc.jar to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e-javadoc.jar
23:10:34  [INFO] ------------------------------------------------------------------------
23:10:34  [INFO] BUILD SUCCESS
23:10:34  [INFO] ------------------------------------------------------------------------
23:10:34  [INFO] Total time: 02:44 min
23:10:34  [INFO] Finished at: 2019-10-08T21:10:33Z
23:10:34  [INFO] ------------------------------------------------------------------------
23:10:34  [Pipeline] }
23:10:34  [Pipeline] // withEnv
23:10:34  [Pipeline] }
23:10:34  [Pipeline] // stage
23:10:34  [Pipeline] stage
23:10:34  [Pipeline] { (Archive (linux-8))
23:10:34  [Pipeline] }
23:10:34  [Pipeline] junit
23:10:34  [Pipeline] // withEnv
23:10:34  Recording test results
23:10:34  [Pipeline] }
23:10:34  [Pipeline] // stage
23:10:34  [Pipeline] stage
23:10:34  [Pipeline] { (Archive (linux-8-2.164.1))
23:10:34  [Pipeline] junit
23:10:34  Recording test results
23:10:34  [Pipeline] findbugs
23:10:34  [FINDBUGS] Collecting findbugs analysis files...
23:10:34  [Pipeline] }
23:10:34  [Pipeline] // stage
23:10:34  [Pipeline] }
23:10:34  [Pipeline] // timeout
23:10:34  [Pipeline] deleteDir
23:10:34  [Pipeline] isUnix
23:10:34  [Pipeline] sh
23:10:34  [FINDBUGS] Searching for all files in /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57 that match the pattern **/target/findbugsXml.xml
23:10:34  [FINDBUGS] No files found. Configuration error?
23:10:34  Skipping warnings blame since pipelines do not have an SCM link.%n
23:10:34  + docker system prune --force --all
23:10:35  [FINDBUGS] Computing warning deltas based on reference build #1
23:10:35  [Pipeline] readFile
23:10:35  [Pipeline] dir
23:10:35  Running in /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo
23:10:35  [Pipeline] {
23:10:35  [Pipeline] fingerprint
23:10:35  Recording fingerprints
23:10:35  [Pipeline] archiveArtifacts
23:10:35  Archiving artifacts
23:10:35  [Pipeline] }
23:10:35  [Pipeline] // dir
23:10:35  [Pipeline] }
23:10:35  [Pipeline] // stage
23:10:35  [Pipeline] }
23:10:35  Deleted Images:
23:10:35  untagged: permissions-report:latest
23:10:35  deleted: sha256:3684bdfc6f7da3a7437b7c951a633cb7ef57ac8cc272408c153abeb2f5517cf8
23:10:35  deleted: sha256:92ebc0799735debc98fc6e6d2eda4ac3e692fa69e6bd43502a8fec1bd7358d78
23:10:35  deleted: sha256:5dfd8349847489a59693fd935fc24500417de47e7479a65013ddcf77d847cf2b
23:10:35  deleted: sha256:e2d776e1a4555ab047c490fedd9480f857a84870a90cdc417cf831ed402f5c0d
23:10:35  deleted: sha256:412aefa9b6c9b417520c9795be9b8c5de1734a75e47502605325bd8fc8e19ef9
23:10:35  untagged: artifactory-users-report:latest
23:10:35  deleted: sha256:4fa62e4cb9da71b27dcd28f3817c334fc84eb215d68d9ae02277364b47bd6c28
23:10:35  [Pipeline] // timeout
23:10:35  deleted: sha256:19383c7e79d64c4e4f0e0b683f32d4cdef5579f19f82fa7c4191bb023afa5717
23:10:35  deleted: sha256:18ba1eb81f47d07aee4eaa0e515fe36f90923fe33ce6c04c8b5a2b8787ab465d
23:10:35  deleted: sha256:5afdded4500f5f79369c4c9bce782eb8129d2fecf41007294a94b4bc73afc4e0
23:10:35  deleted: sha256:b72e3459f3f574cc417b038b136669e2fb942bc1381fcef9c2367ec432175af8
23:10:35  deleted: sha256:a46e254fc9ca15867a67dc20be8636c8f40df5f80c1b7a7c6268b19b8a500bb0
23:10:35  deleted: sha256:b8c7c7b35ffeac4ad1812fc378df6ac886d1344790af2e431b0f281754e01d51
23:10:35  untagged: vault:1.2.1
23:10:35  untagged: vault@sha256:84bd6dd0b506f8489f1b72a6bf07fda816014483913c1989a575510a3c1a0809
23:10:35  deleted: sha256:8a613563fd9c68716a34d52763b2f78460795cf2b224a69b90a9152d5af1d67c
23:10:35  deleted: sha256:ca1bfdbde0f4489ae14bad92adb7d65a80f4fc27c33bc28229c2105a470ada48
23:10:35  deleted: sha256:4a3bb9a6f58a98b63c233aee70dceb84a63c26bf7c575e3dfdcb0d625c125818
23:10:35  deleted: sha256:0f8c2fc8926e4ba4859ed0fa3791775d1124ba319dcd635e7b7011a33269e0c4
23:10:35  deleted: sha256:a88bbaea3e8638fff91ca3c0b150f000e857795d239b6c96a9f7d1863c6403f5
23:10:35  deleted: sha256:1bfeebd65323b8ddf5bd6a51cc7097b72788bc982e9ab3280d53d3c613adffa7
23:10:35  untagged: vault:1.0.3
23:10:35  untagged: vault@sha256:be9b9395c331f442232cefa517b1079ff0845272886526972f0b3d241d4c885a
23:10:35  deleted: sha256:d0c0629c8a51df5ce6875f2f34df6e9fd98405224cea83f18bb120425aa85b3a
23:10:35  deleted: sha256:269b505c95512ff63ca9d48eb9160c70e72c3bba7a00eb4cd7c7b5ba054990e6
23:10:35  deleted: sha256:d42718e00a5458990ffc351c0c65d3562e768eaacb25bb47b85b7e802692581e
23:10:35  deleted: sha256:93cc30ee3cba0a31729355eba8882b4a9c733732ae16cf6b5b1c2e63e06806f1
23:10:35  deleted: sha256:1abfbad3f779cd2fc2f044c062f55e6d8f882d3c417e80cf729e59d0f2818f3d
23:10:35  deleted: sha256:d9ff549177a94a413c425ffe14ae1cc0aa254bc9c7df781add08e7d2fba25d27
23:10:35  untagged: debian:stable-slim
23:10:35  untagged: debian@sha256:a8787fc446fca239c3475b0e7890c202fb8abfee343082418dabdce060cf4f81
23:10:35  deleted: sha256:b861b2eb769faa2e58481025314755502a25d7a8872e1a165fa8f0d19ff13c40
23:10:35  deleted: sha256:7c7dc0cdbaac2b331f2fe356592945f68d14de8a28a891e5447afc8c9e0ecf42
23:10:35  untagged: quay.io/testcontainers/ryuk:0.2.3
23:10:35  untagged: quay.io/testcontainers/ryuk@sha256:bb5a635cac4bd96c93cc476969ce11dc56436238ec7cd028d0524462f4739dd9
23:10:35  deleted: sha256:64849fd2d4645159f8c839015f7754dac1207181ca65cf2a10f08597ac5baa3e
23:10:35  deleted: sha256:0fb5d0c88ea47a3277a6f172c8a9f33338d4609979092de59c85a79bece79b60
23:10:35  deleted: sha256:702e65e13a910118e0a1112dcf08513bcb635b49c499672ce33a886a2141d623
23:10:35  deleted: sha256:503e53e365f34399c4d58d8f4e23c161106cfbce4400e3d0a0357967bad69390
23:10:35  untagged: ruby:2.5-slim
23:10:35  untagged: ruby@sha256:0ece8883daaa60fd928183759eea4ebaaf8b8873c6c2bd3544f9a51f362d98e4
23:10:35  deleted: sha256:a018f77cf2fc3ab3af13b39f43f2001c34c923a6f4247fe9df028be39778ae3f
23:10:35  deleted: sha256:f8fff33f3623d89aba9f5f89c879858396698aefc9a776d26e574d212b326d3a
23:10:35  deleted: sha256:94bbf0f923efbe3abfb1a9b41c29a07138c5effebcd115fa88c2cc95600fa0e4
23:10:35  deleted: sha256:262c86c8e5f0287f455c5386d4bdf7d2fae8c881e768c93bed3f164272a969ae
23:10:35  deleted: sha256:07c274a1e76e05cc86b9c14d19033c875bf19df5413e82588e33fec8286737c7
23:10:35  deleted: sha256:2db44bce66cde56fca25aeeb7d09dc924b748e3adfe58c9cc3eb2bd2f68a1b68
23:10:35  
23:10:35  Total reclaimed space: 506.9MB
23:10:35  [Pipeline] deleteDir
23:10:35  [Pipeline] }
23:10:35  [Pipeline] // node
23:10:35  [Pipeline] }
23:10:36  [Pipeline] isUnix
23:10:36  [Pipeline] sh
23:10:36  + docker system prune --force --all
23:10:36  Deleted Images:
23:10:36  untagged: vault:1.2.1
23:10:36  untagged: vault@sha256:84bd6dd0b506f8489f1b72a6bf07fda816014483913c1989a575510a3c1a0809
23:10:36  deleted: sha256:8a613563fd9c68716a34d52763b2f78460795cf2b224a69b90a9152d5af1d67c
23:10:36  deleted: sha256:ca1bfdbde0f4489ae14bad92adb7d65a80f4fc27c33bc28229c2105a470ada48
23:10:36  deleted: sha256:4a3bb9a6f58a98b63c233aee70dceb84a63c26bf7c575e3dfdcb0d625c125818
23:10:36  deleted: sha256:0f8c2fc8926e4ba4859ed0fa3791775d1124ba319dcd635e7b7011a33269e0c4
23:10:36  deleted: sha256:a88bbaea3e8638fff91ca3c0b150f000e857795d239b6c96a9f7d1863c6403f5
23:10:36  deleted: sha256:1bfeebd65323b8ddf5bd6a51cc7097b72788bc982e9ab3280d53d3c613adffa7
23:10:36  untagged: quay.io/testcontainers/ryuk:0.2.3
23:10:36  untagged: quay.io/testcontainers/ryuk@sha256:bb5a635cac4bd96c93cc476969ce11dc56436238ec7cd028d0524462f4739dd9
23:10:36  deleted: sha256:64849fd2d4645159f8c839015f7754dac1207181ca65cf2a10f08597ac5baa3e
23:10:36  deleted: sha256:0fb5d0c88ea47a3277a6f172c8a9f33338d4609979092de59c85a79bece79b60
23:10:36  deleted: sha256:702e65e13a910118e0a1112dcf08513bcb635b49c499672ce33a886a2141d623
23:10:36  deleted: sha256:503e53e365f34399c4d58d8f4e23c161106cfbce4400e3d0a0357967bad69390
23:10:36  untagged: vault:1.0.3
23:10:36  untagged: vault@sha256:be9b9395c331f442232cefa517b1079ff0845272886526972f0b3d241d4c885a
23:10:36  deleted: sha256:d0c0629c8a51df5ce6875f2f34df6e9fd98405224cea83f18bb120425aa85b3a
23:10:36  deleted: sha256:269b505c95512ff63ca9d48eb9160c70e72c3bba7a00eb4cd7c7b5ba054990e6
23:10:36  deleted: sha256:d42718e00a5458990ffc351c0c65d3562e768eaacb25bb47b85b7e802692581e
23:10:36  deleted: sha256:93cc30ee3cba0a31729355eba8882b4a9c733732ae16cf6b5b1c2e63e06806f1
23:10:36  deleted: sha256:1abfbad3f779cd2fc2f044c062f55e6d8f882d3c417e80cf729e59d0f2818f3d
23:10:36  deleted: sha256:d9ff549177a94a413c425ffe14ae1cc0aa254bc9c7df781add08e7d2fba25d27
23:10:36  
23:10:36  Total reclaimed space: 250.4MB
23:10:36  [Pipeline] }
23:10:36  [Pipeline] // node
23:10:36  [Pipeline] }
23:10:43  [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 56.884 s - in com.datapipe.jenkins.vault.jcasc.secrets.VaultSecretSourceTest
23:10:43  [INFO] Running com.datapipe.jenkins.vault.log.MaskingConsoleLogFilterSpec
23:10:43  [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.162 s - in com.datapipe.jenkins.vault.log.MaskingConsoleLogFilterSpec
23:10:43  [INFO] 
23:10:43  [INFO] Results:
23:10:43  [INFO] 
23:10:43  [INFO] Tests run: 69, Failures: 0, Errors: 0, Skipped: 0
23:10:43  [INFO] 
23:10:43  [INFO] 
23:10:43  [INFO] --- maven-license-plugin:1.8:process (default) @ hashicorp-vault-plugin ---
23:10:44  WARNING: An illegal reflective access operation has occurred
23:10:44  WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass$3$1 (file:/home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/org/codehaus/groovy/groovy/1.6.5/groovy-1.6.5.jar) to method java.lang.Object.finalize()
23:10:44  WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass$3$1
23:10:44  WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
23:10:44  WARNING: All illegal access operations will be denied in a future release
23:10:45  [INFO] Generated /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin/WEB-INF/licenses.xml
23:10:45  [INFO] 
23:10:45  [INFO] --- maven-hpi-plugin:3.6:hpi (default-hpi) @ hashicorp-vault-plugin ---
23:10:45  [INFO] Generating /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin/META-INF/MANIFEST.MF
23:10:45  [INFO] Checking for attached .jar artifact ...
23:10:45  [INFO] Generating jar /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.jar
23:10:45  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.jar
23:10:45  [INFO] Exploding webapp...
23:10:45  [INFO] Copy webapp webResources to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin
23:10:45  [INFO] Assembling webapp hashicorp-vault-plugin in /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin
23:10:45  [INFO] Generating hpi /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.hpi
23:10:45  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.hpi
23:10:45  [INFO] 
23:10:45  [INFO] --- maven-jar-plugin:3.1.2:test-jar (maybe-test-jar) @ hashicorp-vault-plugin ---
23:10:46  [INFO] Skipping packaging of the test-jar
23:10:46  [INFO] 
23:10:46  [INFO] --- maven-source-plugin:3.1.0:jar-no-fork (attach-sources) @ hashicorp-vault-plugin ---
23:10:46  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-sources.jar
23:10:46  [INFO] 
23:10:46  [INFO] --- maven-source-plugin:3.1.0:test-jar-no-fork (attach-test-sources) @ hashicorp-vault-plugin ---
23:10:46  [INFO] Skipping source per configuration.
23:10:46  [INFO] 
23:10:46  [INFO] --- maven-javadoc-plugin:3.1.1:jar (attach-javadocs) @ hashicorp-vault-plugin ---
23:10:53  [INFO] Building jar: /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-javadoc.jar
23:10:53  [INFO] 
23:10:53  [INFO] >>> spotbugs-maven-plugin:3.1.12.1:check (spotbugs) > :spotbugs @ hashicorp-vault-plugin >>>
23:10:53  [INFO] 
23:10:53  [INFO] --- spotbugs-maven-plugin:3.1.12.1:spotbugs (spotbugs) @ hashicorp-vault-plugin ---
23:10:55  [INFO] Fork Value is true
23:11:05  [INFO] Done SpotBugs Analysis....
23:11:05  [INFO] 
23:11:05  [INFO] <<< spotbugs-maven-plugin:3.1.12.1:check (spotbugs) < :spotbugs @ hashicorp-vault-plugin <<<
23:11:05  [INFO] 
23:11:05  [INFO] 
23:11:05  [INFO] --- spotbugs-maven-plugin:3.1.12.1:check (spotbugs) @ hashicorp-vault-plugin ---
23:11:05  [INFO] BugInstance size is 0
23:11:05  [INFO] Error size is 0
23:11:05  [INFO] No errors/warnings found
23:11:05  [INFO] 
23:11:05  [INFO] --- maven-checkstyle-plugin:3.0.0:check (default) @ hashicorp-vault-plugin ---
23:11:07  [INFO] 
23:11:07  [INFO] --- maven-install-plugin:3.0.0-M1:install (default-install) @ hashicorp-vault-plugin ---
23:11:07  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.hpi to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.hpi
23:11:07  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.pom to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.pom
23:11:07  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin.jar to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e.jar
23:11:07  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-sources.jar to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e-sources.jar
23:11:07  [INFO] Installing /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57/target/hashicorp-vault-plugin-javadoc.jar to /home/jenkins/workspace/ins_hashicorp-vault-plugin_PR-57@tmp/m2repo/com/datapipe/jenkins/plugins/hashicorp-vault-plugin/2.5.1-rc263.b8e767fa3e9e/hashicorp-vault-plugin-2.5.1-rc263.b8e767fa3e9e-javadoc.jar
23:11:07  [INFO] ------------------------------------------------------------------------
23:11:07  [INFO] BUILD SUCCESS
23:11:07  [INFO] ------------------------------------------------------------------------
23:11:07  [INFO] Total time: 03:07 min
23:11:07  [INFO] Finished at: 2019-10-08T21:11:07Z
23:11:07  [INFO] ------------------------------------------------------------------------
23:11:07  [Pipeline] }
23:11:07  [Pipeline] // withEnv
23:11:07  [Pipeline] }
23:11:07  [Pipeline] // stage
23:11:07  [Pipeline] stage
23:11:07  [Pipeline] { (Archive (linux-11-2.164.1))
23:11:07  [Pipeline] junit
23:11:07  Recording test results
23:11:07  [Pipeline] }
23:11:07  [Pipeline] // stage
23:11:07  [Pipeline] }
23:11:07  [Pipeline] // timeout
23:11:07  [Pipeline] deleteDir
23:11:07  [Pipeline] isUnix
23:11:07  [Pipeline] sh
23:11:08  + docker system prune --force --all
23:11:10  Deleted Images:
23:11:10  untagged: vault:1.2.1
23:11:10  untagged: vault@sha256:84bd6dd0b506f8489f1b72a6bf07fda816014483913c1989a575510a3c1a0809
23:11:10  deleted: sha256:8a613563fd9c68716a34d52763b2f78460795cf2b224a69b90a9152d5af1d67c
23:11:10  deleted: sha256:ca1bfdbde0f4489ae14bad92adb7d65a80f4fc27c33bc28229c2105a470ada48
23:11:10  deleted: sha256:4a3bb9a6f58a98b63c233aee70dceb84a63c26bf7c575e3dfdcb0d625c125818
23:11:10  deleted: sha256:0f8c2fc8926e4ba4859ed0fa3791775d1124ba319dcd635e7b7011a33269e0c4
23:11:10  deleted: sha256:a88bbaea3e8638fff91ca3c0b150f000e857795d239b6c96a9f7d1863c6403f5
23:11:10  deleted: sha256:1bfeebd65323b8ddf5bd6a51cc7097b72788bc982e9ab3280d53d3c613adffa7
23:11:10  untagged: vault:1.0.3
23:11:10  untagged: vault@sha256:be9b9395c331f442232cefa517b1079ff0845272886526972f0b3d241d4c885a
23:11:10  deleted: sha256:d0c0629c8a51df5ce6875f2f34df6e9fd98405224cea83f18bb120425aa85b3a
23:11:10  deleted: sha256:269b505c95512ff63ca9d48eb9160c70e72c3bba7a00eb4cd7c7b5ba054990e6
23:11:10  deleted: sha256:d42718e00a5458990ffc351c0c65d3562e768eaacb25bb47b85b7e802692581e
23:11:10  deleted: sha256:93cc30ee3cba0a31729355eba8882b4a9c733732ae16cf6b5b1c2e63e06806f1
23:11:10  deleted: sha256:1abfbad3f779cd2fc2f044c062f55e6d8f882d3c417e80cf729e59d0f2818f3d
23:11:10  deleted: sha256:d9ff549177a94a413c425ffe14ae1cc0aa254bc9c7df781add08e7d2fba25d27
23:11:10  untagged: quay.io/testcontainers/ryuk:0.2.3
23:11:10  untagged: quay.io/testcontainers/ryuk@sha256:bb5a635cac4bd96c93cc476969ce11dc56436238ec7cd028d0524462f4739dd9
23:11:10  deleted: sha256:64849fd2d4645159f8c839015f7754dac1207181ca65cf2a10f08597ac5baa3e
23:11:10  deleted: sha256:0fb5d0c88ea47a3277a6f172c8a9f33338d4609979092de59c85a79bece79b60
23:11:10  deleted: sha256:702e65e13a910118e0a1112dcf08513bcb635b49c499672ce33a886a2141d623
23:11:10  deleted: sha256:503e53e365f34399c4d58d8f4e23c161106cfbce4400e3d0a0357967bad69390
23:11:10  
23:11:10  Total reclaimed space: 250.4MB
23:11:10  [Pipeline] }
23:11:10  [Pipeline] // node
23:11:10  [Pipeline] }
23:11:10  [Pipeline] // parallel
23:11:10  [Pipeline] stage
23:11:10  [Pipeline] { (Deploy)
23:11:10  [Pipeline] node
23:11:25  Still waiting to schedule task
23:11:25  Waiting for next available executor on ‘maven’
```