### PR TITLE
[INFRA-2402] - Skip tests if changeset content not relevant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
             <version>1.21</version>
             <scope>test</scope>
         </dependency>
+        <dependency><!-- Copied from jenkins/core/pom.xml -->
+            <groupId>org.kohsuke.stapler</groupId>
+            <artifactId>json-lib</artifactId>
+            <version>2.4-jenkins-2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <testSourceDirectory>src/test/groovy</testSourceDirectory>

--- a/src/test/groovy/BuildPluginStepTests.groovy
+++ b/src/test/groovy/BuildPluginStepTests.groovy
@@ -227,6 +227,58 @@ class BuildPluginStepTests extends BasePipelineTest {
   }
 
   @Test
+  void test_buildPlugin_without_tests_build_number_1() throws Exception {
+    def script = loadScript(scriptName)
+    binding.setProperty('currentBuild', new CurrentBuild())
+    script.call(tests: [skip: true])
+    printCallStack()
+    // then the junit step is disabled
+    assertFalse(helper.callStack.any { call ->
+      call.methodName == 'junit'
+    })
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_with_tests_build_number_1() throws Exception {
+    def script = loadScript(scriptName)
+    binding.setProperty('currentBuild', new CurrentBuild())
+    script.call()
+    printCallStack()
+    // then the junit step is enabled because it is build number 1
+    assertTrue(helper.callStack.any { call ->
+      call.methodName == 'junit'
+    })
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_with_tests_build_number_2_null_changeSets() throws Exception {
+    def script = loadScript(scriptName)
+    binding.setProperty('currentBuild', new CurrentBuild(2))
+    script.call()
+    printCallStack()
+    // then the junit step is enabled because it is build number 2 with null changeSets
+    assertTrue(helper.callStack.any { call ->
+      call.methodName == 'junit'
+    })
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_without_tests_build_number_2_changeSets_with_no_relevant_changes() throws Exception {
+    def script = loadScript(scriptName)
+    binding.setProperty('currentBuild', new CurrentBuild(2, true))
+    script.call()
+    printCallStack()
+    // then the junit step is disabled because it is build number 2 with empty but not null changeSets
+    assertFalse(helper.callStack.any { call ->
+      call.methodName == 'junit'
+    })
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_buildPlugin_with_defaults_with_gradle() throws Exception {
     def script = loadScript(scriptName)
     // when running in a non maven project

--- a/src/test/groovy/BuildPluginStepTests.groovy
+++ b/src/test/groovy/BuildPluginStepTests.groovy
@@ -111,7 +111,7 @@ class BuildPluginStepTests extends BasePipelineTest {
     assertTrue(helper.callStack.findAll { call ->
       call.methodName == 'error'
     }.any { call ->
-      callArgsToString(call).contains('Configuration filed "jdk" must be specified: [platform:linux]')
+      callArgsToString(call).contains('Configuration field "jdk" must be specified: [platform:linux]')
     })
     assertJobStatusFailure()
   }

--- a/src/test/groovy/mock/CurrentBuild.groovy
+++ b/src/test/groovy/mock/CurrentBuild.groovy
@@ -4,6 +4,19 @@ package mock
  * Mock currentBuild
  */
 class CurrentBuild implements Serializable {
-  String result
+  String result = 'SUCCESS'
+  int number = 1
+  def changeSets = null
+  public CurrentBuild() { }
   public CurrentBuild(String result) { this.result = result }
+  public CurrentBuild(int number) { this.number = number }
+
+  public CurrentBuild(int number, boolean initializeChangeSets) {
+    this.number = number
+    if (initializeChangeSets) {
+      List<String> fileOne = [ 'README.md', ]
+      def changeSetOne = [ commitId: 'SHA-1.1', author: 'writer.1', affectedFiles: fileOne ]
+      this.changeSets = [ [items:changeSetOne], ]
+    }
+  }
 }

--- a/src/test/groovy/mock/CurrentBuild.groovy
+++ b/src/test/groovy/mock/CurrentBuild.groovy
@@ -1,5 +1,7 @@
 package mock
 
+import net.sf.json.JSONObject
+
 /**
  * Mock currentBuild
  */
@@ -18,5 +20,9 @@ class CurrentBuild implements Serializable {
       def changeSetOne = [ commitId: 'SHA-1.1', author: 'writer.1', affectedFiles: fileOne ]
       this.changeSets = [ [items:changeSetOne], ]
     }
+  }
+
+  public JSONObject getBuildCauses() {
+    return new JSONObject()
   }
 }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -289,5 +289,6 @@ boolean skipTestsIfNoRelevantChanges(skipTestsInitialValue) {
             }
         }
     }
+    echo "Skipping tests because changeset does not contain java or pom.xml changes"
     return true
 }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -267,6 +267,7 @@ static List<Map<String, String>> recommendedConfigurations() {
  * Return true if tests should be skipped because the changeset
  * contains no changes that will reasonably affect a test.
  */
+@NonCPS
 boolean skipTestsIfNoRelevantChanges(skipTestsInitialValue) {
     if (skipTestsInitialValue) { // Explicit skip wins
         return true

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -274,6 +274,13 @@ boolean skipTestsIfNoRelevantChanges(skipTestsInitialValue) {
     if (currentBuild.number == 1) { // Don't skip tests on first build
         return false
     }
+    buildCauses = currentBuild.getBuildCauses()
+    for (int i = 0; i < buildCauses.size(); i++) {
+        buildCauseClass = buildCauses[i]._class // String name of class
+        if (buildCauseClass == 'hudson.model.Cause$UserIdCause') {
+            return false
+        }
+    }
     if (currentBuild.changeSets == null || currentBuild.changeSets.size() == 0) { // Don't skip tests if no changeSet detected
         // No changeset indicates user launched build without SCM change
         // Run tests on user launched build

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -274,7 +274,9 @@ boolean skipTestsIfNoRelevantChanges(skipTestsInitialValue) {
     if (currentBuild.number == 1) { // Don't skip tests on first build
         return false
     }
-    if (currentBuild.changeSets == null) { // Don't skip tests if no changeSet detected
+    if (currentBuild.changeSets == null || currentBuild.changeSets.size() == 0) { // Don't skip tests if no changeSet detected
+        // No changeset indicates user launched build without SCM change
+        // Run tests on user launched build
         return false
     }
     def changeLogSets = currentBuild.changeSets

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -275,17 +275,17 @@ boolean skipTestsIfNoRelevantChanges(skipTestsInitialValue) {
     if (currentBuild.number == 1) { // Don't skip tests on first build
         return false
     }
-    buildCauses = currentBuild.getBuildCauses()
-    for (int i = 0; i < buildCauses.size(); i++) {
-        buildCauseClass = buildCauses[i]._class // String name of class
-        if (buildCauseClass == 'hudson.model.Cause$UserIdCause') {
-            return false
-        }
-    }
     if (currentBuild.changeSets == null || currentBuild.changeSets.size() == 0) { // Don't skip tests if no changeSet detected
         // No changeset indicates user launched build without SCM change
         // Run tests on user launched build
         return false
+    }
+    buildCauses = currentBuild.getBuildCauses()
+    for (int i = 0; i < buildCauses.size(); i++) {  // Don't skip tests if user started the build
+        buildCauseClass = buildCauses[i]._class // String name of class
+        if (buildCauseClass == 'hudson.model.Cause$UserIdCause') {
+            return false
+        }
     }
     def changeLogSets = currentBuild.changeSets
     for (int i = 0; i < changeLogSets.size(); i++) { // for each changelog

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -219,7 +219,7 @@ List<Map<String, String>> getConfigurations(Map params) {
             error("Configuration field \"platform\" must be specified: $c")
         }
         if (!c.jdk) {
-            error("Configuration filed \"jdk\" must be specified: $c")
+            error("Configuration field \"jdk\" must be specified: $c")
         }
     }
 


### PR DESCRIPTION
## Skip tests if changeset content not relevant

If the changeset does not include files that end with ".java" or a file with name that ends with "pom.xml", skip the tests.

Reduce the CI load while still performing simple evaluation of changes which don't modify Java files or pom files.

Do not skip tests on first build unless the skip test argument is passed explicitly.

@oleg-nenashev is this a useful short-term reduction in CI load when the tests are unlikely to tell us more about the change?