### PR TITLE
Reduce recommended configurations

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -252,12 +252,16 @@ List<Map<String, String>> getConfigurations(Map params) {
 static List<Map<String, String>> recommendedConfigurations() {
     def recentLTS = "2.164.1"
     def configurations = [
+        // Intentionally test configurations which have detected the most problems
+        // Linux - Java 8 with plugin specified minimum Jenkins version
+        // Windows - Java 8 with recent LTS
+        // Linux - Java 11 with recent LTS
         [ platform: "linux", jdk: "8", jenkins: null ],
-        [ platform: "windows", jdk: "8", jenkins: null ],
-        [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+        // [ platform: "windows", jdk: "8", jenkins: null ],
+        // [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
         [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
         [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "windows", jdk: "11", jenkins: recentLTS, javaLevel: "8" ]
+        // [ platform: "windows", jdk: "11", jenkins: recentLTS, javaLevel: "8" ]
     ]
     return configurations
 }


### PR DESCRIPTION
## Reduce recommended configurations to best bug finders

Reduce recommended configurations to best bug finders

Assure that the recommended configuration will test most likely bug finding combinations:

* Windows, JDK 8, recent LTS
* Linux, JDK 11, recent LTS
* Linux, JDK 8, minimum Jenkins version

Don't need to cover every combination, just the most interesting combinations.

Will reduce the load on ci.jenkins.io and may decrease pull request build time.

@oleg-nenashev and @olblak this will reduce the load on ci.jenkins.io by running fewer configurations.  Reduces tested configurations by 50%.