### PR TITLE
Turning off download messages in runATH

### DIFF
--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -146,7 +146,7 @@ def call(Map params = [:]) {
                         if (supportedBrowsers.contains(browser)) {
                             def currentBrowser = browser
 
-                            def commandBase = "./run.sh ${currentBrowser} ./jenkins.war -B -Dmaven.test.failure.ignore=true -DforkCount=1 -B -Dsurefire.rerunFailingTestsCount=${rerunCount}"
+                            def commandBase = "./run.sh ${currentBrowser} ./jenkins.war -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.test.failure.ignore=true -DforkCount=1 -Dsurefire.rerunFailingTestsCount=${rerunCount}"
 
                             if (testsToRun) {
                                 testingbranches["ATH individual tests-${currentBrowser}-jdk${currentJdk}"] = {


### PR DESCRIPTION
Complements https://github.com/jenkinsci/jenkins/pull/4375, which still has a bunch of noise in the `ath` branch.

Note that the build currently _seems_ to be running Maven 3.6.0 but it is hard to tell what will be supported, so I am avoiding `-ntp` for now.