### PR TITLE
maybePublishIncrementals could run on any Linux agent

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -259,7 +259,7 @@ void prepareToPublishIncrementals() {
 void maybePublishIncrementals() {
     if (isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
-            node('maven') {
+            node('maven || linux') {
                 withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
                     sh '''
 curl -i -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://jenkins-incrementals.azurewebsites.net/api/incrementals-publisher?clientId=default&code=$FUNCTION_TOKEN" || echo 'Problem calling Incrementals deployment function'


### PR DESCRIPTION
Hoping to take advantage of Linux VM agents when they are free, since starting an ACI agent is pretty slow. #117 has more options.

Of course right now the function server is broken and no one knows why, but once it is fixed this may be helpful?