### PR TITLE
Activate the benchmark profile directly rather than indirectly via a property

### DIFF
--- a/vars/runBenchmarks.groovy
+++ b/vars/runBenchmarks.groovy
@@ -14,7 +14,7 @@ def call(String artifacts = null) {
             }
 
             stage('Run Benchmarks') {
-                List<String> mvnOptions = ['test', '-Dbenchmark']
+                List<String> mvnOptions = ['test', '-P jmh-benchmark']
                 infra.runMaven(mvnOptions)
             }
 

--- a/vars/runBenchmarks.groovy
+++ b/vars/runBenchmarks.groovy
@@ -14,7 +14,7 @@ def call(String artifacts = null) {
             }
 
             stage('Run Benchmarks') {
-                List<String> mvnOptions = ['test', '-P jmh-benchmark']
+                List<String> mvnOptions = ['test', '-P', 'jmh-benchmark']
                 infra.runMaven(mvnOptions)
             }
 


### PR DESCRIPTION
do not be scared of profiles - activate them directly so you know what is happening (also removed in plugin-pom 4.0)
https://github.com/jenkinsci/plugin-pom/pull/269