### PR TITLE
Add tests.skip option for Gradle based plugins + Documentation formatting fixes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,14 +31,14 @@ buildPlugin()
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel
 * `jdkVersions` (default: `[8]`) - JDK version numbers, must match a version
-    number jdk tool installed
+  number jdk tool installed
 * `jenkinsVersions`: (default: `[null]`) - a matrix of Jenkins baseline versions to build/test against in parallel (null means default,
   only available for Maven projects)
 * `configurations`: An alternative way to specify `platforms`, `jdkVersions` and `jenkinsVersions` (that can not be combined
-  with any of them).   
+  with any of them).
 ** Those options will run the build for all combinations of their values. While that is desirable in
-  many cases, `configurations` permit to provide a specific combinations of label and java/jenkins versions to use:
-  
+  many cases, `configurations` permit to provide a specific combinations of label and java/jenkins versions to use
++
 [source,groovy]
 ----
 buildPlugin(/*...*/, configurations: [
@@ -48,18 +48,17 @@ buildPlugin(/*...*/, configurations: [
 ])
 ----
 
-** It is also possible to use a  `buildPlugin.recommendedConfigurations()` method to get recommended configurations for testing. 
-Note that the recommended configuration may change over time, 
+** It is also possible to use a `buildPlugin.recommendedConfigurations()` method to get recommended configurations for testing.
+Note that the recommended configuration may change over time,
 and hence your CI may break if the new recommended configuration is not compatible
-
++
 [source,groovy]
 ----
 buildPlugin(/*...*/, configurations: buildPlugin.recommendedConfigurations())
 ----
 
-
 * `tests`: (default: `null`) - a map of parameters to run tests during the build
-** `skip` - If `true`, skipp all the tests by setting the `-skipTests` profile.
+** `skip` - If `true`, skip all the tests by setting the `-skipTests` profile.
   It will also skip FindBugs in modern Plugin POMs.
 * `findbugs`: (default: `null`) - a map of parameters to run findbugs and/or archive findbugs reports. (only available for Maven projects)
 ** `run`: set to `true` to add the `findbugs:findbugs` goal to the maven command.
@@ -88,7 +87,7 @@ buildPlugin(platforms: ['linux'], jdkVersions: [7, 8], findbugs: [archive: true,
 === buildPluginWithGradle()
 
 Builds a Jenkins plugin using Gradle.
-The implementation follows the standard build/test/archive pattern. 
+The implementation follows the standard build/test/archive pattern.
 The method targets compatibility with link:https://github.com/jenkinsci/gradle-jpi-plugin[Gradle JPI Plugin],
 and it may not work for other use-cases.
 
@@ -99,15 +98,12 @@ and it may not work for other use-cases.
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel
 * `jdkVersions` (default: `[8]`) - JDK version numbers, must match a version
-    number jdk tool installed
+  number jdk tool installed
 * `configurations`: An alternative way to specify `platforms`, `jdkVersions` (that can not be combined
   with any of them)
 ** Those options will run the build for all combinations of their values. While that is desirable in
   many cases, `configurations` permit to provide a specific combinations of label and java/jenkins versions to use
-** It is also possible to use a  `buildPlugin.recommendedConfigurations()` method to get recommended configurations for testing. 
-Note that the recommended configuration may change over time, 
-and hence your CI may break if the new recommended configuration is not compatible
-* `timeout`: (default: `60`) - the number of minutes for build timeout, cannot be bigger than 180, i.e. 3 hours.
++
 [source,groovy]
 ----
 buildPluginWithGradle(/*...*/, configurations: [
@@ -115,6 +111,19 @@ buildPluginWithGradle(/*...*/, configurations: [
   [ platform: "windows", jdk: "8"],
 ])
 ----
+
+** It is also possible to use a `buildPlugin.recommendedConfigurations()` method to get recommended configurations for testing.
+Note that the recommended configuration may change over time,
+and hence your CI may break if the new recommended configuration is not compatible
++
+[source,groovy]
+----
+buildPluginWithGradle(/*...*/, configurations: buildPlugin.recommendedConfigurations())
+----
+
+* `tests`: (default: `null`) - a map of parameters to run tests during the build
+** `skip` - If `true`, skip all the tests.
+* `timeout`: (default: `60`) - the number of minutes for build timeout, cannot be bigger than 180, i.e. 3 hours.
 
 ==== Limitations
 

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -117,6 +117,9 @@ def call(Map params = [:]) {
                                         'cleanTest',
                                         'build',
                                 ]
+                                if (skipTests) {
+                                    gradleOptions += '--exclude-task test'
+                                }
                                 command = "gradlew ${gradleOptions.join(' ')}"
                                 if (isUnix()) {
                                     command = "./" + command

--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -28,7 +28,8 @@ def call(Map params = [:]) {
         String javaLevel = config.javaLevel
 
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
-        
+        boolean skipTests = params?.tests?.skip
+
         tasks[stageIdentifier] = {
             node(label) {
                 timeout(timeoutValue) {
@@ -55,6 +56,9 @@ def call(Map params = [:]) {
                                 'cleanTest',
                                 'build',
                         ]
+                        if (skipTests) {
+                            gradleOptions += '--exclude-task test'
+                        }
                         String command = "gradlew ${gradleOptions.join(' ')}"
                         if (isUnix()) {
                             command = "./" + command


### PR DESCRIPTION
Adapt documentation to meet the structure as in `buildPlugin`.

Fix Asciidoc notation using list continuation `+` character, so that the lists are rendered correctly (indentation).

/CC @sghill