### PR TITLE
Improve Infra mock in PiplineUnit

### DIFF
--- a/src/test/groovy/PublishReportsStepTests.groovy
+++ b/src/test/groovy/PublishReportsStepTests.groovy
@@ -18,7 +18,7 @@ class PublishReportsStepTests extends BasePipelineTest {
 
     binding.setVariable('env', env)
     binding.setProperty('docker', new Docker())
-    binding.setProperty('infra', new Infra(true))
+    binding.setProperty('infra', new Infra(trusted: true))
 
     helper.registerAllowedMethod('error', [String.class], {s ->
       updateBuildStatus('FAILURE')
@@ -32,7 +32,7 @@ class PublishReportsStepTests extends BasePipelineTest {
   @Test
   void test_without_trusted_infra() throws Exception {
     def script = loadScript(scriptName)
-    binding.setProperty('infra', new Infra(false))
+    binding.setProperty('infra', new Infra(trusted: false))
     // when running with !infra.isTrusted()
     try {
       script.call(null)

--- a/src/test/groovy/RunBenchmarksStepTests.groovy
+++ b/src/test/groovy/RunBenchmarksStepTests.groovy
@@ -15,7 +15,7 @@ class RunBenchmarksStepTests extends BasePipelineTest {
     super.setUp()
 
     binding.setVariable('env', env)
-    binding.setProperty('infra', new Infra(true))
+    binding.setProperty('infra', new Infra(trusted: true))
 
     helper.registerAllowedMethod('archiveArtifacts', [Map.class], { m -> m })
     helper.registerAllowedMethod('echo', [String.class], { s -> s })

--- a/src/test/groovy/mock/Infra.groovy
+++ b/src/test/groovy/mock/Infra.groovy
@@ -5,18 +5,30 @@ package mock
  */
 class Infra implements Serializable {
 
-  private final boolean result
-  public Infra(boolean result) { this.result = result }
-  public Infra() { this.result = false }
-  public void checkout() { }
-  public void checkout(repo) { }
-  public String retrieveMavenSettingsFile(String location) { return location }
-  public String runWithMaven(String cmd) { return cmd }
-  public String runMaven(mvn) { return mvn }
-  public String runMaven(mvn, jdk, foo, settings) { return 'OK' }
-  public String runMaven(mvn, jdk, foo, settings, toolEnv) { return mvn }
-  public String runWithJava(command, jdk) { return command }
-  public String runWithJava(command, jdk, foo, toolEnv) { return command }
-  public boolean isTrusted() { return result }
+  private boolean trusted
+
+  public void checkout(String repo = null) { }
+
+  public String retrieveMavenSettingsFile(String location) {
+    return location
+  }
+
+  public Object runMaven(List<String> options, String jdk = null, List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = null) {
+    def command = "mvn ${options.join(' ')}"
+    return runWithMaven(command, jdk, extraEnv, addToolEnv)
+  }
+
+  public Object runWithMaven(String command, String jdk = null, List<String> extraEnv = null, Boolean addToolEnv = null) {
+    return runWithJava(command, jdk, extraEnv, addToolEnv)
+  }
+
+  public Object runWithJava(String command, String jdk = null, List<String> extraEnv = null, Boolean addToolEnv = null) {
+    return command
+  }
+
+  public boolean isTrusted() {
+    return trusted
+  }
+
   public void maybePublishIncrementals() { }
 }


### PR DESCRIPTION
Use same types in method signatures as in the real implementation.
Use default maps constructor to get named parameters.

It requires pull request #129 to be merged beforehand.