### PR TITLE
[INFRA-2435] Remove repo.azure mirrors

### DIFF
--- a/resources/settings-azure.xml
+++ b/resources/settings-azure.xml
@@ -42,17 +42,4 @@
             </properties>
         </profile>
     </profiles>
-
-    <mirrors>
-        <mirror>
-            <id>azure</id>
-            <url>https://repo.azure.jenkins.io/public/</url> <!-- INFRA-1176 -->
-            <mirrorOf>repo.jenkins-ci.org</mirrorOf>
-        </mirror>
-        <mirror>
-            <id>azure-incrementals</id>
-            <url>https://repo.azure.jenkins.io/incrementals/</url> <!-- IEP-9, JEP-305 -->
-            <mirrorOf>incrementals</mirrorOf>
-        </mirror>
-    </mirrors>
 </settings>


### PR DESCRIPTION
`repo.azure.jenkins.io` is deprecated and we are reverting it to repo.jenkins-ci.org
More information [here](https://issues.jenkins-ci.org/browse/INFRA-2435?focusedCommentId=383771&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-383771)