### PR TITLE
Also collect **/target/invoker-reports/**/*.xml

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -113,7 +113,7 @@ def call(Map params = [:]) {
                                     infra.runMaven(mavenOptions, jdk, null, null, addToolEnv)
                                 } finally {
                                     if (!skipTests) {
-                                        junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml')
+                                        junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml')
                                     }
                                 }
                             } else {


### PR DESCRIPTION
Noticed in https://github.com/jenkinsci/view-job-filters-plugin/pull/17 that https://maven.apache.org/plugins/maven-invoker-plugin/verify-mojo.html#ignoreFailures we are ignoring failures yet not collecting them.