### PR TITLE
windows 2019 images should have curl.exe by default

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -259,11 +259,17 @@ void prepareToPublishIncrementals() {
 void maybePublishIncrementals() {
     if (isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
-            node('maven || linux') {
+            node('maven || linux || windows') {
                 withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
-                    sh '''
+                    if (isUnix()) {
+                        sh '''
 curl -i -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://jenkins-community-functions.azurewebsites.net/api/incrementals-publisher?clientId=default&code=$FUNCTION_TOKEN" || echo 'Problem calling Incrementals deployment function'
-                    '''
+                        '''
+                    } else {
+                        bat '''
+curl.exe -i -H 'Content-Type: application/json' -d '{"build_url":"'%BUILD_URL%'"}' "https://jenkins-community-functions.azurewebsites.net/api/incrementals-publisher?clientId=default&code=%FUNCTION_TOKEN%" || echo 'Problem calling Incrementals deployment function'
+                        '''
+                    }
                 }
             }
         }


### PR DESCRIPTION
This will allow windows to also run deploy