### PR TITLE
Clean workspace before building incrementals

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -111,7 +111,7 @@ class BuildPluginStepTests extends BasePipelineTest {
     assertTrue(helper.callStack.findAll { call ->
       call.methodName == 'error'
     }.any { call ->
-      callArgsToString(call).contains('Configuration filed "jdk" must be specified: [platform:linux]')
+      callArgsToString(call).contains('Configuration field "jdk" must be specified: [platform:linux]')
     })
     assertJobStatusFailure()
   }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -67,11 +67,11 @@ def call(Map params = [:]) {
                                     readFile('.mvn/extensions.xml').contains('git-changelist-maven-extension')
                             if (incrementals) { // Incrementals needs 'git status -s' to be empty at start of job
                                 if (isUnix()) {
-                                    sh(script: 'git clean -xffd || true',
+                                    sh(script: 'git clean -xffd > /dev/null 2>&1',
                                        label:'Clean for incrementals',
                                        returnStatus: true) // Ignore failure if CLI git is not available
                                 } else {
-                                    bat(script: 'git clean -xffd || echo "git clean failure intentionally ignored in incrementals setup"',
+                                    bat(script: 'git clean -xffd 1> null 2>&1',
                                         label:'Clean for incrementals',
                                         returnStatus: true) // Ignore failure if CLI git is not available
                                 }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -66,6 +66,17 @@ def call(Map params = [:]) {
                             isMaven = fileExists('pom.xml')
                             incrementals = fileExists('.mvn/extensions.xml') &&
                                     readFile('.mvn/extensions.xml').contains('git-changelist-maven-extension')
+                            if (incrementals) { // Incrementals needs 'git status -s' to be empty at start of job
+                                if (isUnix()) {
+                                    sh(script: 'git clean -xffd || true',
+                                       label:'Clean for incrementals',
+                                       returnStatus: true) // Ignore failure if CLI git is not available
+                                } else {
+                                    bat(script: 'git clean -xffd || echo "git clean failure intentionally ignored in incrementals setup"',
+                                        label:'Clean for incrementals',
+                                        returnStatus: true) // Ignore failure if CLI git is not available
+                                }
+                            }
                         }
 
                         String changelistF

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -71,7 +71,7 @@ def call(Map params = [:]) {
                                        label:'Clean for incrementals',
                                        returnStatus: true) // Ignore failure if CLI git is not available
                                 } else {
-                                    bat(script: 'git clean -xffd 1> null 2>&1',
+                                    bat(script: 'git clean -xffd 1> nul 2>&1',
                                         label:'Clean for incrementals',
                                         returnStatus: true) // Ignore failure if CLI git is not available
                                 }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -225,7 +225,7 @@ List<Map<String, String>> getConfigurations(Map params) {
             error("Configuration field \"platform\" must be specified: $c")
         }
         if (!c.jdk) {
-            error("Configuration filed \"jdk\" must be specified: $c")
+            error("Configuration field \"jdk\" must be specified: $c")
         }
     }
 


### PR DESCRIPTION
## Clean workspace before building incrementals

The incrementals build process will abort if `git status -s` is not empty.  Since the maven step will invoke `mvn clean`, a `git clean` is safe.  In case command line git is not installed, the script does its very best to not fail with an error and to report that it intentionally did not fail with an error.

Also includes a spelling fix.

This change is needed until ci.jenkins.io agents become 100% ephemeral.  I've been hit repeatedly by tainted agent workspaces with the git plugin.  This will reduce the failure rate of git plugin builds and git client plugin builds on ci.jenkins.io.

See [my git plugin pull request](https://github.com/jenkinsci/git-plugin/pull/870) for an example of this pull request being used in a repository.