### PR TITLE
Update ACI usage

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -15,8 +15,8 @@ def call(Map params = [:]) {
     def repo = params.containsKey('repo') ? params.repo : null
     def failFast = params.containsKey('failFast') ? params.failFast : true
     def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
-    def useAci = params.containsKey('useAci') ? params.useAci : false
     def forceAci = params.containsKey('forceAci') ? params.forceAci : false
+    def useAci = params.containsKey('useAci') ? params.useAci : forceAci
     if(timeoutValue > 180) {
       echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
       timeoutValue = 180
@@ -38,10 +38,9 @@ def call(Map params = [:]) {
         boolean archiveFindbugs = first && params?.findbugs?.archive
         boolean archiveCheckstyle = first && params?.checkstyle?.archive
         boolean skipTests = params?.tests?.skip
-        boolean reallyUseAci = (useAci && label == 'linux') || forceAci
-        boolean addToolEnv = !reallyUseAci
-        
-        if(reallyUseAci) {
+        boolean addToolEnv = !useAci
+
+        if(useAci && (label == 'linux' || label == 'windows')) {
             String aciLabel = jdk == '8' ? 'maven' : 'maven-11'
             if(label == 'windows') {
                 aciLabel += "-windows"


### PR DESCRIPTION
This will enable Windows ACI usage when `useAci: true` is used. It will also only enable ACI when the label matches linux or windows so that if a different platform is specified (arm64, ppc64le, etc), it will work correctly.

/cc @MarkEWaite 