### PR TITLE
Deprecate recommendedConfigurations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,15 +51,6 @@ buildPlugin(/*...*/, configurations: [
 ])
 ----
 
-** It is also possible to use a `buildPlugin.recommendedConfigurations()` method to get recommended configurations for testing.
-Note that the recommended configuration may change over time,
-and hence your CI may break if the new recommended configuration is not compatible
-+
-[source,groovy]
-----
-buildPlugin(/*...*/, configurations: buildPlugin.recommendedConfigurations())
-----
-
 * `tests`: (default: `null`) - a map of parameters to run tests during the build
 ** `skip` - If `true`, skip all the tests by setting the `-skipTests` profile.
   It will also skip FindBugs in modern Plugin POMs.
@@ -113,15 +104,6 @@ buildPluginWithGradle(/*...*/, configurations: [
   [ platform: "linux", jdk: "8" ],
   [ platform: "windows", jdk: "8"],
 ])
-----
-
-** It is also possible to use a `buildPlugin.recommendedConfigurations()` method to get recommended configurations for testing.
-Note that the recommended configuration may change over time,
-and hence your CI may break if the new recommended configuration is not compatible
-+
-[source,groovy]
-----
-buildPluginWithGradle(/*...*/, configurations: buildPlugin.recommendedConfigurations())
 ----
 
 * `tests`: (default: `null`) - a map of parameters to run tests during the build

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -57,14 +57,6 @@ class BuildPluginStepTests extends BasePipelineTest {
   }
 
   @Test
-  void test_recommendedConfigurations() throws Exception {
-    def script = loadScript(scriptName)
-    def configurations = script.recommendedConfigurations()
-    printCallStack()
-    assertFalse(configurations.isEmpty())
-  }
-
-  @Test
   void test_getConfigurations_with_implicit_and_explicit() throws Exception {
     def script = loadScript(scriptName)
     try {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -210,7 +210,7 @@ boolean hasDockerLabel() {
 }
 
 List<Map<String, String>> getConfigurations(Map params) {
-    boolean explicit = params.containsKey("configurations")
+    boolean explicit = params.containsKey("configurations") && params.configurations != null
     boolean implicit = params.containsKey('platforms') || params.containsKey('jdkVersions') || params.containsKey('jenkinsVersions')
 
     if (explicit && implicit) {
@@ -251,22 +251,8 @@ List<Map<String, String>> getConfigurations(Map params) {
 }
 
 /**
- * Get recommended configurations for testing.
- * Includes testing Java 8 and 11 on the newest LTS.
+ * @deprecated no longer recommended
  */
 static List<Map<String, String>> recommendedConfigurations() {
-    def recentLTS = "2.222.3"
-    def configurations = [
-        // Intentionally test configurations which have detected the most problems
-        // Linux - Java 8 with plugin specified minimum Jenkins version
-        // Windows - Java 8 with recent LTS
-        // Linux - Java 11 with recent LTS
-        [ platform: "linux", jdk: "8", jenkins: null ],
-        // [ platform: "windows", jdk: "8", jenkins: null ],
-        // [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
-        // [ platform: "windows", jdk: "11", jenkins: recentLTS, javaLevel: "8" ]
-    ]
-    return configurations
+    null
 }


### PR DESCRIPTION
Amends #92 (which broke some builds) and supersedes #94. Better to specify configurations you want in your `Jenkinsfile`, and adjust those in PRs.