### PR TITLE
Revert "Merge pull request #92 from jglick/patch-1"

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -255,7 +255,7 @@ List<Map<String, String>> getConfigurations(Map params) {
  * Includes testing Java 8 and 11 on the newest LTS.
  */
 static List<Map<String, String>> recommendedConfigurations() {
-    def recentLTS = "2.222.3"
+    def recentLTS = "2.164.1"
     def configurations = [
         // Intentionally test configurations which have detected the most problems
         // Linux - Java 8 with plugin specified minimum Jenkins version


### PR DESCRIPTION
This reverts commit 7f414ef00749918ea206525f84edce0f07f2fb08, reversing
changes made to e24549524ba45cc2dc4f645f92a8678e5ac4ddc9.

Simpler and more targeted changed than #145 . 

There is no urgency to make larger changes than reverting the merge of #92 . 

The discussion of what to do about `recommendedConfigurations` and what if anything to replace it with can be done after we un-break people with the minimal changes possible.  