### PR TITLE
JDK version parameters in `buildPlugin()` are supposed to be strings not integers

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -70,8 +70,8 @@ class BuildPluginStepTests extends BaseTest {
     def script = loadScript(scriptName)
     def configurations = script.getConfigurations([:])
 
-    def expected = [['platform': 'linux', 'jdk': 8, 'jenkins': null, 'javaLevel': null],
-                    ['platform': 'windows', 'jdk': 8, 'jenkins': null, 'javaLevel': null]]
+    def expected = [['platform': 'linux', 'jdk': '8', 'jenkins': null, 'javaLevel': null],
+                    ['platform': 'windows', 'jdk': '8', 'jenkins': null, 'javaLevel': null]]
     assertEquals(expected, configurations)
     printCallStack()
     assertJobStatusSuccess()

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -231,7 +231,7 @@ List<Map<String, String>> getConfigurations(Map params) {
     if (explicit) return params.configurations
 
     def platforms = params.containsKey('platforms') ? params.platforms : ['linux', 'windows']
-    def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : [8]
+    def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : ['8']
     def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]
 
     def ret = []


### PR DESCRIPTION
Noticed after https://github.com/jenkinsci/workflow-job-plugin/pull/165#discussion_r430589682

Perhaps only matters in `useAci` mode: https://github.com/jenkins-infra/pipeline-library/blob/7d45d79ec5ef1ee15558568e012f130faff91456/vars/buildPlugin.groovy#L44