### PR TITLE
Only use ACI agents on Windows when forceAci is true

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -40,12 +40,10 @@ def call(Map params = [:]) {
         boolean skipTests = params?.tests?.skip
         boolean addToolEnv = !useAci
 
-        if(useAci && (label == 'linux' || label == 'windows')) {
-            String aciLabel = jdk == '8' ? 'maven' : 'maven-11'
-            if(label == 'windows') {
-                aciLabel += "-windows"
-            }
-            label = aciLabel
+        if (useAci && label == 'linux') {
+            label = jdk == '8' ? 'maven' : 'maven-11'
+        } else if (forceAci && label == 'windows') {
+            label = jdk == '8' ? 'maven-windows' : 'maven-11-windows'
         }
 
         tasks[stageIdentifier] = {


### PR DESCRIPTION
@slide and @timja and I were recently chatting in `#jenkins-infra` and they mentioned that `useAci` is not supposed to affect Windows agents, you are expected to use `forceAci` if you want ACI agents on Windows (also discussed in [the documentation here](https://github.com/jenkins-infra/pipeline-library#optional-arguments)), but from a quick look at `buildPlugin` I think that `forceAci` doesn't actually do anything right now other than set the default value of `useAci`, and `useAci` _does_ affect Windows.

Maybe I am missing something and `forceAci` does affect platform-specific behavior (for example I do not know the actual labels for ACI and non-ACI agents on ci.jenkins.io), but I figured I'd file this just in case.