### PR TITLE
Add optional recording of code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 
 # IDEA
 .idea
+*.iml
 
 # Visual Studio Code
 .project

--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,10 @@ buildPlugin(/*...*/, configurations: buildPlugin.recommendedConfigurations())
 
 * `tests`: (default: `null`) - a map of parameters to run tests during the build
 ** `skip` - If `true`, skip all the tests by setting the `-skipTests` profile.
-  It will also skip FindBugs in modern Plugin POMs.
+  It will also skip FindBugs and SpotBugs in modern Plugin POMs.
+** `withCoverage` - If `true`, record code coverage with
+https://www.eclemma.org/jacoco/trunk/doc/maven.html[Maven JaCoCo plugin] and
+ https://plugins.jenkins.io/code-coverage-api/[Jenkins Code Coverage API plugin].
 * `spotbugs`, `checkstyle`, `pmd`, `cpd`: (default: `null`) - a map of parameters to archive SpotBugs, CheckStyle, PMD, or CPD warnings, respectively (only available for Maven projects).
 These values can replace or amend the default configuration for the `recordIssues` step of the https://github.com/jenkinsci/warnings-ng-plugin[Warnings NG Plugin].
 See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#configuration[Warnings NG Plugin documentation]

--- a/README.adoc
+++ b/README.adoc
@@ -59,12 +59,10 @@ and hence your CI may break if the new recommended configuration is not compatib
 buildPlugin(/*...*/, configurations: buildPlugin.recommendedConfigurations())
 ----
 
-* `tests`: (default: `null`) - a map of parameters to run tests during the build
+* `tests`: (default: `null`) - a map of parameters to run tests during the build. The test results and the JaCoCo code
+coverage results are recorded after the build with the corresponding Jenkins plugins.
 ** `skip` - If `true`, skip all the tests by setting the `-skipTests` profile.
-  It will also skip FindBugs and SpotBugs in modern Plugin POMs.
-** `withCoverage` - If `true`, record code coverage with
-https://www.eclemma.org/jacoco/trunk/doc/maven.html[Maven JaCoCo plugin] and
- https://plugins.jenkins.io/code-coverage-api/[Jenkins Code Coverage API plugin].
+  It will also skip FindBugs in modern Plugin POMs.
 * `spotbugs`, `checkstyle`, `pmd`, `cpd`: (default: `null`) - a map of parameters to archive SpotBugs, CheckStyle, PMD, or CPD warnings, respectively (only available for Maven projects).
 These values can replace or amend the default configuration for the `recordIssues` step of the https://github.com/jenkinsci/warnings-ng-plugin[Warnings NG Plugin].
 See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#configuration[Warnings NG Plugin documentation]

--- a/test/groovy/BaseTest.groovy
+++ b/test/groovy/BaseTest.groovy
@@ -63,6 +63,9 @@ class BaseTest extends BasePipelineTest {
     helper.registerAllowedMethod('taskScanner', [Map.class], { 'tasks' })
     helper.registerAllowedMethod('excludeFile', [String.class], { true })
 
+    helper.registerAllowedMethod('jacocoAdapter', [String.class], {'jacoco'})
+    helper.registerAllowedMethod('publishCoverage', [Map.class], {s -> s})
+
     helper.registerAllowedMethod('runATH', [Map.class], { })
     helper.registerAllowedMethod('runPCT', [Map.class], { })
     helper.registerAllowedMethod('sh', [String.class], { s -> s })

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertTrue
 
 class BuildPluginStepTests extends BaseTest {
   static final String scriptName = 'vars/buildPlugin.groovy'
-  private static final String COVERAGE_PARAMETERS = '{calculateDiffForChangeRequests=true, adapters=[jacoco]}'
 
   @Override
   @Before
@@ -293,28 +292,10 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_coverage() throws Exception {
     def script = loadScript(scriptName)
-    script.call(tests: [withCoverage: true])
-    printCallStack()
-
-    assertTrue(assertMethodCallContainsPattern('publishCoverage', COVERAGE_PARAMETERS))
-  }
-
-  @Test
-  void test_buildPlugin_with_skip_and_coverage() throws Exception {
-    def script = loadScript(scriptName)
-    script.call(tests: [skip: true, withCoverage: true])
-    printCallStack()
-
-    assertFalse(assertMethodCallContainsPattern('publishCoverage', COVERAGE_PARAMETERS))
-  }
-
-  @Test
-  void test_buildPlugin_default_no_coverage() throws Exception {
-    def script = loadScript(scriptName)
     script.call()
     printCallStack()
 
-    assertFalse(assertMethodCallContainsPattern('publishCoverage', COVERAGE_PARAMETERS))
+    assertTrue(assertMethodCallContainsPattern('publishCoverage', '{calculateDiffForChangeRequests=true, adapters=[jacoco]}'))
   }
 
   @Test

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -290,6 +290,36 @@ class BuildPluginStepTests extends BaseTest {
   }
 
   @Test
+  void test_buildPlugin_with_coverage() throws Exception {
+    def script = loadScript(scriptName)
+    script.call(tests: [withCoverage: true])
+    printCallStack()
+
+    assertTrue(assertMethodCallContainsPattern('publishCoverage', '{adapters=[jacoco]}'))
+    assertTrue(assertMethodCallContainsPattern('echo', 'jacoco:prepare-agent test jacoco:report'))
+  }
+
+  @Test
+  void test_buildPlugin_with_skip_and_coverage() throws Exception {
+    def script = loadScript(scriptName)
+    script.call(tests: [skip: true, withCoverage: true])
+    printCallStack()
+
+    assertFalse(assertMethodCallContainsPattern('publishCoverage', '{adapters=[jacoco]}'))
+    assertFalse(assertMethodCallContainsPattern('echo', 'jacoco:prepare-agent test jacoco:report'))
+  }
+
+  @Test
+  void test_buildPlugin_default_no_coverage() throws Exception {
+    def script = loadScript(scriptName)
+    script.call()
+    printCallStack()
+
+    assertFalse(assertMethodCallContainsPattern('publishCoverage', '{adapters=[jacoco]}'))
+    assertFalse(assertMethodCallContainsPattern('echo', 'jacoco:prepare-agent test jacoco:report'))
+  }
+
+  @Test
   void test_buildPlugin_with_configurations_and_incrementals() throws Exception {
     def script = loadScript(scriptName)
     // when running with incrementals

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue
 
 class BuildPluginStepTests extends BaseTest {
   static final String scriptName = 'vars/buildPlugin.groovy'
+  private static final String COVERAGE_PARAMETERS = '{calculateDiffForChangeRequests=true, adapters=[jacoco]}'
 
   @Override
   @Before
@@ -295,7 +296,7 @@ class BuildPluginStepTests extends BaseTest {
     script.call(tests: [withCoverage: true])
     printCallStack()
 
-    assertTrue(assertMethodCallContainsPattern('publishCoverage', '{adapters=[jacoco]}'))
+    assertTrue(assertMethodCallContainsPattern('publishCoverage', COVERAGE_PARAMETERS))
   }
 
   @Test
@@ -304,7 +305,7 @@ class BuildPluginStepTests extends BaseTest {
     script.call(tests: [skip: true, withCoverage: true])
     printCallStack()
 
-    assertFalse(assertMethodCallContainsPattern('publishCoverage', '{adapters=[jacoco]}'))
+    assertFalse(assertMethodCallContainsPattern('publishCoverage', COVERAGE_PARAMETERS))
   }
 
   @Test
@@ -313,7 +314,7 @@ class BuildPluginStepTests extends BaseTest {
     script.call()
     printCallStack()
 
-    assertFalse(assertMethodCallContainsPattern('publishCoverage', '{adapters=[jacoco]}'))
+    assertFalse(assertMethodCallContainsPattern('publishCoverage', COVERAGE_PARAMETERS))
   }
 
   @Test

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -296,7 +296,6 @@ class BuildPluginStepTests extends BaseTest {
     printCallStack()
 
     assertTrue(assertMethodCallContainsPattern('publishCoverage', '{adapters=[jacoco]}'))
-    assertTrue(assertMethodCallContainsPattern('echo', 'jacoco:prepare-agent test jacoco:report'))
   }
 
   @Test
@@ -306,7 +305,6 @@ class BuildPluginStepTests extends BaseTest {
     printCallStack()
 
     assertFalse(assertMethodCallContainsPattern('publishCoverage', '{adapters=[jacoco]}'))
-    assertFalse(assertMethodCallContainsPattern('echo', 'jacoco:prepare-agent test jacoco:report'))
   }
 
   @Test
@@ -316,7 +314,6 @@ class BuildPluginStepTests extends BaseTest {
     printCallStack()
 
     assertFalse(assertMethodCallContainsPattern('publishCoverage', '{adapters=[jacoco]}'))
-    assertFalse(assertMethodCallContainsPattern('echo', 'jacoco:prepare-agent test jacoco:report'))
   }
 
   @Test

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -32,7 +32,6 @@ def call(Map params = [:]) {
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
         boolean first = tasks.size() == 1
         boolean skipTests = params?.tests?.skip
-        boolean enableCoverage = params?.tests?.withCoverage
         boolean addToolEnv = !useAci
 
         if(useAci && (label == 'linux' || label == 'windows')) {
@@ -106,12 +105,11 @@ def call(Map params = [:]) {
                                 }
                                 mavenOptions += "clean install"
                                 try {
-                                    echo "Running maven with options " + mavenOptions
                                     infra.runMaven(mavenOptions, jdk, null, null, addToolEnv)
                                 } finally {
                                     if (!skipTests) {
                                         junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml')
-                                        if (first && enableCoverage) {
+                                        if (first) {
                                             publishCoverage calculateDiffForChangeRequests: true, adapters: [jacocoAdapter('**/target/site/jacoco/jacoco.xml')]
                                         }
                                     }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -1,6 +1,4 @@
-#!/usr/bin/env groovy
-import org.codehaus.groovy.runtime.DefaultGroovyMethods
-
+#!/usr/bin/env groovy 
 //TODO(oleg_nenashev): This thing is not simple anymore. I suggest reworking it to a config YAML
 // which would be compatible with essentials.yml (INFRA-1673)
 /**
@@ -107,9 +105,6 @@ def call(Map params = [:]) {
                                     mavenOptions += "-DskipTests"
                                 }
                                 mavenOptions += "clean install"
-                                if (!skipTests && first && enableCoverage) {
-                                    mavenOptions += "jacoco:prepare-agent test jacoco:report"
-                                }
                                 try {
                                     echo "Running maven with options " + mavenOptions
                                     infra.runMaven(mavenOptions, jdk, null, null, addToolEnv)

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -117,7 +117,7 @@ def call(Map params = [:]) {
                                     if (!skipTests) {
                                         junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml')
                                         if (first && enableCoverage) {
-                                            publishCoverage adapters: [jacocoAdapter('target/site/jacoco/jacoco.xml')]
+                                            publishCoverage adapters: [jacocoAdapter('**/target/site/jacoco/jacoco.xml')]
                                         }
                                     }
                                 }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -112,7 +112,7 @@ def call(Map params = [:]) {
                                     if (!skipTests) {
                                         junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml')
                                         if (first && enableCoverage) {
-                                            publishCoverage adapters: [jacocoAdapter('**/target/site/jacoco/jacoco.xml')]
+                                            publishCoverage calculateDiffForChangeRequests: true, adapters: [jacocoAdapter('**/target/site/jacoco/jacoco.xml')]
                                         }
                                     }
                                 }


### PR DESCRIPTION
Add a new configuration option `withCoverage` to enable the computation and recording of code coverage results using [JaCoCo maven plugin](https://www.eclemma.org/jacoco/trunk/doc/maven.html) and [Jenkins Code Coverage API plugin](https://github.com/jenkinsci/code-coverage-api-plugin).

See https://ci.jenkins.io/job/Plugins/job/analysis-model/job/PR-484/3/ for an example.