### PR TITLE
Skip publishing checks for java and javadoc tool

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -226,7 +226,7 @@ class BuildPluginStepTests extends BaseTest {
 
     assertTrue(assertMethodCall('java'))
     assertTrue(assertMethodCall('javaDoc'))
-    assertTrue(assertMethodCallContainsPattern('recordIssues', '{enabledForFailure=true, tools=[java, javadoc], filters=[true], sourceCodeEncoding=UTF-8, trendChartType=TOOLS_ONLY, referenceJobName=build/plugin/master}'))
+    assertTrue(assertMethodCallContainsPattern('recordIssues', '{enabledForFailure=true, tools=[java, javadoc], filters=[true], sourceCodeEncoding=UTF-8, trendChartType=TOOLS_ONLY, referenceJobName=build/plugin/master, skipPublishingChecks=true}'))
 
     assertTrue(assertMethodCall('spotBugs'))
     assertTrue(assertMethodCallContainsPattern('recordIssues', '{tool=spotbugs, sourceCodeEncoding=UTF-8, trendChartType=TOOLS_ONLY, referenceJobName=build/plugin/master, qualityGates=[{threshold=1, type=NEW, unstable=true}]}'))

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -156,7 +156,8 @@ def call(Map params = [:]) {
                                         filters: [excludeFile('.*Assert.java')],
                                         sourceCodeEncoding: 'UTF-8',
                                         trendChartType: 'TOOLS_ONLY',
-                                        referenceJobName: referenceJobName
+                                        referenceJobName: referenceJobName,
+                                        skipPublishingChecks: true
 
                                 // Default configuration for SpotBugs can be overwritten using a `spotbugs`, `checkstyle', etc. parameter (map).
                                 // Configuration see: https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#configuration


### PR DESCRIPTION
https://github.com/jenkinsci/analysis-model/pull/486 has been released for fixing the duplicate java and javadoc checks.

But not sure if we want checks showing up for these?

The javadoc ones can be quite spammy, and we don't have a quality gate setup for it atm.

Thoughts?

@uhafner @jglick @daniel-beck @XiongKezhi