### PR TITLE
vars/buildDockerAndPublishImage.groovy fixes

### DIFF
--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -143,9 +143,7 @@ spec:
         }
       }
       stage("Deploy tag as tag") {
-        // semver regex from https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39
-        when { tag pattern: '^([a-zA-Z0-9_-]+-(\\d+\\.\\d+\\.\\d+)|v(\\d+\\.\\d+\\.\\d+)|(\\d+\\.\\d+\\.\\d+))$', comparator: "REGEXP" }
-        // for now since testing only handles simple string, start with that
+        when { buildingTag() }
         environment {
           DOCKER = credentials("${config.credentials}")
         }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -18,7 +18,7 @@ def call(String imageName, Map config=[:]) {
   pipeline {
     agent {
       kubernetes {
-        label 'helmfile'
+        label 'build-publish-docker'
         inheritFrom 'jnlp-linux'
         yaml """
 apiVersion: "v1"


### PR DESCRIPTION
Use username and password login for docker since that what infra.ci has now
Build any tag, we don't need to restrict it (yet)
Not a helmfile node, but a build docker image node 