### PR TITLE
Add up to 10 retries with 10 seconds between for incrementals publishing

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -271,11 +271,11 @@ void maybePublishIncrementals() {
                 withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
                     if (isUnix()) {
                         sh '''
-curl -i -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://jenkins-community-functions.azurewebsites.net/api/incrementals-publisher?clientId=default&code=$FUNCTION_TOKEN" || echo 'Problem calling Incrementals deployment function'
+curl --retry 10 --retry-delay 10 -i -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://jenkins-community-functions.azurewebsites.net/api/incrementals-publisher?clientId=default&code=$FUNCTION_TOKEN" || echo 'Problem calling Incrementals deployment function'
                         '''
                     } else {
                         bat '''
-curl.exe -i -H "Content-Type: application/json" -d "{""build_url"":""%BUILD_URL%""}" "https://jenkins-community-functions.azurewebsites.net/api/incrementals-publisher?clientId=default&code=%FUNCTION_TOKEN%" || echo Problem calling Incrementals deployment function
+curl.exe --retry 10 --retry-delay 10 -i -H "Content-Type: application/json" -d "{""build_url"":""%BUILD_URL%""}" "https://jenkins-community-functions.azurewebsites.net/api/incrementals-publisher?clientId=default&code=%FUNCTION_TOKEN%" || echo Problem calling Incrementals deployment function
                         '''
                     }
                 }


### PR DESCRIPTION
We have seen where incrementals publishing can result in 503 errors for some builds. This adds up to 10 retries with 10 seconds in between (arbitrary numbers) to hopefully alleviate the 503 issue.