### PR TITLE
Use --no-transfer-progress instead of Slf4j listener setting

### DIFF
--- a/resources/settings-azure.xml
+++ b/resources/settings-azure.xml
@@ -32,14 +32,5 @@
                 </pluginRepository>
             </pluginRepositories>
         </profile>
-        <profile>
-            <id>silent-artifact-download</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>warn</org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>
-            </properties>
-        </profile>
     </profiles>
 </settings>

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -26,7 +26,7 @@ def call(Map params = [:]) {
             if (configData.ath != null && !configData.ath.disabled) {
                 stage("Run ATH") {
                     dir("ath") {
-                        runATH jenkins: customWarURI, metadataFile: metadataPath, javaOptions: ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn", testPluginResolution]
+                        runATH jenkins: customWarURI, metadataFile: metadataPath, javaOptions: [testPluginResolution]
                     }
                 }
             }

--- a/vars/essentialsTest.groovy
+++ b/vars/essentialsTest.groovy
@@ -26,7 +26,7 @@ def call(Map params = [:]) {
             if (configData.ath != null && !configData.ath.disabled) {
                 stage("Run ATH") {
                     dir("ath") {
-                        runATH jenkins: customWarURI, metadataFile: metadataPath, javaOptions: [testPluginResolution]
+                        runATH jenkins: customWarURI, metadataFile: metadataPath, javaOptions: ['--no-transfer-progress', testPluginResolution]
                     }
                 }
             }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -79,7 +79,7 @@ Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = nu
         '--batch-mode',
         '--show-version',
         '--errors',
-        '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn',
+        '--no-transfer-progress',
     ]
     if (settingsFile != null) {
         mvnOptions += "-s $settingsFile"

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -12,7 +12,7 @@ def call(Map params = [:]) {
     def jdks = params.get('jdks', [8])
     def athContainerImageTag = params.get("athImage", "jenkins/ath");
     def configFile = params.get("configFile", null)
-    def defaultJavaOptions = params.get('javaOptions', ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"])
+    def defaultJavaOptions = params.get('javaOptions', [])
 
     def mirror = "http://mirrors.jenkins.io/"
     def defaultCategory = "org.jenkinsci.test.acceptance.junit.SmokeTest"
@@ -146,7 +146,7 @@ def call(Map params = [:]) {
                         if (supportedBrowsers.contains(browser)) {
                             def currentBrowser = browser
 
-                            def commandBase = "./run.sh ${currentBrowser} ./jenkins.war -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.test.failure.ignore=true -DforkCount=1 -Dsurefire.rerunFailingTestsCount=${rerunCount}"
+                            def commandBase = "./run.sh ${currentBrowser} ./jenkins.war -B -ntp -Dmaven.test.failure.ignore=true -DforkCount=1 -Dsurefire.rerunFailingTestsCount=${rerunCount}"
 
                             if (testsToRun) {
                                 testingbranches["ATH individual tests-${currentBrowser}-jdk${currentJdk}"] = {

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -12,7 +12,7 @@ def call(Map params = [:]) {
     def jdks = params.get('jdks', [8])
     def athContainerImageTag = params.get("athImage", "jenkins/ath");
     def configFile = params.get("configFile", null)
-    def defaultJavaOptions = params.get('javaOptions', [])
+    def defaultJavaOptions = params.get('javaOptions', ['--no-transfer-progress'])
 
     def mirror = "http://mirrors.jenkins.io/"
     def defaultCategory = "org.jenkinsci.test.acceptance.junit.SmokeTest"

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -10,7 +10,7 @@ def call(Map params = [:]) {
     def metadataFile = params.get('metadataFile', 'essentials.yml')
     def jenkins = params.get('jenkins', 'latest')
     def pctExtraOptions = params.get('pctExtraOptions', [])
-    def javaOptions = params.get('javaOptions', ["-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"])
+    def javaOptions = params.get('javaOptions', [])
     def dockerOptions = params.get('dockerOptions', [])
     def jdkVersion = params.get('jdkVersion', '8')
 

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -10,7 +10,7 @@ def call(Map params = [:]) {
     def metadataFile = params.get('metadataFile', 'essentials.yml')
     def jenkins = params.get('jenkins', 'latest')
     def pctExtraOptions = params.get('pctExtraOptions', [])
-    def javaOptions = params.get('javaOptions', [])
+    def javaOptions = params.get('javaOptions', ['--no-transfer-progress'])
     def dockerOptions = params.get('dockerOptions', [])
     def jdkVersion = params.get('jdkVersion', '8')
 
@@ -157,4 +157,3 @@ def call(Map params = [:]) {
 
     })
 }
-


### PR DESCRIPTION
## Use --no-transfer-progress instead of Slf4j listener setting

The build logs do not need to be cluttered with reports of artifact download progress.  We silenced those messages previously by adjusting the warning level of `Slf4jMavenTransferListener`.

Apache Maven 3.6.2 provides the `-ntp` command line argument (`--no-transfer-progress`) more simply.

See https://issues.jenkins-ci.org/browse/INFRA-2080 for details.

I confirmed by searching plugin build logs on ci.jenkins.io that the last time a plugin build on ci.jenkins.io used a version of maven older than 3.6.2 was Feb 2020.