### PR TITLE
Adding 15m timeout to maybePublishIncrementals

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -267,6 +267,7 @@ void prepareToPublishIncrementals() {
 void maybePublishIncrementals() {
     if (isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
+          timeout(15) {
             node('maven || linux || windows') {
                 withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
                     if (isUnix()) {
@@ -280,6 +281,7 @@ curl.exe --retry 10 --retry-delay 10 -i -H "Authorization: Bearer %FUNCTION_TOKE
                     }
                 }
             }
+          }
         }
     } else {
         echo 'Skipping deployment to Incrementals'


### PR DESCRIPTION
https://github.com/jenkinsci/bom/pull/319 restored Incrementals publishing in that component, and now in https://ci.jenkins.io/job/Tools/job/bom/job/PR-320/4/flowGraphTable/ I see https://ci.jenkins.io/computer/EC2%20(aws)%20-%20Windows%202019%20(i-00f85dbdf3c9d5129)/ hung for nearly two hours. (I am not authorized to look at this node’s actual status or logs so I cannot tell what is wrong with it.) At any rate, publishing Incrementals is designed to be a best effort, so we should cap how long it spends.