### PR TITLE
Update recentLTS

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -305,7 +305,7 @@ List<Map<String, String>> getConfigurations(Map params) {
  * Includes testing Java 8 and 11 on the newest LTS.
  */
 static List<Map<String, String>> recommendedConfigurations() {
-    def recentLTS = "2.164.1"
+    def recentLTS = "2.176.4"
     def configurations = [
         // Intentionally test configurations which have detected the most problems
         // Linux - Java 8 with plugin specified minimum Jenkins version


### PR DESCRIPTION
A few plugins that are common dependencies do not work with the previous recentLTS value. This updates to a more recent LTS version number.