### PR TITLE
Chore/pipeline unit update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <!-- Dependency versions -->
         <groovy.version>2.4.17</groovy.version>
         <junit.version>4.13.1</junit.version>
-        <jenkins-pipeline-unit.version>1.4</jenkins-pipeline-unit.version>
+        <jenkins-pipeline-unit.version>1.8</jenkins-pipeline-unit.version>
         <groovy-eclipse-compiler.version>3.4.0-01</groovy-eclipse-compiler.version>
     </properties>
 

--- a/test/groovy/BaseTest.groovy
+++ b/test/groovy/BaseTest.groovy
@@ -15,7 +15,7 @@ class BaseTest extends BasePipelineTest {
   @Override
   void setUp() throws Exception {
     super.setUp()
-    
+
     binding.setVariable('env', env)
     binding.setProperty('scm', new String())
     binding.setProperty('buildPlugin', loadScript('vars/buildPlugin.groovy'))
@@ -36,7 +36,6 @@ class BaseTest extends BasePipelineTest {
       updateBuildStatus('FAILURE')
       throw new Exception(s)
     })
-    helper.registerAllowedMethod('fileExists', [String.class], { s -> s })
     helper.registerAllowedMethod('fingerprint', [String.class], { s -> s })
     helper.registerAllowedMethod('git', [String.class], { 'OK' })
     helper.registerAllowedMethod('hasDockerLabel', [], { true })
@@ -47,7 +46,6 @@ class BaseTest extends BasePipelineTest {
     helper.registerAllowedMethod('parallel', [Map.class, Closure.class], { l, body -> body() })
     helper.registerAllowedMethod('pwd', [], { '/foo' })
     helper.registerAllowedMethod('pwd', [Map.class], { '/bar' })
-    helper.registerAllowedMethod('readFile', [String.class], { s -> s })
     helper.registerAllowedMethod('readYaml', [Map.class], {
       Yaml yaml = new Yaml()
       return yaml.load('')
@@ -78,7 +76,7 @@ class BaseTest extends BasePipelineTest {
     helper.registerAllowedMethod('milestone', [String.class], { true })
     helper.registerAllowedMethod('milestone', [Integer.class], { true }) // actually String but apparently this mock does not handle stock Groovy coercion?
   }
-  
+
   def assertMethodCallContainsPattern(String methodName, String pattern) {
     return helper.callStack.findAll { call ->
       call.methodName == methodName

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -14,6 +14,8 @@ class BuildPluginStepTests extends BaseTest {
   @Before
   void setUp() throws Exception {
     super.setUp()
+    // It is expected to be on Maven by default. Override this behavior when you need to specialize
+    helper.registerAllowedMethod('fileExists', [String.class], { s -> return s.equals('pom.xml') })
     env.NODE_LABELS = 'docker'
     env.JOB_NAME = 'build/plugin/test'
     binding.setVariable('BUILD_NUMBER', '1')
@@ -303,8 +305,10 @@ class BuildPluginStepTests extends BaseTest {
   void test_buildPlugin_with_configurations_and_incrementals() throws Exception {
     def script = loadScript(scriptName)
     // when running with incrementals
-    helper.registerAllowedMethod('fileExists', [String.class], { s -> return s.equals('.mvn/extensions.xml') })
-    helper.registerAllowedMethod('readFile', [String.class], { return 'git-changelist-maven-extension' })
+    helper.registerAllowedMethod('fileExists', [String.class], { s ->
+      return s.equals('.mvn/extensions.xml') || s.equals('pom.xml')
+    })
+    helper.addReadFileMock('.mvn/extensions.xml', 'git-changelist-maven-extension')
     // and no jenkins version
     script.call(configurations: [['platform': 'linux', 'jdk': 8, 'jenkins': null, 'javaLevel': null]])
     printCallStack()

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -1,4 +1,4 @@
-#!/usr/bin/env groovy 
+#!/usr/bin/env groovy
 //TODO(oleg_nenashev): This thing is not simple anymore. I suggest reworking it to a config YAML
 // which would be compatible with essentials.yml (INFRA-1673)
 /**


### PR DESCRIPTION
The goal of this change request is to bump the JenkinsPipelineUnit dependency to version `1.8`.

The reason of this change is to allow testing and mocking around Kubernetes agents, as per the [`jenkinsci/JenkinsPipelineUnit` 1.8 changelog](https://github.com/jenkinsci/JenkinsPipelineUnit/releases/tag/v1.8).

By upgrading JenkinsPipelineUnit, some tests of `BuildPluginStepTests` broke: the 2nd commit of this change request fixes this by:

- Relying on the default mock behavior from PipelineUnit instead of the custom `BaseTest.groovy` for the methods `fileExists` (should return `false` by default) and `readFile` (should return "empty string")
-  Define a specific mock for the method `fileExists` when the argument is `pom.xml` in the the whole `BuildPluginStepTests` class.
  - Most of the tests of this class are expecting a "Build with Maven" case 
  - The "non maven" tests are already overriding the mock behavior to return false
  - Any other usage of the `fileExists` would require a custom test with an explicit behavior
- Fix the `test_buildPlugin_with_configurations_and_incrementals` to explicitly defines the conditional branches to be met. 