### PR TITLE
Chore: Allow running tests with OpenJDK 11 and 15: bump Groovy and Junit dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -126,7 +126,7 @@ buildPluginWithGradle(/*...*/, configurations: buildPlugin.recommendedConfigurat
 
 ==== Limitations
 
-Not all features of `buildPlugin()` for Maven are supported in the gradle flow. 
+Not all features of `buildPlugin()` for Maven are supported in the gradle flow.
 Examples of not supported features:
 
 * Deployment of incremental versions (link:https://github.com/jenkinsci/jep/tree/master/jep/305[JEP-305])
@@ -336,9 +336,9 @@ The PCT revision to use in case that pctUrl points to a github destination, can 
  A String indicating the file path (relative to where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. *Defaults to `essentials.yml` at the location where this step is invoked*
 `jenkins`::
  URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. *Can be overriden from the metadata file*
-`pctExtraOptions`:: 
+`pctExtraOptions`::
  List of extra PCT options to be passed to the PCT executable. Defaults to empty list.
-`javaOptions`:: 
+`javaOptions`::
  List of extra Java options to be passed to the PCT executable. Defaults to empty list.
 `dockerOptions`::
  List of extra options to be passed to PCT containers ( e.g. `maven-repo:/root/.m2`)
@@ -420,7 +420,8 @@ Supported parameters:
 (Optional) If `artifacts` is not null, invokes `archiveArtifacts` with the given string value.
 
 
-===== Example
+==== Example
+
 [source, groovy]
 ----
 runBenchmarks('jmh-report.json')
@@ -447,8 +448,7 @@ Name of the docker image to build
 registry: override the smart default of jenkinsciinfra/ or jenkins4eval/
 dockerfile: override the default dockerfile of Dockerfile
 
-
-===== Example
+==== Example
 [source, groovy]
 ----
 buildDockerImage_k8s('plugins-site-api')
@@ -457,3 +457,12 @@ buildDockerImage_k8s('plugins-site-api')
 === Design documents for runATH and runPCT
 
 The design and some more details about the runATH and runPCT steps can be found link:https://wiki.jenkins.io/display/JENKINS/runATH+and+runPCT+step+design[here]
+
+== Contribute
+
+=== Requirements
+
+* (Open)JDK v8
+* Maven 3.6.x
+
+=== 

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,10 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <!-- Dependency versions -->
-        <groovy.version>2.4.17</groovy.version>
+        <groovy.version>3.0.7</groovy.version>
         <junit.version>4.13.1</junit.version>
         <jenkins-pipeline-unit.version>1.8</jenkins-pipeline-unit.version>
-        <groovy-eclipse-compiler.version>3.4.0-01</groovy-eclipse-compiler.version>
+        <groovy-eclipse-compiler.version>3.6.0-03</groovy-eclipse-compiler.version>
     </properties>
 
     <dependencies>
@@ -43,6 +43,8 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>
+            <!-- Type pom replaces the über "groovy-all.jar", for version 3+ -->
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -95,7 +97,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-batch</artifactId>
-                        <version>2.5.7-01</version>
+                        <version>3.0.7-02</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <!-- Dependency versions -->
         <groovy.version>3.0.7</groovy.version>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>5.7.0</junit.version>
         <jenkins-pipeline-unit.version>1.8</jenkins-pipeline-unit.version>
         <groovy-eclipse-compiler.version>3.6.0-03</groovy-eclipse-compiler.version>
     </properties>
@@ -48,8 +48,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This PR allows executing the library's unit tests (`mvn clean test`) when you have a recent OpenJDK (11 or 15).

It involves bumping the Groovy dependency (and associated compiler sub-dependencies) to 3.x (instead of 2.x), as well as Junit to 5.x.

Please note that the `pom.xml` is still specifying a compile target as `1.8` as before of course.