### PR TITLE
Bump JDK from 8 to 11 for the CI execution 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 pipeline {
     agent {
-        label "maven"
+        label "maven-11"
     }
     options {
         timestamps()


### PR DESCRIPTION
This PR follows up https://github.com/jenkins-infra/pipeline-library/pull/173.

It changes the label of the CI agent of the pipeline in order to use JDK11 instead of JDK 1.8.

Please not that, as per https://github.com/jenkins-infra/documentation/blob/352a54adf1c3710a2c1061426dab64315378b4a8/ci.adoc , JDK15 is not yet available.

Signed-off-by: dduportal <damien.duportal@gmail.com>