### PR TITLE
fix: regression when determining docker registry name

### DIFF
--- a/src/io/jenkins/infra/DockerConfig.groovy
+++ b/src/io/jenkins/infra/DockerConfig.groovy
@@ -36,7 +36,7 @@ class DockerConfig {
   }
 
   String getFullImageName() {
-    return getRegistry() + "/" + imageName
+    return (getRegistry().endsWith('/') ? getRegistry() : getRegistry() + '/') + imageName
   }
 
   // Custom getter to avoid declaring NonCPS method called from constructor


### PR DESCRIPTION
slight regression in the pipeline library when overridding the registry
name for docker builds.  Previously the user was expected to include a
trailing slash at the end of the registry name, this is no longer expected.

An example of the previous usage can be seen https://github.com/garethjevans/jenkins-image/blob/05a56a379a63c43955f28163e0be44662246ada8/Jenkinsfile#L1