### PR TITLE
feat: support passing of platform into img builds

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -39,6 +39,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(DOCKERFILE) and export it 
 		--label "org.label-schema.vcs-ref=$(GIT_COMMIT_REV)" \
 		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
 		--label "org.label-schema.build-date=$(BUILD_DATE)" \
+		--platform $(PLATFORM) \
 		-f $(PWD)/$(DOCKERFILE) \
 		./
 	@$(CONTAINER_BIN) save --output=$(IMAGE_ARCHIVE) $(IMAGE_NAME)

--- a/src/io/jenkins/infra/DockerConfig.groovy
+++ b/src/io/jenkins/infra/DockerConfig.groovy
@@ -19,6 +19,8 @@ class DockerConfig {
 
   def infraConfig
 
+  String platform
+
   public DockerConfig(String imageName, InfraConfig infraConfig, Map config=[:]) {
     this.imageName = imageName
 
@@ -33,6 +35,8 @@ class DockerConfig {
     this.mainBranch = config.get('mainBranch', 'master')
 
     this.buildDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(new Date())
+
+    this.platform = config.get('platform', 'linux/amd64')
   }
 
   String getFullImageName() {

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -38,6 +38,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       getDockerfile{ 'Dockerfile' }
       getCredentials{ '' }
       getImageName{ 'deathstar' }
+      getPlatform{ 'linux/amd64' }
     }
   }
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -30,6 +30,7 @@ def call(String imageName, Map config=[:]) {
       BUILD_DATE = "${dockerConfig.buildDate}"
       IMAGE_NAME = "${dockerConfig.imageName}"
       DOCKERFILE = "${dockerConfig.dockerfile}"
+      PLATFORM   = "${dockerConfig.platform}"
     } // environment
 
     stages {

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -13,7 +13,8 @@
           (Valid examples: "jenkinsci", "registry.quay.io/jenkins-beta", "10.0.2.15:8080/admin").</li>
           <li>String mainBranch: (Optional, defaults to "master") Name of the git's principal branch used to trigger deploy of the "latest" tag (Example: "main").</li>
           <li>String dockerfile: (Optional, defaults to "Dockerfile") Relative path to the Dockerfile to use within the repository's context (Example: "build.dockerfile", "docker/Dockerfile").</li>
-          <li>String credentials: (Optional, defaults to "jenkins-dockerhub") Name of the Jenkins'credentials used to authenticate on the Docker remote registry during the full build process. (Example: "internal-registry-credential").</li>
+          <li>String credentials: (Optional, defaults to "jenkins-dockerhub") Name of the Jenkins' credentials used to authenticate on the Docker remote registry during the full build process. (Example: "internal-registry-credential").</li>
+          <li>String platform: (Optional, defaults to "linux/amd64") Name of the docker platform to use when building this image, for multiple use a comma separated list (Example: "linux/amd64,linux/arm64").</li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
This will default to `linux/amd64` but can be overridden.

Signed-off-by: Gareth Evans <gareth@bryncynfelin.co.uk>