### PR TITLE
feat: allow build metadata to be calculated from a script

### DIFF
--- a/src/io/jenkins/infra/DockerConfig.groovy
+++ b/src/io/jenkins/infra/DockerConfig.groovy
@@ -25,6 +25,8 @@ class DockerConfig {
 
   String gitCredentials
 
+  String metadataFromSh
+
   public DockerConfig(String imageName, InfraConfig infraConfig, Map config=[:]) {
     this.imageName = imageName
 
@@ -45,6 +47,8 @@ class DockerConfig {
     this.automaticSemanticVersioning = config.get('automaticSemanticVersioning', false)
     
     this.gitCredentials = config.get('gitCredentials', '')
+
+    this.metadataFromSh = config.get('metadataFromSh', '')
   }
 
   String getFullImageName() {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -46,6 +46,10 @@ def call(String imageName, Map config=[:]) {
           container('next-version') {
             script {
               nextVersion = sh(script:'jx-release-version', returnStdout: true).trim()
+              if (dockerConfig.metadataFromSh != '') {
+                metadata = sh(script: "${dockerConfig.metadataFromSh}", returnStdout: true).trim()
+                nextVersion = nextVersion + metadata
+              }
             }
           }
           echo "Next Release Version = $nextVersion"

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -15,6 +15,8 @@
           <li>String dockerfile: (Optional, defaults to "Dockerfile") Relative path to the Dockerfile to use within the repository's context (Example: "build.dockerfile", "docker/Dockerfile").</li>
           <li>String credentials: (Optional, defaults to "jenkins-dockerhub") Name of the Jenkins' credentials used to authenticate on the Docker remote registry during the full build process. (Example: "internal-registry-credential").</li>
           <li>String platform: (Optional, defaults to "linux/amd64") Name of the docker platform to use when building this image, for multiple use a comma separated list (Example: "linux/amd64,linux/arm64").</li>
+          <li>Boolean automaticSemanticVersioning: (Optional, defaults to "false") Should we create a release for every merge to the mainBranch.  This uses "jx-release-version" to determine the version number based on the commit history.</li>
+          <li>String metadataFromSh: (Optional, defaults to "") If "automaticSemanticVersioning" is set, use a script to calculate the build metadata to be appended to the generated version.</li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
This is used when `automaticSemanticVersioning` is configured, as an example it can be used to calculate the build metadata to be appended to the calculated  next version.

e.g. 

To determine a version from a parent dockerfile, the following could be used:

```
metadataFromSh: 'cat Dockerfile | grep FROM | sed "s|FROM jenkins/jenkins:|+|"'
```

this will calculate something like:

```
+2.280
```

which will be appended to the new version as follows:

```
1.1.0+2.280
```