### PR TITLE
Allow `buildDockerAndPublish` library to be called multiple times on a single pipeline build

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -1,12 +1,16 @@
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= $(IMAGE_NAME)
-DOCKERFILE ?= Dockerfile
-IMAGE_ARCHIVE ?= $(PWD)/image.tar
+IMAGE_DIR ?= $(PWD)
+IMAGE_DOCKERFILE ?= $(IMAGE_DIR)/Dockerfile
+IMAGE_ARCHIVE ?= $(IMAGE_DIR)/image.tar
+IMAGE_PLATFORM ?= linux/amd64
+HADOLINT_REPORT ?= $(IMAGE_DIR)/hadolint.json
+TEST_HARNESS ?= $(IMAGE_DIR)/cst.yml
 
 ## Use this variable if you want to use Docker instead
 CONTAINER_BIN ?= img
-PLATFORM ?= linux/amd64
+
 
 ## Image metadatas
 GIT_COMMIT_REV ?= $(shell git log -n 1 --pretty=format:'%h')
@@ -19,14 +23,14 @@ help: ## Show this Makefile's help
 
 all: clean lint build test ## Execute the complete process except the "deploy" step
 
-lint: ## Lint the $(DOCKERFILE) content
-	@echo "== Linting $(PWD)/$(DOCKERFILE)..."
-	@echo "Writing Lint results to $(PWD)/hadolint.json"
-	@hadolint --format=json $(PWD)/$(DOCKERFILE) > $(PWD)/hadolint.json
+lint: ## Lint the $(IMAGE_DOCKERFILE) content
+	@echo "== Linting $(IMAGE_DOCKERFILE)..."
+	@echo "Writing Lint results to $(HADOLINT_REPORT)"
+	@hadolint --format=json $(IMAGE_DOCKERFILE) > $(HADOLINT_REPORT)
 	@echo "== Lint ✅ Succeeded"
 
-build: ## Build the Docker Image $(IMAGE_NAME) from $(DOCKERFILE) and export it to $(IMAGE_ARCHIVE)
-	@echo "== Building $(IMAGE_NAME) from $(PWD)/$(DOCKERFILE)..."
+build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE) and export it to $(IMAGE_ARCHIVE)
+	@echo "== Building $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)..."
 	@$(CONTAINER_BIN) build \
 		-t $(IMAGE_NAME) \
 		--build-arg "GIT_COMMIT_REV=$(GIT_COMMIT_REV)" \
@@ -40,21 +44,20 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(DOCKERFILE) and export it 
 		--label "org.label-schema.vcs-ref=$(GIT_COMMIT_REV)" \
 		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
 		--label "org.label-schema.build-date=$(BUILD_DATE)" \
-		--platform $(PLATFORM) \
-		-f $(PWD)/$(DOCKERFILE) \
-		$(PWD)
+		--platform $(IMAGE_PLATFORM) \
+		-f $(IMAGE_DOCKERFILE) \
+		$(IMAGE_DIR)
 	@$(CONTAINER_BIN) save --output=$(IMAGE_ARCHIVE) $(IMAGE_NAME)
 	@echo "== Build ✅ Succeeded, image $(IMAGE_NAME) exported to $(IMAGE_ARCHIVE)."
 
 clean: ## Delete any file generated during the build steps
 	@echo "== Cleaning working directory from generated artefacts..."
-	@rm -f $(PWD)/*.tar $(PWD)/hadolint.json
+	@rm -f $(IMAGE_DIR)/*.tar $(HADOLINT_REPORT)
 	@echo "== Cleanup ✅ Succeeded"
 
 test: ## Execute the test harness on the Docker Image archive at $(IMAGE_ARCHIVE)
-	@echo "== Testing $(IMAGE_NAME) from $(IMAGE_ARCHIVE)..."
-	@echo "Writing test report to $(PWD)/cst-result.xml..."
-	@container-structure-test test --driver=tar --image=$(IMAGE_ARCHIVE) --config=$(PWD)/cst.yml
+	@echo "== Test $(IMAGE_NAME) with $(TEST_HARNESS) from $(IMAGE_ARCHIVE)..."
+	@container-structure-test test --driver=tar --image=$(IMAGE_ARCHIVE) --config=$(TEST_HARNESS)
 	@echo "== Test ✅ Succeeded"
 
 ## This steps expects that you are logged to the Docker registry to push image into

--- a/resources/io/jenkins/infra/docker/pod-template.yml
+++ b/resources/io/jenkins/infra/docker/pod-template.yml
@@ -5,7 +5,6 @@ metadata:
   labels:
     jenkins: "agent"
     job/kind: "docker-image-build"
-    docker-image/name: "${IMAGE_NAME}"
   annotations:
     container.apparmor.security.beta.kubernetes.io/builder: unconfined
     container.seccomp.security.alpha.kubernetes.io/builder: unconfined

--- a/src/io/jenkins/infra/DockerConfig.groovy
+++ b/src/io/jenkins/infra/DockerConfig.groovy
@@ -29,6 +29,8 @@ class DockerConfig {
 
   String nextVersionCommand
 
+  String dockerImageDir
+
   public DockerConfig(String imageName, InfraConfig infraConfig, Map config=[:]) {
     this.imageName = imageName
 
@@ -45,14 +47,16 @@ class DockerConfig {
     this.buildDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(new Date())
 
     this.platform = config.get('platform', 'linux/amd64')
-    
+
     this.automaticSemanticVersioning = config.get('automaticSemanticVersioning', false)
-    
+
     this.gitCredentials = config.get('gitCredentials', '')
 
     this.metadataFromSh = config.get('metadataFromSh', '')
 
     this.nextVersionCommand = config.get('nextVersionCommand', 'jx-release-version')
+
+    this.dockerImageDir = config.imageDir
   }
 
   String getFullImageName() {
@@ -63,5 +67,11 @@ class DockerConfig {
   String getRegistry() {
     def reg = registry ?: infraConfig?.dockerRegistry ?: 'noregistry'
     return reg.endsWith('/') ? reg[0..-2] : reg
+  }
+
+  String getDockerImageDir() {
+    def childFile = new File(this.dockerfile)
+    def parentDir = childFile.getParentFile() ?: new File('.')
+    return  dockerImageDir ?: parentDir.getPath()
   }
 }

--- a/test/groovy/io/jenkins/infra/DockerConfigTest.groovy
+++ b/test/groovy/io/jenkins/infra/DockerConfigTest.groovy
@@ -28,6 +28,7 @@ class DockerConfigTest {
         assertEquals( 'master', dockerConfig.mainBranch)
         assertEquals( 'jenkins-dockerhub', dockerConfig.credentials)
         assertEquals( 'Dockerfile', dockerConfig.dockerfile)
+        assertEquals( '.', dockerConfig.getDockerImageDir())
     }
 
 
@@ -66,7 +67,8 @@ class DockerConfigTest {
           dockerConfig = new DockerConfig(testImageName, new InfraConfig(), [
             dockerfile: 'build.Dockerfile',
             credentials: 'company-docker-registry-credz',
-            mainBranch: 'main'
+            mainBranch: 'main',
+            imageDir: 'docker/'
           ])
         }
 
@@ -75,6 +77,7 @@ class DockerConfigTest {
         assertEquals( 'main', dockerConfig.mainBranch)
         assertEquals( 'company-docker-registry-credz', dockerConfig.credentials)
         assertEquals( 'build.Dockerfile', dockerConfig.dockerfile)
+        assertEquals( 'docker/', dockerConfig.getDockerImageDir())
     }
 
 }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -9,9 +9,7 @@ def call(String imageName, Map config=[:]) {
 
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
-  final String podYamlTemplate = libraryResource 'io/jenkins/infra/docker/pod-template.yml'
-  // Customize Pod label to improve build analysis
-  final String yamlPodDef = podYamlTemplate.replaceAll('\\$IMAGE_NAME', imageName).replaceAll('\\$?\\{IMAGE_NAME\\}', imageName)
+  final String yamlPodDef      = libraryResource 'io/jenkins/infra/docker/pod-template.yml'
 
   final boolean semVerEnabled = dockerConfig.automaticSemanticVersioning && env.BRANCH_NAME == dockerConfig.mainBranch
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -109,8 +109,17 @@ def call(String imageName, Map config=[:]) {
 
           if (env.TAG_NAME || env.BRANCH_NAME == dockerConfig.mainBranch) {
             stage("Deploy ${dockerImageName}") {
-              def docker_image_tag = env.TAG_NAME ? env.TAG_NAME : 'latest'
-              sh "IMAGE_DEPLOY_NAME=${dockerConfig.getFullImageName()}:${docker_image_tag} make deploy"
+              def imageDeployName = dockerConfig.getFullImageName()
+
+              if(env.TAG_NAME) {
+                // User could specify a tag in the image name. In that case the git tag is appended. Otherwise the docker tag is set to the git tag.
+                if(imageDeployName.contains(':')) {
+                  imageDeployName += "-${env.TAG_NAME}"
+                } else {
+                  imageDeployName += ":${env.TAG_NAME}"
+                }
+              }
+              sh "IMAGE_DEPLOY_NAME=${imageDeployName} make deploy"
             } //stage
           } // if
         } // withEnv

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -7,15 +7,17 @@
     The following arguments are available for this function:
     <ul>
       <li>String imageName: (Mandatory) name of the image to built, usually referenced as the "Repository" part of a Docker image's name without any tag (Example: "builder" or "terraform").</li>
-      <li>Map config: (Optionnal) custom configuration for the image build an deploy process. The maps can holds any of the following keys:
+      <li>Map config: (Optional) custom configuration for the image build an deploy process. The maps can holds any of the following keys:
         <ul>
           <li>String registry: (Optional, defaults to "registry-1.docker.io/jenkinsciinfra") Registry reference of the Docker image to be published. It might contains hostname, port and "namespace".
           (Valid examples: "jenkinsci", "registry.quay.io/jenkins-beta", "10.0.2.15:8080/admin").</li>
           <li>String mainBranch: (Optional, defaults to "master") Name of the git's principal branch used to trigger deploy of the "latest" tag (Example: "main").</li>
-          <li>String dockerfile: (Optional, defaults to "Dockerfile") Relative path to the Dockerfile to use within the repository's context (Example: "build.dockerfile", "docker/Dockerfile").</li>
+          <li>String dockerfile: (Optional, defaults to "Dockerfile") Relative path to the Dockerfile to use within the repository (Example: "build.dockerfile", "docker/Dockerfile").</li>
+          <li>String imageDir: (Optional, defaults to the parent directory of "Dockerfile") Path to a directory to use as build context (Example: "docker/", "python/2.7").</li>
           <li>String credentials: (Optional, defaults to "jenkins-dockerhub") Name of the Jenkins' credentials used to authenticate on the Docker remote registry during the full build process. (Example: "internal-registry-credential").</li>
           <li>String platform: (Optional, defaults to "linux/amd64") Name of the docker platform to use when building this image, for multiple use a comma separated list (Example: "linux/amd64,linux/arm64").</li>
-          <li>Boolean automaticSemanticVersioning: (Optional, defaults to "false") Should we create a release for every merge to the mainBranch.  This uses "jx-release-version" to determine the version number based on the commit history.</li>
+          <li>Boolean automaticSemanticVersioning: (Optional, defaults to "false") Should we create a release for every merge to the mainBranch. This uses "jx-release-version" to determine the version number based on the commit history.</li>
+          <li>String gitCredentials: (Optional, defaults to "") If "automaticSemanticVersioning" is set, name of the credential to use when tagging the git repository. Support User/password or GitHub App credential types.</li>
           <li>String metadataFromSh: (Optional, defaults to "") If "automaticSemanticVersioning" is set, use a script to calculate the build metadata to be appended to the generated version.</li>
         </ul>
       </li>
@@ -46,6 +48,37 @@
       <li>A push event on the repository's principal branch referenced by "config.mainBranch".</li>
       <li>A tag event on the repository.</li>
     </ul>
+
+    <b>Example Usages</b>
+
+    <pre><code>
+    buildDockerAndPublishImage('terraform', [
+      mainBranch: 'main',
+      dockerfile: 'docker/Dockerfile',
+      registry: 'docker4eval'
+    ])
+    </code></pre>
+
+    <pre><code>
+    parallel(
+      failFast: true,
+      'docker': {
+        buildDockerAndPublishImage('docker', [
+          dockerfile: 'docker/Dockerfile',
+        ])
+      },
+      'golang': {
+        buildDockerAndPublishImage('golang', [
+          dockerfile: 'golang/Dockerfile',
+        ])
+      },
+      'coreruntime-2.2': {
+        buildDockerAndPublishImage('coreruntime-2.2', [
+          dockerfile: 'coreruntime/22/Dockerfile',
+        ])
+      },
+    )
+    </code></pre>
 </p>
 
 <!--


### PR DESCRIPTION
This Pull requests allow to define different Docker images to be built for a given repository, or to add custom pipeline code around the library call.

Usage example (also added to the library's txt internal doc):

```groovy
properties([
  buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')),
  pipelineTriggers([cron('@daily')]),
])

def registryName = 'dduportal'
def principalBranch = 'main'

parallel(
  failFast: true,
  'docker': {
     buildDockerAndPublishImage('docker', [
      mainBranch: principalBranch,
      dockerfile: 'docker/Dockerfile',
      registry: registryName,
    ])
  },
  'coreruntime-2.2': {
     buildDockerAndPublishImage('coreruntime-2.2', [
      mainBranch: principalBranch,
      dockerfile: 'coreruntime/22/Dockerfile',
      registry: registryName,
    ])
  },
)
```

In particular, this PR changed the following:

* Switch pipeline syntax to scripted for `buildDockerAndPublishImage.groovy`
* Introduce a new input parameter `imageDir` to specify the Docker build context when required (defaults to the directory containing the specified `Dockerfile`)
* Updating stage names (showing the image name) and the recordIssue (hadolint) step to handle multiple calls on a single build
* Introduce a new kind of (optional) test harness: "Common test", which expects a file `common-cst.yml` to be present at the repository's root. The existing `cst.yml` is renamed to "Image Specific test", and the file is expected to be found on the `imageDir` directory
* Support images where the tag is specified in the provided Docker Image Name (example: `jenkins-infra/coreruntime:2.2`). It's a simple and not smart support: the git tag is appended with an hyphen instead of a colon.

