### PR TITLE
feat: make next version command configurable

### DIFF
--- a/resources/io/jenkins/infra/docker/pod-template.yml
+++ b/resources/io/jenkins/infra/docker/pod-template.yml
@@ -25,7 +25,7 @@ spec:
         memory: "512Mi"
         cpu: "500m"
     - name: next-version
-      image: gcr.io/jenkinsxio/jx-release-version:2.2.3
+      image: gcr.io/jenkinsxio/jx-release-version:2.2.6
       command:
         - cat
       tty: true

--- a/src/io/jenkins/infra/DockerConfig.groovy
+++ b/src/io/jenkins/infra/DockerConfig.groovy
@@ -27,6 +27,8 @@ class DockerConfig {
 
   String metadataFromSh
 
+  String nextVersionCommand
+
   public DockerConfig(String imageName, InfraConfig infraConfig, Map config=[:]) {
     this.imageName = imageName
 
@@ -49,6 +51,8 @@ class DockerConfig {
     this.gitCredentials = config.get('gitCredentials', '')
 
     this.metadataFromSh = config.get('metadataFromSh', '')
+
+    this.nextVersionCommand = config.get('nextVersionCommand', 'jx-release-version')
   }
 
   String getFullImageName() {

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -55,6 +55,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       getMetadataFromSh{ '' }
       getFullImageName { 'jenkinsciinfra/deathstar' }
       getAutomaticSemanticVersioning{ false }
+      getNextVersionCommand{ 'jx-release-version' }
     }
     infraConfig.use {
       dockerConfig.use {
@@ -104,6 +105,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       getMainBranch{ 'master' }
       getMainBranch{ 'master' }
       getAutomaticSemanticVersioning{ true }
+      getNextVersionCommand{ 'jx-release-version' }
       getMetadataFromSh{ '' }
       getGitCredentials{ 'git-credentials' }
       getFullImageName { 'jenkinsciinfra/deathstar' }
@@ -168,6 +170,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       getMetadataFromSh{ metadataSh }
       getGitCredentials{ 'git-credentials' }
       getFullImageName { 'jenkinsciinfra/deathstar' }
+      getNextVersionCommand{ 'jx-release-version' }
     }
     infraConfig.use {
       dockerConfig.use {
@@ -224,6 +227,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       getMetadataFromSh{ '' }
       getFullImageName { 'registry.company.com/deathstar' }
       getAutomaticSemanticVersioning{ false }
+      getNextVersionCommand{ 'jx-release-version' }
     }
     infraConfig.use {
       dockerConfig.use {
@@ -262,6 +266,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       getMetadataFromSh{ '' }
       getFullImageName { 'testregistry/deathstar' }
       getAutomaticSemanticVersioning{ false }
+      getNextVersionCommand{ 'jx-release-version' }
     }
     infraConfig.use {
       dockerConfig.use {
@@ -331,6 +336,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       getMainBranch{ 'master' }
       getFullImageName { 'registry.company.com/deathstar' }
       getAutomaticSemanticVersioning{ false }
+      getNextVersionCommand{ 'jx-release-version' }
       getMetadataFromSh{ '' }
     }
     infraConfig.use {
@@ -436,6 +442,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       getMainBranch{ 'master' }
       getMainBranch{ 'master' }
       getAutomaticSemanticVersioning{ false }
+      getNextVersionCommand{ 'jx-release-version' }
       getMetadataFromSh{ '' }
     }
     infraConfig.use {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -45,7 +45,7 @@ def call(String imageName, Map config=[:]) {
         steps {
           container('next-version') {
             script {
-              nextVersion = sh(script:'jx-release-version', returnStdout: true).trim()
+              nextVersion = sh(script:"${dockerConfig.nextVersionCommand}", returnStdout: true).trim()
               if (dockerConfig.metadataFromSh != '') {
                 metadata = sh(script: "${dockerConfig.metadataFromSh}", returnStdout: true).trim()
                 nextVersion = nextVersion + metadata


### PR DESCRIPTION
Make the  command to be run to determine the next version configurable.  Whilst most scenarios will probably be fine with the default `jx-release-version`, it may be required to use something a little more complex like `jx-release-version -next-version=semantic:strip-prerelease`