### PR TITLE
Validate readyness for release

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -86,6 +86,7 @@ def call(Map params = [:]) {
                                         '-Dspotbugs.failOnError=false',
                                         '-Dcheckstyle.failOnViolation=false',
                                         '-Dcheckstyle.failsOnError=false',
+                                        '-Pjenkins-release',
                                 ]
                                 // jacoco had file locking issues on Windows, so only running on linux
                                 if (isUnix()) {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -108,7 +108,7 @@ def call(Map params = [:]) {
                                 if (skipTests) {
                                     mavenOptions += "-DskipTests"
                                 }
-                                mavenOptions += "clean install"
+                                mavenOptions += "clean verify"
                                 try {
                                     infra.runMaven(mavenOptions, jdk, null, null, addToolEnv)
                                 } finally {


### PR DESCRIPTION
With the current build process, for plugins using Maven, it can happen that the CI is not detecting that the code is not valid for a release. Which means that, maintainers cannot trust the CI when they want to perform a release (issues can happen).

With this changeset, the PR and main branch of the repositories would be validated to see if the content of the repository is good enough for to be released.