### PR TITLE
chore(deps): bump jx-release-version to 2.3.4

### DIFF
--- a/resources/io/jenkins/infra/docker/pod-template.yml
+++ b/resources/io/jenkins/infra/docker/pod-template.yml
@@ -25,7 +25,7 @@ spec:
         memory: "512Mi"
         cpu: "500m"
     - name: next-version
-      image: gcr.io/jenkinsxio/jx-release-version:2.2.6
+      image: gcr.io/jenkinsxio/jx-release-version:2.3.4
       command:
         - cat
       tty: true


### PR DESCRIPTION
This version contains the fix for handling merge commits corrected which should give us the correct version bumps for the docker-jenkins-* repositories.