### PR TITLE
Feat: add a new 'updatecli()' shared library

### DIFF
--- a/resources/io/jenkins/infra/updatecli/pod-template.yml
+++ b/resources/io/jenkins/infra/updatecli/pod-template.yml
@@ -1,0 +1,25 @@
+---
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  labels:
+    jenkins: "agent"
+    job/kind: "updatecli"
+spec:
+  restartPolicy: "Never"
+  containers:
+    - name: "updatecli"
+      image: "ghcr.io/updatecli/updatecli:v0.2.0" #"UPDATECLI_DOCKER_IMAGE"
+      imagePullPolicy: "IfNotPresent"
+      command:
+        - sleep
+      args:
+        - 1d
+      resources:
+        limits:
+          memory: "128Mi"
+          cpu: "200m"
+        requests:
+          memory: "128Mi"
+          cpu: "200m"
+...

--- a/test/groovy/BaseTest.groovy
+++ b/test/groovy/BaseTest.groovy
@@ -76,6 +76,11 @@ class BaseTest extends DeclarativePipelineTest {
     helper.registerAllowedMethod('writeYaml', [Map.class], { })
     helper.registerAllowedMethod('milestone', [String.class], { true })
     helper.registerAllowedMethod('milestone', [Integer.class], { true }) // actually String but apparently this mock does not handle stock Groovy coercion?
+
+    // Kubernetes Agents in scripted syntax
+    helper.registerAllowedMethod('podTemplate', [Map.class, Closure.class], { m, body ->body() })
+    helper.registerAllowedMethod('container', [String.class, Closure.class], { s, body ->body() })
+    binding.setVariable('POD_LABEL', 'builder')
   }
 
   def assertMethodCallContainsPattern(String methodName, String pattern) {

--- a/test/groovy/UpdatecliStepTests.groovy
+++ b/test/groovy/UpdatecliStepTests.groovy
@@ -1,0 +1,115 @@
+
+
+import org.junit.Before
+import org.junit.Test
+import groovy.mock.interceptor.StubFor
+
+import io.jenkins.infra.*
+import com.lesfurets.jenkins.unit.declarative.*
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
+
+class UpdatecliStepTests extends BaseTest {
+  static final String scriptName = "vars/updatecli.groovy"
+  Map env = [:]
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+
+    // Mock Pipeline method which are not already declared in the parent class
+    helper.registerAllowedMethod('libraryResource', [String.class], { '' })
+  }
+
+  @Test
+  void itRunSuccessfullyWithDefault() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling with the "updatecli" function with default configuration
+    script.call()
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // With the static files read as expected
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/updatecli/pod-template.yml'))
+
+    // And the repository checkouted
+    assertTrue(assertMethodCallContainsPattern('checkout', ''))
+
+    // And only the diff command called with default values
+    assertTrue(assertMethodCallContainsPattern('sh','updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.yaml'))
+    assertFalse(assertMethodCallContainsPattern('sh','updatecli apply'))
+  }
+
+  @Test
+  void itRunSuccessfullyWithCustomAction() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling with the "updatecli" function with a custom action "eat"
+    script.call(action: 'eat')
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // With the static files read as expected
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/updatecli/pod-template.yml'))
+
+    // And the repository checkouted
+    assertTrue(assertMethodCallContainsPattern('checkout',''))
+
+    // And only the custom command called with default values
+    assertFalse(assertMethodCallContainsPattern('sh','updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.yaml'))
+    assertTrue(assertMethodCallContainsPattern('sh','updatecli eat --config ./updatecli/updatecli.d --values ./updatecli/values.yaml'))
+  }
+
+  @Test
+  void itRunSuccessfullyWithCustomConfigAndEmptyValues() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling with the "updatecli" function with a custom config and an empty values
+    script.call(config: './ops/config.yml', values: '')
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // With the static files read as expected
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/updatecli/pod-template.yml'))
+
+    // And the repository checkouted
+    assertTrue(assertMethodCallContainsPattern('checkout',''))
+
+    // And only the default command called with custom config and NO values
+    assertTrue(assertMethodCallContainsPattern('sh','updatecli diff --config ./ops/config.yml'))
+    assertFalse(assertMethodCallContainsPattern('sh','--values'))
+  }
+
+  @Test
+  void itRunSuccessfullyWithEmptyConfigAndCustomValues() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling with the "updatecli" function with a custom config and an empty values
+    script.call(values: './values.yaml', config: '')
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // With the static files read as expected
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/updatecli/pod-template.yml'))
+
+    // And the repository checkouted
+    assertTrue(assertMethodCallContainsPattern('checkout',''))
+
+    // And only the default command called with custom config and NO values
+    assertTrue(assertMethodCallContainsPattern('sh','updatecli diff --values ./values.yaml'))
+    assertFalse(assertMethodCallContainsPattern('sh','--config'))
+  }
+}

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -7,8 +7,8 @@ def call(userConfig = [:]) {
     updatecliDockerImage: 'ghcr.io/updatecli/updatecli:latest',
   ]
 
-  // No Deep Merge - https://e.printstacktrace.blog/how-to-merge-two-maps-in-groovy/
-  final Map finalConfig = defaultConfig + userConfig
+  // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
+  final Map finalConfig = defaultConfig << userConfig
 
   // final String podYamlTemplate = libraryResource 'io/jenkins/infra/docker/pod-template.yml'
   // Customize Pod label to improve build analysis

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -1,0 +1,34 @@
+
+def call(userConfig = [:]) {
+  def defaultConfig = [
+    action: 'diff',
+    config: './updatecli/updatecli.d',
+    values: './updatecli/values.yaml',
+    updatecliDockerImage: 'ghcr.io/updatecli/updatecli:latest',
+  ]
+
+  // No Deep Merge - https://e.printstacktrace.blog/how-to-merge-two-maps-in-groovy/
+  final Map finalConfig = defaultConfig + userConfig
+
+  // final String podYamlTemplate = libraryResource 'io/jenkins/infra/docker/pod-template.yml'
+  // Customize Pod label to improve build analysis
+  final String yamlPodDef = libraryResource 'io/jenkins/infra/updatecli/pod-template.yml' // podYamlTemplate.replaceAll('\\$IMAGE_NAME', imageName).replaceAll('\\$?\\{IMAGE_NAME\\}', imageName)
+
+  def updatecliCommand = 'updatecli ' +  finalConfig.action
+  // Do not add the flag "--config" if the provided value is "empty string"
+  updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ''
+  // Do not add the flag "--values" if the provided value is "empty string"
+  updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ''
+
+
+  podTemplate(yaml: yamlPodDef) {
+    node(POD_LABEL) {
+      container('updatecli') {
+        stage("Updatecli: ${finalConfig.action}") {
+          checkout scm
+          sh updatecliCommand
+        }// stage
+      } // container
+    } // node
+  } // podTemplate
+}

--- a/vars/updatecli.txt
+++ b/vars/updatecli.txt
@@ -1,0 +1,41 @@
+
+<p>
+    Execute <a href="https://www.updatecli.io/updatecli" target="_blank">updatecli</a> on the repository.
+
+    <p>
+    The following arguments are available for this function:
+    <ul>
+      <li>String action: (Optional - Default: "diff") Updatecli action (e.g. subcommand) to execute.</li>
+      <li>String config: (Optional - Default: "./updatecli/updatecli.d") path to the file or directory with the updatecli configuration (flag "--config").</li>
+      <li>String values: (Optional - Default: "./updatecli/values.yaml") path to the file with the updatecli values (flag "--values").</li>
+      <li>String updatecliDockerImage: (Optional - Default: "ghcr.io/updatecli/updatecli:latest") Docker Image of updatecli to be used in the process.</li>
+    </ul>
+
+    Examples:
+
+    <pre><code>
+    // Run the "updatecli diff" command
+    updatecli()
+    </code></pre>
+
+    <pre><code>
+    // updatecli can use the environment variable "UPDATECLI_GITHUB_TOKEN" as a token source to allow GitHub access (both API reads and PR creation)
+    withCredentials([string(credentialsId: 'github-credential-with-write-access', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
+      updatecli(
+        // Run the "updatecli apply" command
+        action: "apply"
+        // Configuration of updatecli is stored in the file "updateci.yaml" at the repository's root
+        config: "./updateci.yaml",
+        // No values flag to be passed
+        values: "",
+      )
+    }
+    </code></pre>
+
+
+    </p>
+</p>
+
+<!--
+vim: ft=html
+-->


### PR DESCRIPTION
This PR adds a new shared library to allow executing `updatecli` in your pipelines.

Example:

```groovy
@Library('pipeline-library@pull/200/head') _

parallel(
  failFast: true,
  'docker-image': {
    // Do something...
  },
  'updatecli': {
    withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
      updatecli(action: 'diff')
      if (env.BRANCH_NAME == 'main') {
        updatecli(action: 'apply')
      }
    }
  },
)
```
