### PR TITLE
Deprecating `javaLevel`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,7 @@ buildPlugin()
 buildPlugin(/*...*/, configurations: [
   [ platform: "linux", jdk: "8", jenkins: null ],
   [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: "2.150", javaLevel: 8 ]
+  [ platform: "linux", jdk: "11", jenkins: "2.150" ]
 ])
 ----
 
@@ -131,7 +131,7 @@ Examples of not supported features:
 
 * Deployment of incremental versions (link:https://github.com/jenkinsci/jep/tree/master/jep/305[JEP-305])
 * Publishing of static analysis and coverage reports (Checkstyle, SpotBugs, JaCoCo)
-* Configuring `jenkinsVersion` and `javaLevel` for the build flow (as standalone arguments or as `configurations`)
+* Configuring `jenkinsVersion` for the build flow (as standalone arguments or as `configurations`)
 * Usage of link:https://azure.microsoft.com/en-us/services/container-instances/[Azure Container Instances] as agents (only Maven agents are configured)
 
 === infra.isTrusted()

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -74,8 +74,8 @@ class BuildPluginStepTests extends BaseTest {
     def script = loadScript(scriptName)
     def configurations = script.getConfigurations([:])
 
-    def expected = [['platform': 'linux', 'jdk': '8', 'jenkins': null, 'javaLevel': null],
-                    ['platform': 'windows', 'jdk': '8', 'jenkins': null, 'javaLevel': null]]
+    def expected = [['platform': 'linux', 'jdk': '8', 'jenkins': null],
+                    ['platform': 'windows', 'jdk': '8', 'jenkins': null]]
     assertEquals(expected, configurations)
     printCallStack()
     assertJobStatusSuccess()
@@ -310,7 +310,7 @@ class BuildPluginStepTests extends BaseTest {
     })
     helper.addReadFileMock('.mvn/extensions.xml', 'git-changelist-maven-extension')
     // and no jenkins version
-    script.call(configurations: [['platform': 'linux', 'jdk': 8, 'jenkins': null, 'javaLevel': null]])
+    script.call(configurations: [['platform': 'linux', 'jdk': 8, 'jenkins': null]])
     printCallStack()
     // then it runs the fingerprint
     assertTrue(assertMethodCallContainsPattern('fingerprint', '**/*-rc*.*/*-rc*.*'))

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -27,7 +27,9 @@ def call(Map params = [:]) {
         String label = config.platform
         String jdk = config.jdk
         String jenkinsVersion = config.jenkins
-        String javaLevel = config.javaLevel
+        if (config.javaLevel != null) {
+            echo 'WARNING: javaLevel is deprecated and should not be used'
+        }
 
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
         boolean first = tasks.size() == 1
@@ -100,9 +102,6 @@ def call(Map params = [:]) {
                                 }
                                 if (jenkinsVersion) {
                                     mavenOptions += "-Djenkins.version=${jenkinsVersion} -Daccess-modifier-checker.failOnError=false"
-                                }
-                                if (javaLevel) {
-                                    mavenOptions += "-Djava.level=${javaLevel}"
                                 }
                                 if (skipTests) {
                                     mavenOptions += "-DskipTests"
@@ -299,8 +298,7 @@ List<Map<String, String>> getConfigurations(Map params) {
                 ret << [
                         "platform": p,
                         "jdk": jdk,
-                        "jenkins": jenkins,
-                        "javaLevel": null   // not supported in the old format
+                        "jenkins": jenkins
                 ]
             }
         }
@@ -321,10 +319,10 @@ static List<Map<String, String>> recommendedConfigurations() {
         // Linux - Java 11 with recent LTS
         [ platform: "linux", jdk: "8", jenkins: null ],
         // [ platform: "windows", jdk: "8", jenkins: null ],
-        // [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
-        // [ platform: "windows", jdk: "11", jenkins: recentLTS, javaLevel: "8" ]
+        // [ platform: "linux", jdk: "8", jenkins: recentLTS ],
+        [ platform: "windows", jdk: "8", jenkins: recentLTS ],
+        [ platform: "linux", jdk: "11", jenkins: recentLTS ],
+        // [ platform: "windows", jdk: "11", jenkins: recentLTS ]
     ]
     return configurations
 }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -28,7 +28,7 @@ def call(Map params = [:]) {
         String jdk = config.jdk
         String jenkinsVersion = config.jenkins
         if (config.containsKey('javaLevel')) {
-            echo 'WARNING: javaLevel is deprecated and should not be used'
+            echo 'WARNING: Ignoring deprecated "javaLevel" parameter. This parameter should be removed from your "Jenkinsfile".'
         }
 
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -27,7 +27,7 @@ def call(Map params = [:]) {
         String label = config.platform
         String jdk = config.jdk
         String jenkinsVersion = config.jenkins
-        if (config.javaLevel != null) {
+        if (config.containsKey('javaLevel')) {
             echo 'WARNING: javaLevel is deprecated and should not be used'
         }
 


### PR DESCRIPTION
For years now `java.level` has been mandatory in the POM (https://github.com/jenkinsci/plugin-pom/pull/88) and this is something intrinsic to the source code, not something you would ever want to override for a particular build; it will almost always need to stay fixed at `8`. (Not to be confused with the JDK version, which you may switch to `11` to test against Java 11.) Thus it is silly to redundantly specify `javaLevel: 8` in your `Jenkinsfile`.
