### PR TITLE
Run `fingerprint` for non-plugin JEP-305 deployments

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -260,6 +260,7 @@ void prepareToPublishIncrementals() {
     String version = sh script: 'mvn -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate', returnStdout: true
     echo "Collecting $version from $m2repo for possible Incrementals publishing"
     dir(m2repo) {
+        fingerprint '**/*-rc*.*/*-rc*.*' // includes any incrementals consumed
         archiveArtifacts "**/$version/*$version*"
     }
 }


### PR DESCRIPTION
To match https://github.com/jenkins-infra/pipeline-library/blob/db4df33e3defe15f718f050999a9a832ccd52186/vars/buildPlugin.groovy#L228.

Note that this will not cover JEP-229-style deps, which do not use the `-rc` infix.