### PR TITLE
Simplify incrementals publishing

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -277,7 +277,7 @@ void maybePublishIncrementals() {
                         contentType: 'APPLICATION_JSON',
                         validResponseCodes: '100:599',
                         timeout: 300,
-                        requestBody: '{"build_url":"'$BUILD_URL'"}',
+                        requestBody: /{"build_url":"$BUILD_URL"}/,
                         authentication: 'incrementals-publisher-token'
         }
     } else {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -272,13 +272,16 @@ void prepareToPublishIncrementals() {
 void maybePublishIncrementals() {
     if (new InfraConfig(env).isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
-            httpRequest url: 'https://incrementals.jenkins.io/',
-                        httpMode: 'POST',
-                        contentType: 'APPLICATION_JSON',
-                        validResponseCodes: '100:599',
-                        timeout: 300,
-                        requestBody: /{"build_url":"$BUILD_URL"}/,
-                        authentication: 'incrementals-publisher-token'
+            withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
+                httpRequest 
+                    url: 'https://incrementals.jenkins.io/',
+                    httpMode: 'POST',
+                    contentType: 'APPLICATION_JSON',
+                    validResponseCodes: '100:599',
+                    timeout: 300,
+                    requestBody: /{"build_url":"$BUILD_URL"}/,
+                    customHeaders: [[maskValue: true, name: 'Authorization', value: 'Bearer ${FUNCTION_TOKEN}']]
+            }
         }
     } else {
         echo 'Skipping deployment to Incrementals'

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -279,7 +279,7 @@ void maybePublishIncrementals() {
                     validResponseCodes: '100:599',
                     timeout: 300,
                     requestBody: /{"build_url":"$BUILD_URL"}/,
-                    customHeaders: [[name: 'Authorization', value: 'Bearer ${FUNCTION_TOKEN}']],
+                    customHeaders: [[name: 'Authorization', value: 'Bearer $FUNCTION_TOKEN']],
                     consoleLogResponseBody: true
             }
         }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -273,8 +273,7 @@ void maybePublishIncrementals() {
     if (new InfraConfig(env).isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
             withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
-                httpRequest 
-                    url: 'https://incrementals.jenkins.io/',
+                httpRequest url: 'https://incrementals.jenkins.io/',
                     httpMode: 'POST',
                     contentType: 'APPLICATION_JSON',
                     validResponseCodes: '100:599',

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -273,7 +273,7 @@ void maybePublishIncrementals() {
     if (new InfraConfig(env).isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
             httpRequest url: 'https://incrementals.jenkins.io/',
-                        httpMode: 'POST'
+                        httpMode: 'POST',
                         contentType: 'APPLICATION_JSON',
                         validResponseCodes: '100:599',
                         timeout: 300,

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -279,7 +279,8 @@ void maybePublishIncrementals() {
                     validResponseCodes: '100:599',
                     timeout: 300,
                     requestBody: /{"build_url":"$BUILD_URL"}/,
-                    customHeaders: [[maskValue: true, name: 'Authorization', value: 'Bearer ${FUNCTION_TOKEN}']]
+                    customHeaders: [[maskValue: true, name: 'Authorization', value: 'Bearer ${FUNCTION_TOKEN}']],
+                    consoleLogResponseBody: true
             }
         }
     } else {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -279,7 +279,7 @@ void maybePublishIncrementals() {
                     validResponseCodes: '100:599',
                     timeout: 300,
                     requestBody: /{"build_url":"$BUILD_URL"}/,
-                    customHeaders: [[maskValue: true, name: 'Authorization', value: 'Bearer ${FUNCTION_TOKEN}']],
+                    customHeaders: [[name: 'Authorization', value: 'Bearer ${FUNCTION_TOKEN}']],
                     consoleLogResponseBody: true
             }
         }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -279,7 +279,7 @@ void maybePublishIncrementals() {
                     validResponseCodes: '100:599',
                     timeout: 300,
                     requestBody: /{"build_url":"$BUILD_URL"}/,
-                    customHeaders: [[name: 'Authorization', value: 'Bearer $FUNCTION_TOKEN']],
+                    customHeaders: [[name: 'Authorization', value: 'Bearer ' + FUNCTION_TOKEN]],
                     consoleLogResponseBody: true
             }
         }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -272,23 +272,13 @@ void prepareToPublishIncrementals() {
 void maybePublishIncrementals() {
     if (new InfraConfig(env).isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
-          timeout(300) {
-            node('maven || linux || windows') {
-                timeout(15) {
-                    withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
-                        if (isUnix()) {
-                            sh '''
-    curl --retry 10 --retry-delay 10 -i -H "Authorization: Bearer $FUNCTION_TOKEN" -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://incrementals.jenkins.io/" || echo 'Problem calling Incrementals deployment function'
-                            '''
-                        } else {
-                            bat '''
-    curl.exe --retry 10 --retry-delay 10 -i -H "Authorization: Bearer %FUNCTION_TOKEN%" -H "Content-Type: application/json" -d "{""build_url"":""%BUILD_URL%""}" "https://incrementals.jenkins.io/" || echo Problem calling Incrementals deployment function
-                            '''
-                        }
-                    }
-                }
-            }
-          }
+            httpRequest url: 'https://incrementals.jenkins.io/',
+                        httpMode: 'POST'
+                        contentType: 'APPLICATION_JSON',
+                        validResponseCodes: '100:599',
+                        timeout: 300,
+                        requestBody: '{"build_url":"'$BUILD_URL'"}',
+                        authentication: 'incrementals-publisher-token'
         }
     } else {
         echo 'Skipping deployment to Incrementals'

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -272,17 +272,19 @@ void prepareToPublishIncrementals() {
 void maybePublishIncrementals() {
     if (new InfraConfig(env).isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
         stage('Deploy') {
-          timeout(15) {
+          timeout(300) {
             node('maven || linux || windows') {
-                withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
-                    if (isUnix()) {
-                        sh '''
-curl --retry 10 --retry-delay 10 -i -H "Authorization: Bearer $FUNCTION_TOKEN" -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://incrementals.jenkins.io/" || echo 'Problem calling Incrementals deployment function'
-                        '''
-                    } else {
-                        bat '''
-curl.exe --retry 10 --retry-delay 10 -i -H "Authorization: Bearer %FUNCTION_TOKEN%" -H "Content-Type: application/json" -d "{""build_url"":""%BUILD_URL%""}" "https://incrementals.jenkins.io/" || echo Problem calling Incrementals deployment function
-                        '''
+                timeout(15) {
+                    withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
+                        if (isUnix()) {
+                            sh '''
+    curl --retry 10 --retry-delay 10 -i -H "Authorization: Bearer $FUNCTION_TOKEN" -H 'Content-Type: application/json' -d '{"build_url":"'$BUILD_URL'"}' "https://incrementals.jenkins.io/" || echo 'Problem calling Incrementals deployment function'
+                            '''
+                        } else {
+                            bat '''
+    curl.exe --retry 10 --retry-delay 10 -i -H "Authorization: Bearer %FUNCTION_TOKEN%" -H "Content-Type: application/json" -d "{""build_url"":""%BUILD_URL%""}" "https://incrementals.jenkins.io/" || echo Problem calling Incrementals deployment function
+                            '''
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I've had a number of failures on incrementals publishing from remoting errors, causing long core builds to fail and CD releases not to happen
