### PR TITLE
feat: add a new global library 'withRetryAndTimeout' to allow circuit breaking pipeline steps

### DIFF
--- a/vars/withRetryAndTimeout.groovy
+++ b/vars/withRetryAndTimeout.groovy
@@ -9,11 +9,10 @@ def call(Map userConfig = [:], Closure body) {
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
   final Map finalConfig = defaultConfig << userConfig
 
-  def counter = 0
+  def counter = 1
 
   // From https://issues.jenkins.io/browse/JENKINS-51454?focusedCommentId=389893&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-389893
   retry(finalConfig.retries) {
-    counter += 1
     try {
       timeout(time: finalConfig.bodyTimeout, unit: finalConfig.bodyTimeoutUnit) {
         withEnv(["PIPELINE_RETRY_COUNTER=${counter}"]) {
@@ -26,6 +25,7 @@ def call(Map userConfig = [:], Closure body) {
         throw ex
       }
       throw new RuntimeException(ex)
+      counter += 1
     }
   }
 }

--- a/vars/withRetryAndTimeout.groovy
+++ b/vars/withRetryAndTimeout.groovy
@@ -20,7 +20,7 @@ def call(Map userConfig = [:], Closure body) {
         }
       }
     } catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException ex){
-      def causes = ex.getCauses()
+      def causes = ex.causes
       if(causes.find { ! (it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout) }) {
         throw ex
       }

--- a/vars/withRetryAndTimeout.groovy
+++ b/vars/withRetryAndTimeout.groovy
@@ -1,0 +1,31 @@
+
+def call(Map userConfig = [:], Closure body) {
+  def defaultConfig = [
+    retries: 3,
+    bodyTimeout: 10,
+    bodyTimeoutUnit: 'MINUTES',
+  ]
+
+  // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
+  final Map finalConfig = defaultConfig << userConfig
+
+  def counter = 0
+
+  // From https://issues.jenkins.io/browse/JENKINS-51454?focusedCommentId=389893&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-389893
+  retry(finalConfig.retries) {
+    counter += 1
+    try {
+      timeout(time: finalConfig.bodyTimeout, unit: finalConfig.bodyTimeoutUnit) {
+        withEnv(["PIPELINE_RETRY_COUNTER=${counter}"]) {
+          body()
+        }
+      }
+    } catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException ex){
+      def causes = ex.getCauses()
+      if(causes.find { ! (it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout) }) {
+        throw ex
+      }
+      throw new RuntimeException(ex)
+    }
+  }
+}

--- a/vars/withRetryAndTimeout.groovy
+++ b/vars/withRetryAndTimeout.groovy
@@ -22,10 +22,12 @@ def call(Map userConfig = [:], Closure body) {
     } catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException ex){
       def causes = ex.causes
       if(causes.find { ! (it instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution$ExceededTimeout) }) {
+        // Only increment when timeout is reached, it's the only path to a retry
+        counter += 1
         throw ex
       }
       throw new RuntimeException(ex)
-      counter += 1
+
     }
   }
 }


### PR DESCRIPTION
This PR provide a circuit breaker of type "retry with timeout per retry" library.

Its initial case it to ensure that some of the jenkins-infra's docker builds involving network operations were not blocking (e.g. 10 min timeout before failing the step), but retrying a few times before really failing the job.

Ref. https://issues.jenkins.io/browse/JENKINS-51454

Please note that there are incoming PRs on the Jenkins Pipeline-related plugins that would allow using pure `retry` and `timeout` methods instead of try/catch: the library would have to be reconsidered or updated and better tested at this moment.

Another added value of this library: an environment variable `PIPELINE_RETRY_COUNTER` is injected to hold the retry counter's values (e.g. "how many retries?"). This value can be used by consumer to identify uniquely some resources such as warning-ng reports.