### PR TITLE
[JENKINS-43353] Use new `disableConcurrentBuilds/abortPrevious` project option

### DIFF
--- a/test/groovy/BaseTest.groovy
+++ b/test/groovy/BaseTest.groovy
@@ -74,8 +74,6 @@ class BaseTest extends DeclarativePipelineTest {
     helper.registerAllowedMethod('withCredentials', [List.class, Closure.class], { list, body -> body() })
     helper.registerAllowedMethod('withEnv', [List.class, Closure.class], { list, body -> body() })
     helper.registerAllowedMethod('writeYaml', [Map.class], { })
-    helper.registerAllowedMethod('milestone', [String.class], { true })
-    helper.registerAllowedMethod('milestone', [Integer.class], { true }) // actually String but apparently this mock does not handle stock Groovy coercion?
 
     // Kubernetes Agents in scripted syntax
     helper.registerAllowedMethod('podTemplate', [Map.class, Closure.class], { m, body ->body() })

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -18,7 +18,6 @@ class BuildPluginStepTests extends BaseTest {
     helper.registerAllowedMethod('fileExists', [String.class], { s -> return s.equals('pom.xml') })
     env.NODE_LABELS = 'docker'
     env.JOB_NAME = 'build/plugin/test'
-    binding.setVariable('BUILD_NUMBER', '1')
   }
 
   @Test

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -3,10 +3,9 @@
  * Simple wrapper step for building a plugin
  */
 def call(Map params = [:]) {
-    def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber) // JENKINS-43353 / JENKINS-58625
-
     // Faster build and reduces IO needs
     properties([
+        disableConcurrentBuilds(abortPrevious: true),
         durabilityHint('PERFORMANCE_OPTIMIZED'),
         buildDiscarder(logRotator(numToKeepStr: '5')),
     ])


### PR DESCRIPTION
If https://github.com/jenkinsci/workflow-job-plugin/pull/200 is merged and released and ci.jenkins.io updated, simplify the cancellation of older running builds.
