### PR TITLE
Remove pointless call to `retrieveMavenSettingsFile`

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -88,12 +88,6 @@ Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = nu
     ]
     if (settingsFile != null) {
         mvnOptions += "-s $settingsFile"
-    } else if (jdk.toInteger() > 7 && new InfraConfig(env).isRunningOnJenkinsInfra()) {
-        /* Azure mirror only works for sufficiently new versions of the JDK due to Letsencrypt cert */
-        def settingsXml = "${pwd tmp: true}/settings-azure.xml"
-        if (retrieveMavenSettingsFile(settingsXml)) {
-            mvnOptions += "-s $settingsXml"
-        }
     }
     mvnOptions.addAll(options)
     mvnOptions.unique()


### PR DESCRIPTION
A bit of cleanup forgotten in #216.