### PR TITLE
chore: bump jx-release-version to version 2.4.13

### DIFF
--- a/io/jenkins/infra/docker/jxNextVersionImage
+++ b/io/jenkins/infra/docker/jxNextVersionImage
@@ -1,0 +1,1 @@
+ghcr.io/jenkins-x/jx-release-version:2.4.13

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -34,7 +34,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
 
     // Mock Pipeline method which are not already declared in the parent class
     helper.registerAllowedMethod('hadoLint', [Map.class], { m -> m })
-    helper.registerAllowedMethod('libraryResource', [String.class], { '' })
+    helper.registerAllowedMethod('libraryResource', [String.class], { s -> s == 'io/jenkins/infra/docker/jxNextVersionImage' ? 'jx-release-version:1.2.3' : '' })
     helper.registerAllowedMethod('fileExists', [String.class], { true })
     addEnvVar('WORKSPACE', '/tmp')
 
@@ -97,7 +97,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
 
     // And the correct pod template defined
     assertTrue(assertMethodCallContainsPattern('containerTemplate', 'jenkinsciinfra/builder:latest'))
-    assertTrue(assertMethodCallContainsPattern('containerTemplate', 'gcr.io/jenkinsxio/jx-release-version:2.3.4'))
+    assertTrue(assertMethodCallContainsPattern('containerTemplate', 'jx-release-version:1.2.3'))
 
     // And the make target called as shell steps
     assertTrue(assertMethodCallContainsPattern('sh','make lint'))

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -10,6 +10,7 @@ def call(String imageName, Map config=[:]) {
 
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
+  final String defaultNextVersionImage = libraryResource 'io/jenkins/infra/docker/jxNextVersionImage'
   final boolean semVerEnabled = dockerConfig.automaticSemanticVersioning && env.BRANCH_NAME == dockerConfig.mainBranch
 
   final String dockerImageName = dockerConfig.imageName
@@ -33,7 +34,7 @@ def call(String imageName, Map config=[:]) {
       ),
       containerTemplate(
         name: 'next-version',
-        image: config.nextVersionImage ?: 'gcr.io/jenkinsxio/jx-release-version:2.3.4',
+        image: config.nextVersionImage ?: defaultNextVersionImage,
         command: 'cat',
         ttyEnabled: true,
         resourceRequestCpu: '200m',


### PR DESCRIPTION
This PR applies https://github.com/jenkins-infra/docker-jenkins-weekly/pull/273 to the whole "docker build" library so that everyone benefits from this bump.

It includes a Docker image naming change and factorize the default value in a simple text file to allow an easy updatecli configuration on this one.
