### PR TITLE
Auto update jx next version

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,32 @@
+---
+name: updatecli
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run once per day
+    - cron: '* 0 * * *'
+  push:
+  pull_request:
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Diff
+        uses: updatecli/updatecli-action@v1
+        with:
+          command: diff
+          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Apply
+        uses: updatecli/updatecli-action@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          command: apply
+          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -4,8 +4,8 @@ name: updatecli
 on:
   workflow_dispatch:
   schedule:
-    # Run once per day
-    - cron: '* 0 * * *'
+    # Every monday
+    - cron: '* * * * 1'
   push:
   pull_request:
 jobs:

--- a/updatecli/updatecli.d/jx-next-version.yml
+++ b/updatecli/updatecli.d/jx-next-version.yml
@@ -1,0 +1,32 @@
+---
+title: "Bump jx-release-version version"
+sources:
+  default:
+    kind: githubRelease
+    name: Get the latest jx-release-version version
+    spec:
+      owner: "jenkins-x-plugins"
+      repository: "jx-release-version"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimPrefix: "v"
+      - addPrefix: "ghcr.io/jenkins-x/jx-release-version:"
+targets:
+  updateJxReleaseVersion:
+    name: Update jx-release-version in file
+    sourceID: default
+    kind: file
+    spec:
+      file: io/jenkins/infra/docker/jxNextVersionImage
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "updatebot"
+  email: "updatebot@olblak.com"
+  username: "jenkins-infra-bot"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  owner: "jenkins-infra"
+  repository: "packer-images"


### PR DESCRIPTION
This PR depends on #224 .

It enables updatecli (in Github action) to allow an automatic weekly update of the "ops components" (e.g. the component un supported by dependendabot that are conigured with an updatecli YAML manifest)