### PR TITLE
Fix [infra.groovy] Correct the JDK searcher + fallback to tools

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -152,7 +152,7 @@ Object runWithJava(String command, String jdk = 8, List<String> extraEnv = null,
             if (!isUnix()) {
                 javaBinToTry += '.exe' // On windows, binaries have an extension
             }
-            if(fileExists(javaBinToTry)) {
+            if (fileExists(javaBinToTry)) {
                 javaHome = javaHomeToTry
                 break
             }


### PR DESCRIPTION
After the change #231 some builds were broken on VM agents to a buggy behaviors (the JDK location map was specifying path to java bin instead of hava home dir).

Example of broken build reported by @MarkEWaite : https://ci.jenkins.io/job/Plugins/job/folder-properties-plugin/job/PR-8/4/console.

This PRs aims at fixing this issue.

It also introduces the following changes:

- Re-introduce the use of the Jenkins JDK tools as a fallback (to avoid breaking builds as we keep the tools configured)
- Try to factorize the code to improve readbility

Validated on https://ci.jenkins.io/job/Plugins/job/folder-properties-plugin/job/PR-8/31/.