### PR TITLE
feat [infra] allow runMaven with an integer for JDK version

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -79,7 +79,7 @@ boolean retrieveMavenSettingsFile(String settingsXml, String jdk = 8) {
  * @return nothing
  * @see #retrieveMavenSettingsFile(String)
  */
-Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = true) {
+Object runMaven(List<String> options, String jdk = "8", List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = true) {
     List<String> mvnOptions = [
         '--batch-mode',
         '--show-version',
@@ -93,6 +93,19 @@ Object runMaven(List<String> options, String jdk = 8, List<String> extraEnv = nu
     mvnOptions.unique()
     String command = "mvn ${mvnOptions.join(' ')}"
     runWithMaven(command, jdk, extraEnv, addToolEnv)
+}
+
+/**
+ * Runs Maven for the specified options in the current workspace.
+ * Maven settings will be added by default if needed.
+ * @param Major version of JDK to be used (integer)
+ * @param options Options to be passed to the Maven command
+ * @param extraEnv Extra environment variables to be passed when invoking the command
+ * @return nothing
+ * @see #retrieveMavenSettingsFile(String)
+ */
+Object runMaven(List<String> options, Integer jdk, List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = true) {
+    runMaven(options, jdk.toString(), extraEnv, settingsFile, addToolEnv)
 }
 
 /**


### PR DESCRIPTION
While working on https://github.com/jenkinsci/jenkins/pull/5843, I stumbled on the `runMaven` method not found in the DSL.

I had to specify the JDK version as a string: since it was an integer in the pipeline, I assume that signature matching failed.

This PR introduces (based on the fact I did not misunderstood the problem) a new variant of `runMaven` to ensure that providing the JDK as integer also works, to avoid a tedious call to `toString()`)