### PR TITLE
chore(updatecli) enable automatic upgrade of images for docker-builder, jx-release and updatecli

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -24,9 +24,9 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Apply
         uses: updatecli/updatecli-action@v1
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         with:
           command: apply
-          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
+          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/resources/io/jenkins/infra/docker/jxNextVersionImage
+++ b/resources/io/jenkins/infra/docker/jxNextVersionImage
@@ -1,1 +1,0 @@
-ghcr.io/jenkins-x/jx-release-version:2.4.13

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -96,8 +96,8 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
 
     // And the correct pod template defined
-    assertTrue(assertMethodCallContainsPattern('containerTemplate', 'jenkinsciinfra/builder:latest'))
-    assertTrue(assertMethodCallContainsPattern('containerTemplate', 'jx-release-version:1.2.3'))
+    assertTrue(assertMethodCallContainsPattern('containerTemplate', 'jenkinsciinfra/builder:'))
+    assertTrue(assertMethodCallContainsPattern('containerTemplate', 'jx-release-version:'))
 
     // And the make target called as shell steps
     assertTrue(assertMethodCallContainsPattern('sh','make lint'))

--- a/updatecli/updatecli.d/docker-builder.yml
+++ b/updatecli/updatecli.d/docker-builder.yml
@@ -1,0 +1,41 @@
+---
+title: "Bump docker-builder version on shared library resources"
+sources:
+  lastVersion:
+    kind: githubRelease
+    name: Get the latest docker-builder version
+    spec:
+      owner: "jenkins-infra"
+      repository: "docker-builder"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+
+conditions:
+  checkIfDockerImageIsPublished:
+    name: "Check if the Docker Image is published"
+    kind: dockerImage
+    spec:
+      image: "jenkinsciinfra/builder"
+
+targets:
+  updateGroovyCode:
+    name: Update docker-builder in groovy code
+    kind: file
+    spec:
+      file: vars/buildDockerAndPublishImage.groovy
+      # Please note that the patterns are specified as "block scalars" (>) with the last endline trimed (-) to avoid tedious escaping of simple quotes
+      matchpattern: >-
+        'jenkinsciinfra/builder:(.*)'
+      replacepattern: >-
+        'jenkinsciinfra/builder:{{ source `lastVersion` }}'
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/updatecli.d/jx-next-version.yml
+++ b/updatecli/updatecli.d/jx-next-version.yml
@@ -1,7 +1,7 @@
 ---
-title: "Bump jx-release-version version"
+title: "Bump jx-release-version version on shared library resources"
 sources:
-  default:
+  lastVersion:
     kind: githubRelease
     name: Get the latest jx-release-version version
     spec:
@@ -10,17 +10,28 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
-        kind: latest
-    transformers:
-      - trimPrefix: "v"
-      - addPrefix: "ghcr.io/jenkins-x/jx-release-version:"
+        kind: semver
+
+# https://github.com/updatecli/updatecli/issues/365
+# conditions:
+#   checkIfDockerImageIsPublished:
+#     name: "Check if the Docker Image is published"
+#     kind: dockerImage
+#     spec:
+#       hostname: 'ghcr.io'
+#       image: 'jenkins-x/jx-release-version'
+
 targets:
-  updateJxReleaseVersion:
-    name: Update jx-release-version in file
-    sourceID: default
+  updateGroovyCode:
+    name: Update jx-release-version in groovy code
     kind: file
     spec:
-      file: resources/io/jenkins/infra/docker/jxNextVersionImage
+      file: vars/buildDockerAndPublishImage.groovy
+      # Please note that the patterns are specified as "block scalars" (>) with the last endline trimed (-) to avoid tedious escaping of simple quotes
+      matchpattern: >-
+        'ghcr.io/jenkins-x/jx-release-version:(.*)'
+      replacepattern: >-
+        'ghcr.io/jenkins-x/jx-release-version:{{ source `lastVersion` }}'
     scm:
       github:
         user: "{{ .github.user }}"

--- a/updatecli/updatecli.d/updatecli.yml
+++ b/updatecli/updatecli.d/updatecli.yml
@@ -1,0 +1,43 @@
+---
+title: "Bump updatecli version on shared library resources"
+sources:
+  lastVersion:
+    kind: githubRelease
+    name: Get the latest docker-builder version
+    spec:
+      owner: "updatecli"
+      repository: "updatecli"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: semver
+
+# https://github.com/updatecli/updatecli/issues/365
+# conditions:
+#   checkIfDockerImageIsPublished:
+#     name: "Check if the Docker Image is published"
+#     kind: dockerImage
+#     spec:
+#       hostname: 'ghcr.io'
+#       image: 'updatecli/updatecli'
+
+targets:
+  updateGroovyCode:
+    name: Update docker-builder in groovy code
+    kind: file
+    spec:
+      file: vars/updatecli.groovy
+      # Please note that the patterns are specified as "block scalars" (>) with the last endline trimed (-) to avoid tedious escaping of simple quotes
+      matchpattern: >-
+        'ghcr.io/updatecli/updatecli:(.*)'
+      replacepattern: >-
+        'ghcr.io/updatecli/updatecli:{{ source `lastVersion` }}'
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -10,7 +10,6 @@ def call(String imageName, Map config=[:]) {
 
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
-  final String defaultNextVersionImage = libraryResource 'io/jenkins/infra/docker/jxNextVersionImage'
   final boolean semVerEnabled = dockerConfig.automaticSemanticVersioning && env.BRANCH_NAME == dockerConfig.mainBranch
 
   final String dockerImageName = dockerConfig.imageName
@@ -34,7 +33,7 @@ def call(String imageName, Map config=[:]) {
       ),
       containerTemplate(
         name: 'next-version',
-        image: config.nextVersionImage ?: defaultNextVersionImage,
+        image: config.nextVersionImage ?: 'ghcr.io/jenkins-x/jx-release-version:2.4.13',
         command: 'cat',
         ttyEnabled: true,
         resourceRequestCpu: '200m',


### PR DESCRIPTION
- Since updatecli 0.13.0, we can use pattern matching to directly edit the groovy code: it's easier than relying on a file
- Initial "updatecli diff" will report "green" but its logs will tells us "failure) in the PR: because the changes are not merged yet on the principal branch (ref. https://github.com/updatecli/updatecli/issues/262)
- Dependanbot will now tracks the updatecli action version daily