### PR TITLE
Remove un-needed ATH option (breaks ATH)

### DIFF
--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -12,7 +12,7 @@ def call(Map params = [:]) {
     def jdks = params.get('jdks', [8])
     def athContainerImageTag = params.get("athImage", "jenkins/ath");
     def configFile = params.get("configFile", null)
-    def defaultJavaOptions = params.get('javaOptions', ['--no-transfer-progress'])
+    def defaultJavaOptions = params.get('javaOptions', [])
 
     def mirror = "http://mirrors.jenkins.io/"
     def defaultCategory = "org.jenkinsci.test.acceptance.junit.SmokeTest"


### PR DESCRIPTION
See https://ci.jenkins.io/job/Core/job/jenkins/job/stable-2.319/2/testReport/junit/plugins/GradlePluginTest/ath___Running_ATH___ATH_individual_tests_firefox_jdk8___run_gradle_script/

```
[Gradle] - Launching build.
Unpacking https://services.gradle.org/distributions/gradle-4.10.2-bin.zip to /home/jenkins/workspace/Core_jenkins_stable-2.319/ath/testfirefoxjdk8/target/jenkins1809325966980291028home/tools/hudson.plugins.gradle.GradleInstallation/Gradle_4.10.2 on Jenkins
[gradle] $ /home/jenkins/workspace/Core_jenkins_stable-2.319/ath/testfirefoxjdk8/target/jenkins1809325966980291028home/tools/hudson.plugins.gradle.GradleInstallation/Gradle_4.10.2/bin/gradle --quiet --no-daemon environmentVariables -b hello.gradle
Unrecognized option: --no-transfer-progress
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Build step 'Invoke Gradle script' changed build result to FAILURE
Build step 'Invoke Gradle script' marked build as failure
Finished: FAILURE
```

Added it to the main repo in a safe way in https://github.com/jenkinsci/acceptance-test-harness/pull/710

Regression in https://github.com/jenkins-infra/pipeline-library/pull/164/files/8463fdc6e5939b695e1e12c74622bbaaca1a2b02#diff-dbf4cd3bd16a05edffff4fc796cbeaaf5bbb0c67cbee8f8e3a90132069e9db2e