### PR TITLE
chore(updatecli) improve automatic updates (avoid failing PRs and check for GHCR images)

### DIFF
--- a/test/groovy/UpdatecliStepTests.groovy
+++ b/test/groovy/UpdatecliStepTests.groovy
@@ -34,7 +34,7 @@ class UpdatecliStepTests extends BaseTest {
     assertJobStatusSuccess()
 
     // And the correct pod template defined
-    assertTrue(assertMethodCallContainsPattern('containerTemplate', 'ghcr.io/updatecli/updatecli:latest'))
+    assertTrue(assertMethodCallContainsPattern('containerTemplate', 'ghcr.io/updatecli/updatecli:'))
 
     // And the repository checkouted
     assertTrue(assertMethodCallContainsPattern('checkout', ''))

--- a/updatecli/updatecli.d/jx-next-version.yml
+++ b/updatecli/updatecli.d/jx-next-version.yml
@@ -12,14 +12,14 @@ sources:
       versionFilter:
         kind: semver
 
-# https://github.com/updatecli/updatecli/issues/365
-# conditions:
-#   checkIfDockerImageIsPublished:
-#     name: "Check if the Docker Image is published"
-#     kind: dockerImage
-#     spec:
-#       hostname: 'ghcr.io'
-#       image: 'jenkins-x/jx-release-version'
+conditions:
+  checkIfDockerImageIsPublished:
+    name: "Check if the Docker Image is published"
+    kind: dockerImage
+    spec:
+      image: 'ghcr.io/jenkins-x/jx-release-version'
+      username: "{{ .github.username }}"
+      password: "{{ requiredEnv .github.token }}"
 
 targets:
   updateGroovyCode:

--- a/updatecli/updatecli.d/updatecli.yml
+++ b/updatecli/updatecli.d/updatecli.yml
@@ -12,15 +12,14 @@ sources:
       versionFilter:
         kind: latest
 
-# https://github.com/updatecli/updatecli/issues/365
-# conditions:
-#   checkIfDockerImageIsPublished:
-#     name: "Check if the Docker Image is published"
-#     kind: dockerImage
-#     spec:
-#       hostname: "ghcr.io"
-#       image: "updatecli/updatecli"
-#       token: "{{ requiredEnv .github.token }}"
+conditions:
+  checkIfDockerImageIsPublished:
+    name: "Check if the Docker Image is published"
+    kind: dockerImage
+    spec:
+      image: "ghcr.io/updatecli/updatecli"
+      username: "{{ .github.username }}"
+      password: "{{ requiredEnv .github.token }}"
 
 targets:
   updateGroovyCode:


### PR DESCRIPTION
- add updatecli condition to ensure that GHCR docker image are published (thanks to the help of @olblak in https://github.com/updatecli/updatecli/issues/365)
- Avoid to fail tests when updating the updatecli's container image tag (PR #243 is an example where it failed)