### PR TITLE
chore: more memory for updatecli

### DIFF
--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -30,8 +30,8 @@ def call(userConfig = [:]) {
         ttyEnabled: true,
         resourceRequestCpu: '200m',
         resourceLimitCpu: '200m',
-        resourceRequestMemory: '256Mi',
-        resourceLimitMemory: '256Mi',
+        resourceRequestMemory: '512Mi',
+        resourceLimitMemory: '512Mi',
       ),
     ]
   ) {


### PR DESCRIPTION
Trying to make this pipeline running: https://github.com/jenkins-infra/docker-confluence-data/pull/13