### PR TITLE
feat(terraform) add a new library to manage Terraform builds - INFRA-3132

### DIFF
--- a/test/groovy/BaseTest.groovy
+++ b/test/groovy/BaseTest.groovy
@@ -75,12 +75,15 @@ class BaseTest extends DeclarativePipelineTest {
     helper.registerAllowedMethod('withCredentials', [List.class, Closure.class], { list, body -> body() })
     helper.registerAllowedMethod('withEnv', [List.class, Closure.class], { list, body -> body() })
     helper.registerAllowedMethod('writeYaml', [Map.class], { })
+    helper.registerAllowedMethod('publishChecks', [Map.class], { m -> m })
+    helper.registerAllowedMethod('input', [Map.class], { m -> m })
 
     // Kubernetes Agents in scripted syntax
     helper.registerAllowedMethod('podTemplate', [Map.class, Closure.class], { m, body ->body() })
     helper.registerAllowedMethod('containerTemplate', [Map.class], { m -> m })
     helper.registerAllowedMethod('podAnnotation', [Map.class], { m -> m })
     helper.registerAllowedMethod('container', [String.class, Closure.class], { s, body ->body() })
+    helper.registerAllowedMethod('merge', [], { })
     binding.setVariable('POD_LABEL', 'builder')
   }
 

--- a/test/groovy/TerraformStepTests.groovy
+++ b/test/groovy/TerraformStepTests.groovy
@@ -40,7 +40,7 @@ class TerraformStepTests extends BaseTest {
   void itRunSuccessfullyWithDefaultTimeTrigger() throws Exception {
     def script = loadScript(scriptName)
 
-    // when calling the shared library global function with defaults
+    // When calling the shared library global function with defaults
     script.call()
     printCallStack()
 
@@ -95,7 +95,7 @@ class TerraformStepTests extends BaseTest {
   void itRunSuccessfullyWithDefaultOnPR() throws Exception {
     def script = loadScript(scriptName)
 
-    // when calling the shared library global function with defaults
+    // When calling the shared library global function with defaults
     // on a change request (PR) from <fork_repo>/main -> <current_repo>/main
     addEnvVar('CHANGE_ID', '1234')
     script.call()
@@ -126,7 +126,7 @@ class TerraformStepTests extends BaseTest {
     assertFalse(assertMethodCallContainsPattern('stage', 'Shipping Changes'))
     assertFalse(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ deploy'))
 
-    // no daily cron trigger for the PR jobs
+    // No daily cron trigger for the PR jobs
     assertFalse(assertMethodCallContainsPattern('pipelineTriggers', '@daily'))
   }
 
@@ -134,7 +134,7 @@ class TerraformStepTests extends BaseTest {
   void itRunSuccessfullyWithRepoScanOnFeatureBranch() throws Exception {
     def script = loadScript(scriptName)
 
-    // when calling the shared library global function with defaults
+    // When calling the shared library global function with defaults
     // on a feature branch (not  a change request) triggered by a periodic code scan
     binding.setProperty('currentBuild', new CurrentBuild(
       'SUCCESS',
@@ -179,7 +179,7 @@ class TerraformStepTests extends BaseTest {
   void itRunSuccessfullyWithManualBuildCause() throws Exception {
     def script = loadScript(scriptName)
 
-    // when calling the shared library global function with defaults
+    // When calling the shared library global function with defaults
     // with a user manually-trigger build on the main branch
     binding.setProperty('currentBuild', new CurrentBuild(
       'SUCCESS',
@@ -215,7 +215,7 @@ class TerraformStepTests extends BaseTest {
     def script = loadScript(scriptName)
     final String customImage = 'hashicorp/terraform-full:0.13.0'
 
-    // when calling the shared library global function with custom parameters
+    // When calling the shared library global function with custom parameters
     script.call(
       cronTriggerExpression: '@weekly',
       stagingCredentials: stagingCustomCreds,

--- a/test/groovy/TerraformStepTests.groovy
+++ b/test/groovy/TerraformStepTests.groovy
@@ -1,0 +1,244 @@
+import org.junit.Before
+import org.junit.Test
+import mock.CurrentBuild
+
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class TerraformStepTests extends BaseTest {
+  static final String scriptName = 'vars/terraform.groovy'
+  static final String dummyBuildUrl = 'https://ci.jenkins.io/dummy/jobs/main/1/' // Trailing slash is mandatory
+
+  // The
+  ArrayList stagingCustomCreds = [
+    [$class: 'UsernamePasswordMultiBinding', credentialsId: 'credential-1', passwordVariable: 'STAGING_PSW', usernameVariable: 'STAGING_USR'],
+    [$class: 'StringBinding', credentialsId: 'credential-common', variable: 'COMMON_SECRET']
+  ]
+  ArrayList productionCustomCreds = [
+    [$class: 'UsernamePasswordMultiBinding', credentialsId: 'credential-2', passwordVariable: 'PRODUCTION_PSW', usernameVariable: 'PRODUCTION_USR'],
+    [$class: 'StringBinding', credentialsId: 'credential-common', variable: 'COMMON_SECRET']
+  ]
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+
+    // Default behavior is a build triggered by a timertrigger on the main branch (most common case)
+    binding.setProperty('currentBuild', new CurrentBuild(
+      'SUCCESS',
+      ['hudson.triggers.TimerTrigger']
+    ))
+    addEnvVar('BRANCH_NAME', 'main')
+
+    // Used by the publish checks
+    addEnvVar('BUILD_URL', dummyBuildUrl)
+
+  }
+
+  @Test
+  void itRunSuccessfullyWithDefaultTimeTrigger() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling the shared library global function with defaults
+    script.call()
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // With all the stages called
+    /** Staging **/
+    assertTrue(assertMethodCallContainsPattern('stage', 'Staging'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Validate Terraform for Staging Environment'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ validate'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Commons Test Terraform Project'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ common-tests'))
+    assertFalse(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ tests'))
+
+    /** Production **/
+    assertTrue(assertMethodCallContainsPattern('stage', 'Production'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Generate Terraform Plan'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ plan'))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', 'terraform-plan-for-humans.txt'))
+    // Default is the principal branch: not a PR, no notification
+    assertFalse(assertMethodCallContainsPattern('stage', 'Notify User on the PR'))
+    assertFalse(assertMethodCallContainsPattern('publishChecks', dummyBuildUrl + 'artifact/terraform-plan-for-humans.txt'))
+    // Despite being on the principal branch, default build trigger is "timer"
+    assertFalse(assertMethodCallContainsPattern('stage', 'Waiting for User Input (Manual Approval)'))
+    assertFalse(assertMethodCallContainsPattern('input', 'Should we apply these changes to production?'))
+    assertFalse(assertMethodCallContainsPattern('stage', 'Shipping Changes'))
+    assertFalse(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ deploy'))
+
+    // With the code checkouted (1 for production, 1 for staging by default)
+    assertTrue(assertMethodCallOccurrences('checkout',4))
+
+    // With Terraform configured to run in automation trhough the environment
+    assertTrue(assertMethodCallContainsPattern('withEnv','TF_IN_AUTOMATION=1'))
+    assertTrue(assertMethodCallContainsPattern('withEnv','TF_INPUT=0'))
+    assertTrue(assertMethodCallContainsPattern('withEnv','TF_CLI_ARGS_plan=-detailed-exitcode'))
+
+    // And none of the "custom" secrets defined in this tests suite (to ensure a non false positive on other tests)
+    assertFalse(assertMethodCallContainsPattern('withCredentials','STAGING_PSW'))
+    assertFalse(assertMethodCallContainsPattern('withCredentials','PRODUCTION_USR'))
+    assertFalse(assertMethodCallContainsPattern('withCredentials','COMMON_SECRET'))
+
+    // And a daily cron trigger for the job
+    assertTrue(assertMethodCallContainsPattern('pipelineTriggers', '@daily'))
+
+    // And the correct pod templates defined
+    assertTrue(assertMethodCallContainsPattern('containerTemplate', 'jenkinsciinfra/hashicorp-tools:')) // Not tag as it's managed by updatecli
+    assertTrue(assertMethodCallOccurrences('containerTemplate', 2)) // Only 1 container per pod, but 2 pod spawn (staging and production)
+  }
+
+  @Test
+  void itRunSuccessfullyWithDefaultOnPR() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling the shared library global function with defaults
+    // on a change request (PR) from <fork_repo>/main -> <current_repo>/main
+    addEnvVar('CHANGE_ID', '1234')
+    script.call()
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // With all the stages called
+    /** Staging **/
+    assertTrue(assertMethodCallContainsPattern('stage', 'Staging'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Validate Terraform for Staging Environment'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Test Terraform Project'))
+
+    /** Production **/
+    assertTrue(assertMethodCallContainsPattern('stage', 'Production'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Generate Terraform Plan'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ plan'))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', 'terraform-plan-for-humans.txt'))
+
+    // It's a change request: we expect a user notify
+    assertTrue(assertMethodCallContainsPattern('stage', 'Notify User on the PR'))
+    assertTrue(assertMethodCallContainsPattern('publishChecks', dummyBuildUrl + 'artifact/terraform-plan-for-humans.txt'))
+    // No User Approval on change requests
+    assertFalse(assertMethodCallContainsPattern('stage', 'Waiting for User Input (Manual Approval)'))
+    assertFalse(assertMethodCallContainsPattern('input', 'Should we apply these changes to production?'))
+    // No shipping on change requests
+    assertFalse(assertMethodCallContainsPattern('stage', 'Shipping Changes'))
+    assertFalse(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ deploy'))
+
+    // no daily cron trigger for the PR jobs
+    assertFalse(assertMethodCallContainsPattern('pipelineTriggers', '@daily'))
+  }
+
+  @Test
+  void itRunSuccessfullyWithRepoScanOnFeatureBranch() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling the shared library global function with defaults
+    // on a feature branch (not  a change request) triggered by a periodic code scan
+    binding.setProperty('currentBuild', new CurrentBuild(
+      'SUCCESS',
+      ['hudson.triggers.PeriodicFolderTrigger']
+    ))
+    addEnvVar('BRANCH_NAME', 'feat/terraform')
+    script.call()
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // With all the stages called
+    /** Staging **/
+    assertTrue(assertMethodCallContainsPattern('stage', 'Staging'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Validate Terraform for Staging Environment'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Test Terraform Project'))
+
+    /** Production **/
+    assertTrue(assertMethodCallContainsPattern('stage', 'Production'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Generate Terraform Plan'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ plan'))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', 'terraform-plan-for-humans.txt'))
+
+    // Default is the principal branch: not a PR, no notification
+    assertFalse(assertMethodCallContainsPattern('stage', 'Notify User on the PR'))
+    assertFalse(assertMethodCallContainsPattern('publishChecks', dummyBuildUrl + 'artifact/terraform-plan-for-humans.txt'))
+    // Despite being on the principal branch, default build trigger is "timer"
+    assertFalse(assertMethodCallContainsPattern('stage', 'Waiting for User Input (Manual Approval)'))
+    assertFalse(assertMethodCallContainsPattern('input', 'Should we apply these changes to production?'))
+    assertFalse(assertMethodCallContainsPattern('stage', 'Shipping Changes'))
+    assertFalse(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ deploy'))
+
+    // Ensure that drift-detection is disabled
+    assertFalse(assertMethodCallContainsPattern('withEnv','TF_CLI_ARGS_plan=-detailed-exitcode'))
+
+    // And a daily cron trigger for the job
+    assertFalse(assertMethodCallContainsPattern('pipelineTriggers', '@daily'))
+  }
+
+  @Test
+  void itRunSuccessfullyWithManualBuildCause() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling the shared library global function with defaults
+    // with a user manually-trigger build on the main branch
+    binding.setProperty('currentBuild', new CurrentBuild(
+      'SUCCESS',
+      ['hudson.model.Cause$UserIdCause']
+    ))
+    script.call()
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    /** Staging is not run when user manually triggers the build **/
+    assertFalse(assertMethodCallContainsPattern('stage', 'Staging'))
+    assertFalse(assertMethodCallContainsPattern('stage', 'Validate Terraform for Staging Environment'))
+    assertFalse(assertMethodCallContainsPattern('stage', 'Test Terraform Project'))
+    assertFalse(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ common-tests'))
+    /** Production **/
+    assertTrue(assertMethodCallContainsPattern('stage', 'Production'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Generate Terraform Plan'))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', 'terraform-plan-for-humans.txt'))
+    assertTrue(assertMethodCallContainsPattern('stage', 'Shipping Changes'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ deploy'))
+    // Different stages than defaults'
+    assertTrue(assertMethodCallContainsPattern('stage', 'Waiting for User Input (Manual Approval)'))
+    assertTrue(assertMethodCallContainsPattern('input', 'Should we apply these changes to production?'))
+
+    // Terraform is set up through environment to NOT detect configuration drift
+    assertFalse(assertMethodCallContainsPattern('withEnv','TF_CLI_ARGS_plan=-detailed-exitcode'))
+  }
+
+  @Test
+  void itRunSuccessfullyWithCustomParameters() throws Exception {
+    def script = loadScript(scriptName)
+    final String customImage = 'hashicorp/terraform-full:0.13.0'
+
+    // when calling the shared library global function with custom parameters
+    script.call(
+      cronTriggerExpression: '@weekly',
+      stagingCredentials: stagingCustomCreds,
+      productionCredentials: productionCustomCreds,
+      agentContainerImage: customImage,
+    )
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // With the custom secrets defined
+    // And none of the "custom" secrets defined in this tests suiye (to ensure a non false positive on other tests)
+    assertTrue(assertMethodCallContainsPattern('withCredentials','STAGING_PSW'))
+    assertTrue(assertMethodCallContainsPattern('withCredentials','PRODUCTION_USR'))
+    assertTrue(assertMethodCallContainsPattern('withCredentials','COMMON_SECRET'))
+
+    // And the custom cron trigger
+    assertTrue(assertMethodCallContainsPattern('pipelineTriggers', '@weekly'))
+
+    // And the custom agent container template defined
+    assertFalse(assertMethodCallContainsPattern('containerTemplate', 'jenkinsciinfra/terraform:'))
+    assertTrue(assertMethodCallContainsPattern('containerTemplate', customImage))
+    assertTrue(assertMethodCallOccurrences('containerTemplate', 2))
+  }
+}

--- a/test/groovy/TerraformStepTests.groovy
+++ b/test/groovy/TerraformStepTests.groovy
@@ -33,7 +33,6 @@ class TerraformStepTests extends BaseTest {
 
     // Used by the publish checks
     addEnvVar('BUILD_URL', dummyBuildUrl)
-
   }
 
   @Test

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -1,0 +1,168 @@
+/**
+terraform.groovy: Please look at https://github.com/jenkins-infra/shared-tools/tree/main/terraform#jenkins-pipeline for documentation and usage.
+**/
+
+def call(userConfig = [:]) {
+  def defaultConfig = [
+    cronTriggerExpression: '@daily', // Defaults to run once a day (to detect configuration drift)
+    stagingCredentials: [], // No custom secrets for staging by default
+    productionCredentials: [], // No custom secrets for production by default
+    productionBranch: 'main', // Defaults to the principal branch
+    agentContainerImage: 'jenkinsciinfra/hashicorp-tools:0.3.5', // Version managed by updatecli
+    runTests: false, // Executes the tests provided by the "calling" project, which should provide a tests/Makefile
+    runCommonTests: true, // Executes the default test suite from the shared tools repository (terratest)
+  ]
+
+  // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
+  final Map finalConfig = defaultConfig << userConfig
+
+  // Detects build causes once and for all
+  final Boolean isBuildCauseTimer = currentBuild.getBuildCauses().contains('hudson.triggers.TimerTrigger')
+  final Boolean isBuildCauseUser = currentBuild.getBuildCauses().contains('hudson.model.Cause$UserIdCause')
+  final Boolean isBuildOnChangeRequest = env.CHANGE_ID
+  final Boolean isBuildOnProductionBranch = (env.BRANCH_NAME == finalConfig.productionBranch)
+
+  Map parallelStages = [failFast: false]
+
+  final String sharedToolsSubDir = '.shared-tools'
+  final String makeCliCmd = "make --directory=${sharedToolsSubDir}/terraform/"
+
+  // Defines a cron trigger only if it's requested by the user through input parameter
+  if (isBuildOnProductionBranch && !isBuildOnChangeRequest) {
+    properties([
+      pipelineTriggers([defaultConfig.cronTriggerExpression])
+    ])
+  }
+
+  withEnv([
+    // https://www.terraform.io/docs/cli/config/environment-variables.html#tf_in_automation
+    "TF_IN_AUTOMATION=1",
+    // https://www.terraform.io/docs/cli/config/environment-variables.html#tf_input
+    "TF_INPUT=0",
+  ]) {
+
+
+    if (!isBuildCauseUser) {
+      parallelStages['staging'] = {
+        stage('Staging') {
+          agentTemplate(finalConfig.agentContainerImage, {
+            withCredentials(finalConfig.stagingCredentials) {
+              stage('🔎 Validate Terraform for Staging Environment') {
+                getInfraSharedTools(sharedToolsSubDir)
+
+                sh makeCliCmd + ' validate'
+              }
+              if (finalConfig.runCommonTests) {
+                stage('✅ Commons Test Terraform Project') {
+                  sh makeCliCmd + ' common-tests'
+                }
+              }
+              if (finalConfig.runTests) {
+                stage('✅ Specific Tests Terraform Project') {
+                  sh 'make -C ./tests'
+                }
+              }
+            }
+          })
+        }
+      }
+    }
+
+    parallelStages['production'] = {
+      stage('Production') {
+        agentTemplate(finalConfig.agentContainerImage, {
+          withCredentials(defaultConfig.productionCredentials) {
+            stage('🦅 Generate Terraform Plan') {
+              // When the job is triggered by the daily cron timer, then the plan succeed only if there is no changes found (e.g. no config drift)
+              // For all other triggers, the plan succeed either there are changes or not
+              String tfCliArsPlan=''
+              final String planFileName = 'terraform-plan-for-humans.txt'
+              if (isBuildCauseTimer) {
+                tfCliArsPlan='-detailed-exitcode'
+              }
+              withEnv([
+                // https://www.terraform.io/docs/cli/config/environment-variables.html#tf_cli_args-and-tf_cli_args_name
+                "TF_CLI_ARGS_plan=${tfCliArsPlan}",
+                "PLAN_FILE_NAME=${planFileName}",
+              ]) {
+                getInfraSharedTools(sharedToolsSubDir)
+
+                try {
+                  sh makeCliCmd + ' plan'
+                }
+                finally {
+                  archiveArtifacts planFileName
+                }
+              }
+            }
+
+            if (isBuildOnChangeRequest) {
+              stage('🗣 Notify User on the PR ') {
+                final String planFileUrl = "${env.BUILD_URL}artifact/terraform-plan-for-humans.txt"
+                publishChecks name: "terraform-plan",
+                  title: "Terraform plan for this change request",
+                  text: "The terraform plan for this change request can be found at <${planFileUrl}>.",
+                  detailsURL: planFileUrl
+              }
+            }
+
+            // Only ask for manual approval when the build was manually launched by a human
+            // Note that we keep waiting with the current node agent as we want to keep the context
+            if (isBuildCauseUser){
+              stage("⏳ Waiting for User Input (Manual Approval)") {
+                input message: "Should we apply these changes to production?", ok: "🚢 Yes, ship it!"
+              }
+            }
+            if (!isBuildCauseTimer && isBuildOnProductionBranch) {
+              stage('🚢 Shipping Changes') {
+                sh makeCliCmd + ' deploy'
+              }
+            }
+          }
+        })
+      }
+    }
+
+    // Execute parallel stages from the map
+    parallel parallelStages
+  }
+}
+
+def agentTemplate(containerImage, body) {
+  podTemplate(
+    // Custom YAML definition to enforce no service account token (if Terraform uses kubernetes, it would grant it a wrong access)
+    yaml: '''
+      apiVersion: v1
+      kind: Pod
+      spec:
+        automountServiceAccountToken: false
+    ''',
+    // The Docker image here is aimed at "1 container per pod" and is embedding Jenkins agent tooling
+    containers: [
+      containerTemplate(
+        name: 'jnlp',
+        image: containerImage,
+      ),
+    ]
+  ) {
+    node(POD_LABEL) {
+      body.call()
+    }
+  }
+}
+
+
+// Retrieves the shared tooling
+def getInfraSharedTools(String sharedToolsSubDir) {
+  // Checkout the actual project on the same gitref as the Jenkinsfile
+  checkout scm
+
+  // Remove any leftover from developers (normal content or submodule) to avoid injection
+  sh 'rm -rf ' + sharedToolsSubDir
+
+  // Retrieve the "legit" shared tooling (should be the same as the submodule but we're never sure enough)
+  checkout changelog: false, poll: false,
+    scm: [$class: 'GitSCM', branches: [[name: '*/main']],
+    extensions: [[$class: 'CleanBeforeCheckout', deleteUntrackedNestedRepositories: true], [$class: 'RelativeTargetDirectory', relativeTargetDir: sharedToolsSubDir],
+      [$class: 'GitSCMStatusChecksExtension', skip: true]], userRemoteConfigs: [[credentialsId: 'github-app-infra', url: 'https://github.com/jenkins-infra/shared-tools.git']]]
+}

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -41,7 +41,6 @@ def call(userConfig = [:]) {
     "TF_INPUT=0",
   ]) {
 
-
     if (!isBuildCauseUser) {
       parallelStages['staging'] = {
         stage('Staging') {

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -75,10 +75,10 @@ def call(userConfig = [:]) {
             stage('🦅 Generate Terraform Plan') {
               // When the job is triggered by the daily cron timer, then the plan succeed only if there is no changes found (e.g. no config drift)
               // For all other triggers, the plan succeed either there are changes or not
-              String tfCliArsPlan=''
+              String tfCliArsPlan = ''
               final String planFileName = 'terraform-plan-for-humans.txt'
               if (isBuildCauseTimer) {
-                tfCliArsPlan='-detailed-exitcode'
+                tfCliArsPlan = '-detailed-exitcode'
               }
               withEnv([
                 // https://www.terraform.io/docs/cli/config/environment-variables.html#tf_cli_args-and-tf_cli_args_name

--- a/vars/terraform.txt
+++ b/vars/terraform.txt
@@ -1,0 +1,1 @@
+The pipeline library "terraform()" is documented on the following page: https://github.com/jenkins-infra/shared-tools/tree/main/terraform#jenkins-pipeline.


### PR DESCRIPTION
This PR introduces a new library to share the terraform workflow between all the terraform repositories of the jenkis-infra.

Please note that we are trying something new, suggested a while ago by Victor Martinez (for Docker library) and @lemeurherve more recently: the Makefile/doc is moved on another repository used as submodule for development, while the shared library clones the shared-tools repository to avoid any possibility of "makefile/shell" injection.

- Tested in real life in https://github.com/jenkins-infra/aws/pull/59
- https://github.com/jenkins-infra/shared-tools/tree/main/terraform

