### PR TITLE
fix(updatecli) downgrade updatecli to 0.16.1

### DIFF
--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -3,7 +3,7 @@ def call(userConfig = [:]) {
     action: 'diff',
     config: './updatecli/updatecli.d',
     values: './updatecli/values.yaml',
-    updatecliDockerImage: 'ghcr.io/updatecli/updatecli:v0.17.1',
+    updatecliDockerImage: 'ghcr.io/updatecli/updatecli:v0.16.1',
     containerMemory: '128Mi'
   ]
 


### PR DESCRIPTION
Until https://github.com/updatecli/updatecli/issues/431 is fixed.

It avoids failing our builds.