### PR TITLE
Bump maven-surefire-plugin from 3.0.0-M3 to 3.0.0-M5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.lesfurets</groupId>
             <artifactId>jenkins-pipeline-unit</artifactId>
             <version>${jenkins-pipeline-unit.version}</version>
@@ -108,7 +114,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.0.0-M5</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Follow up of https://github.com/jenkins-infra/pipeline-library/pull/187.
https://github.com/jenkins-infra/pipeline-library/pull/187 was reverted (https://github.com/jenkins-infra/pipeline-library/pull/187#pullrequestreview-648607000) because moving to the new surefire version lead to the deactivation of all tests.
https://issues.apache.org/jira/browse/SUREFIRE-1911 was opened on `maven-surefire-plugin` side.

I did some debugging. On M3, `maven-surefire-plugin` uses `TestNGProvider` to execute the tests. On M5, `maven-surefire-plugin` uses `JUnitPlatformProvider` to execute the tests.
`TestNGProvider` is able to run JUnit 4 tests without any additional dependency.
However, `JUnitPlatformProvider` being focused on JUnit 5, requires `junit-vintage-engine` to be among the project depencies.

My conclusion is that the current project configuration is wrong and it was revealed by the new `maven-surefire-plugin` version.