### PR TITLE
chore(updatecli) remove deprecated directives in manifests

### DIFF
--- a/updatecli/updatecli.d/docker-builder.yml
+++ b/updatecli/updatecli.d/docker-builder.yml
@@ -1,5 +1,18 @@
 ---
 title: "Bump docker-builder version on shared library resources"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
 sources:
   lastVersion:
     kind: githubRelease
@@ -30,15 +43,7 @@ targets:
         'jenkinsciinfra/builder:(.*)'
       replacepattern: >-
         'jenkinsciinfra/builder:{{ source `lastVersion` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateDoc:
     updateDoc:
     name: Update docker-builder in documentation
@@ -47,12 +52,12 @@ targets:
       file: vars/buildDockerAndPublishImage.txt
       matchpattern: jenkinsciinfra/builder:(\d\.\d\.\d)
       replacepattern: jenkinsciinfra/builder:{{ source `lastVersion` }}
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateGroovyCode
+      - updateDoc

--- a/updatecli/updatecli.d/docker-helmfile.yml
+++ b/updatecli/updatecli.d/docker-helmfile.yml
@@ -1,5 +1,18 @@
 ---
 title: "Bump docker-helmfile version on shared library resources"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
 sources:
   lastVersion:
     kind: githubRelease
@@ -30,15 +43,7 @@ targets:
         'jenkinsciinfra/helmfile:(.*)'
       replacepattern: >-
         'jenkinsciinfra/helmfile:{{ source `lastVersion` }}'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateDoc:
     name: Update docker-helmfile in documentation
     kind: file
@@ -46,12 +51,13 @@ targets:
       file: vars/updatecli.txt
       matchpattern: jenkinsciinfra/helmfile:(\d\.\d\.\d)
       replacepattern: jenkinsciinfra/helmfile:{{ source `lastVersion` }}
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
+
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateGroovyCode
+      - updateDoc


### PR DESCRIPTION
The goal of this PR is to ensure that the latest updatecli 0.17.x syntax.