### PR TITLE
chore(updatecli) fix manifests to use semver for docker images and adapt to latest updatecli features

### DIFF
--- a/updatecli/updatecli.d/docker-builder.yml
+++ b/updatecli/updatecli.d/docker-builder.yml
@@ -23,7 +23,7 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
-        kind: latest
+        kind: semver
 
 conditions:
   checkIfDockerImageIsPublished:
@@ -31,6 +31,7 @@ conditions:
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/builder"
+      architecture: amd64
 
 targets:
   updateGroovyCode:
@@ -38,7 +39,7 @@ targets:
     kind: file
     spec:
       file: vars/buildDockerAndPublishImage.groovy
-      # Please note that the patterns are specified as "block scalars" (>) with the last endline trimed (-) to avoid tedious escaping of simple quotes
+      # Please note that the patterns are specified as "block scalars" (>) with the last endline trimmed (-) to avoid tedious escaping of simple quotes
       matchpattern: >-
         'jenkinsciinfra/builder:(.*)'
       replacepattern: >-
@@ -57,7 +58,11 @@ targets:
 pullrequests:
   default:
     kind: github
+    title: Bump docker-builder version on shared library resources to {{ source "lastVersion" }}
     scmID: default
     targets:
       - updateGroovyCode
       - updateDoc
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/docker-helmfile.yml
+++ b/updatecli/updatecli.d/docker-helmfile.yml
@@ -23,7 +23,7 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
-        kind: latest
+        kind: semver
 
 conditions:
   checkIfDockerImageIsPublished:
@@ -31,6 +31,7 @@ conditions:
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/helmfile"
+      architecture: amd64
 
 targets:
   updateGroovyCode:
@@ -38,7 +39,7 @@ targets:
     kind: file
     spec:
       file: vars/updatecli.groovy
-      # Please note that the patterns are specified as "block scalars" (>) with the last endline trimed (-) to avoid tedious escaping of simple quotes
+      # Please note that the patterns are specified as "block scalars" (>) with the last endline trimmed (-) to avoid tedious escaping of simple quotes
       matchpattern: >-
         'jenkinsciinfra/helmfile:(.*)'
       replacepattern: >-
@@ -57,7 +58,11 @@ targets:
 pullrequests:
   default:
     kind: github
+    title: Bump docker-helmfile version on shared library resources to {{ source "lastVersion" }}
     scmID: default
     targets:
       - updateGroovyCode
       - updateDoc
+    spec:
+      labels:
+        - dependencies


### PR DESCRIPTION
Closes #283 and #293 (PRs that will be superseeded by new ones)