### PR TITLE
chore(updatecli) fix regexp to handle semver properly even when more than 1 digit

### DIFF
--- a/updatecli/updatecli.d/docker-builder.yml
+++ b/updatecli/updatecli.d/docker-builder.yml
@@ -51,8 +51,8 @@ targets:
     kind: file
     spec:
       file: vars/buildDockerAndPublishImage.txt
-      matchpattern: jenkinsciinfra/builder:(\d\.\d\.\d)
-      replacepattern: jenkinsciinfra/builder:{{ source `lastVersion` }}
+      matchpattern: jenkinsciinfra/builder:(\d+\.\d+\.\d+)\"
+      replacepattern: jenkinsciinfra/builder:{{ source `lastVersion` }}"
     scmID: default
 
 pullrequests:

--- a/updatecli/updatecli.d/docker-helmfile.yml
+++ b/updatecli/updatecli.d/docker-helmfile.yml
@@ -50,10 +50,9 @@ targets:
     kind: file
     spec:
       file: vars/updatecli.txt
-      matchpattern: jenkinsciinfra/helmfile:(\d\.\d\.\d)
-      replacepattern: jenkinsciinfra/helmfile:{{ source `lastVersion` }}
+      matchpattern: jenkinsciinfra/helmfile:(\d+\.\d+\.\d+)\"
+      replacepattern: jenkinsciinfra/helmfile:{{ source `lastVersion` }}"
     scmID: default
-
 
 pullrequests:
   default:


### PR DESCRIPTION
This PR fixes the regexp used to search for the docker image versions to ensure that integer with mutliple digits are correctly handled.

Ref. https://github.com/jenkins-infra/pipeline-library/pull/293#discussion_r800390550