### PR TITLE
Allow empty artifacts

### DIFF
--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -77,7 +77,7 @@ def call(Map params = [:]) {
                             error 'There were test failures; halting early'
                         }
                         if (doArchiveArtifacts) {
-                            archiveArtifacts artifacts: '**/build/libs/*.hpi,**/build/libs/*.jpi', fingerprint: true
+                            archiveArtifacts artifacts: '**/build/libs/*.hpi,**/build/libs/*.jpi', fingerprint: true, allowEmptyArchive: true
                         }
                     }
                 }


### PR DESCRIPTION
Allows using this with gradle projects that aren't plugins

noticed in https://github.com/jenkinsci/JenkinsPipelineUnit/pull/486