### PR TITLE
Fix typo: allowEmptyArchive is a field of params

### DIFF
--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -77,7 +77,7 @@ def call(Map params = [:]) {
                             error 'There were test failures; halting early'
                         }
                         if (doArchiveArtifacts) {
-                            archiveArtifacts artifacts: '**/build/libs/*.hpi,**/build/libs/*.jpi', fingerprint: true, allowEmptyArchive: true
+                            archiveArtifacts artifacts: '**/build/libs/*.hpi,**/build/libs/*.jpi', fingerprint: true, params.allowEmptyArchive: true
                         }
                     }
                 }


### PR DESCRIPTION
The `allowEmptyArtifacts` parameter was added in #300, but there was a typo.
