### PR TITLE
feat(parallelDockerUpdatecli) allow passing custom configuration to updatecli (such as a custom Docker Image)

### DIFF
--- a/test/groovy/ParallelDockerUpdatecliStepTests.groovy
+++ b/test/groovy/ParallelDockerUpdatecliStepTests.groovy
@@ -154,7 +154,7 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
   void itRunsSuccessfullyWithCustomParameters() throws Exception {
     def script = loadScript(scriptName)
 
-    // when calling with the "parallelDockerUpdatecli" function with custom parameters
+    // When calling with the "parallelDockerUpdatecli" function with custom parameters
     // Note: imageName & rebuildImageOnPeriodicJob have already been tested in other tests
     addEnvVar('BRANCH_IS_PRIMARY', 'true')
     script.call(
@@ -183,43 +183,15 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
     // No Warning issued
     assertFalse(assertMethodCallContainsPattern('echo', 'WARNING:'))
 
-    // And the custom parameters are taken in account
+    // And the custom parameters are taken in account for docker image build
     assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', 'mainBranch=' + anotherMainBranchName))
     assertTrue(assertMethodCallContainsPattern('string', anotherCredentialsId))
-    assertTrue(assertMethodCallContainsPattern('updatecli', 'cronTriggerExpression=' + anotherCronTriggerExpression))
-    assertTrue(assertMethodCallContainsPattern('updatecli', 'containerMemory=' + anotherContainerMemory))
-  }
 
-  @Test
-  void itRunsSuccessfullyWithCustomUpdatecliConfig() throws Exception {
-    def script = loadScript(scriptName)
-
-    addEnvVar('BRANCH_IS_PRIMARY', 'true')
-    script.call(
-      imageName: testImageName,
-      updatecliConfig: [
-        containerMemory: anotherContainerMemory,
-      ],
-    )
-    printCallStack()
-
-    // Then we expect a successfull build
-    assertJobStatusSuccess()
-
-    // And the error message is not shown
-    assertFalse(assertMethodCallContainsPattern('echo', 'ERROR: no imageName provided.'))
-
-    // No Warning issued
-    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING:'))
-
-    // And the correct image name is passed to buildDockerAndPublishImage
-    assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', testImageName))
-
-    // And the method "updatecli()" is called for "diff" and "apply" actions (both with the same custom config)
+    // And the method "updatecli()" is called for "diff" and "apply" actions (both with the same custom parameters)
     assertTrue(assertMethodCallOccurrences('updatecli', 2))
     assertTrue(assertMethodCallContainsPattern('updatecli', 'action=diff'))
     assertTrue(assertMethodCallContainsPattern('updatecli', 'action=apply'))
-    assertTrue(assertMethodCallContainsPattern('updatecli', 'cronTriggerExpression=@weekly'))
+    assertTrue(assertMethodCallContainsPattern('updatecli', 'cronTriggerExpression=' + anotherCronTriggerExpression))
     assertTrue(assertMethodCallContainsPattern('updatecli', 'containerMemory=' + anotherContainerMemory))
   }
 
@@ -227,6 +199,7 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
   void itRunsSuccessfullyWithOutdatedUpdatecliConfig() throws Exception {
     def script = loadScript(scriptName)
 
+    // When calling with the "parallelDockerUpdatecli" function with custom parameters, including legcay parameters for updatecli
     addEnvVar('BRANCH_IS_PRIMARY', 'true')
     script.call(
       imageName: testImageName,

--- a/test/groovy/ParallelDockerUpdatecliStepTests.groovy
+++ b/test/groovy/ParallelDockerUpdatecliStepTests.groovy
@@ -11,7 +11,7 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
   static final String testImageName = 'myImage'
   static final String anotherMainBranchName = 'another'
   static final String anotherCronTriggerExpression = '@daily'
-  static final String anotherContainerMemory = '512Mi'
+  static final String anotherContainerMemory = '345Mi' // different than the default value specified in ${scriptName}
   static final String anotherCredentialsId = 'another-github-token'
 
   @Override

--- a/test/groovy/ParallelDockerUpdatecliStepTests.groovy
+++ b/test/groovy/ParallelDockerUpdatecliStepTests.groovy
@@ -160,9 +160,9 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
     script.call(
       imageName: testImageName,
       mainBranch: anotherMainBranchName,
+      updatecliApplyCronTriggerExpression: anotherCronTriggerExpression,
       updatecliConfig: [
         containerMemory: anotherContainerMemory,
-        cronTriggerExpression: anotherCronTriggerExpression,
       ],
       credentialsId: anotherCredentialsId
     )
@@ -204,7 +204,7 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
     script.call(
       imageName: testImageName,
       containerMemory: anotherContainerMemory,
-      cronTriggerExpression: anotherCronTriggerExpression,
+      updatecliApplyCronTriggerExpression: anotherCronTriggerExpression,
     )
     printCallStack()
 

--- a/test/groovy/ParallelDockerUpdatecliStepTests.groovy
+++ b/test/groovy/ParallelDockerUpdatecliStepTests.groovy
@@ -154,7 +154,7 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
   void itRunsSuccessfullyWithCustomParameters() throws Exception {
     def script = loadScript(scriptName)
 
-    // When calling with the "parallelDockerUpdatecli" function with custom parameters
+    // When the "parallelDockerUpdatecli" function is called with custom parameters
     // Note: imageName & rebuildImageOnPeriodicJob have already been tested in other tests
     addEnvVar('BRANCH_IS_PRIMARY', 'true')
     script.call(
@@ -199,7 +199,7 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
   void itRunsSuccessfullyWithOutdatedUpdatecliConfig() throws Exception {
     def script = loadScript(scriptName)
 
-    // When calling with the "parallelDockerUpdatecli" function with custom parameters, including legcay parameters for updatecli
+    // When the "parallelDockerUpdatecli" function is called with custom parameters, including legcay parameters for updatecli
     addEnvVar('BRANCH_IS_PRIMARY', 'true')
     script.call(
       imageName: testImageName,
@@ -208,7 +208,7 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
     )
     printCallStack()
 
-    // Then we expect a successfull build
+    // Then a successfull build is expected
     assertJobStatusSuccess()
 
     // And the error message is not shown

--- a/test/groovy/ParallelDockerUpdatecliStepTests.groovy
+++ b/test/groovy/ParallelDockerUpdatecliStepTests.groovy
@@ -40,6 +40,9 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
 
     // And the error message is shown
     assertTrue(assertMethodCallContainsPattern('echo', 'ERROR: no imageName provided.'))
+
+    // No Warning issued
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING:'))
   }
 
   @Test
@@ -65,6 +68,9 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
 
     // And updatecli(action: 'apply') is called only if we are on the primary branch
     assertTrue(assertMethodCallContainsPattern('updatecli', 'action=apply'))
+
+    // No Warning issued
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING:'))
   }
 
   @Test
@@ -89,6 +95,9 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
 
     // And updatecli(action: 'apply') is called only if we are on the primary branch
     assertFalse(assertMethodCallContainsPattern('updatecli', 'action=apply'))
+
+    // No Warning issued
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING:'))
   }
 
   @Test
@@ -110,6 +119,9 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
 
     // And updatecli(action: 'diff') is called
     assertTrue(assertMethodCallContainsPattern('updatecli', 'action=diff'))
+
+    // No Warning issued
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING:'))
   }
 
   @Test
@@ -132,6 +144,9 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
 
     // And updatecli(action: 'diff') is called
     assertTrue(assertMethodCallContainsPattern('updatecli', 'action=diff'))
+
+    // No Warning issued
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING:'))
   }
 
 
@@ -145,8 +160,10 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
     script.call(
       imageName: testImageName,
       mainBranch: anotherMainBranchName,
-      cronTriggerExpression: anotherCronTriggerExpression,
-      containerMemory: anotherContainerMemory,
+      updatecliConfig: [
+        containerMemory: anotherContainerMemory,
+        cronTriggerExpression: anotherCronTriggerExpression,
+      ],
       credentialsId: anotherCredentialsId
     )
     printCallStack()
@@ -163,9 +180,77 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
     // And updatecli(action: 'diff') is called
     assertTrue(assertMethodCallContainsPattern('updatecli', 'action=diff'))
 
+    // No Warning issued
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING:'))
+
     // And the custom parameters are taken in account
     assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', 'mainBranch=' + anotherMainBranchName))
     assertTrue(assertMethodCallContainsPattern('string', anotherCredentialsId))
+    assertTrue(assertMethodCallContainsPattern('updatecli', 'cronTriggerExpression=' + anotherCronTriggerExpression))
+    assertTrue(assertMethodCallContainsPattern('updatecli', 'containerMemory=' + anotherContainerMemory))
+  }
+
+  @Test
+  void itRunsSuccessfullyWithCustomUpdatecliConfig() throws Exception {
+    def script = loadScript(scriptName)
+
+    addEnvVar('BRANCH_IS_PRIMARY', 'true')
+    script.call(
+      imageName: testImageName,
+      updatecliConfig: [
+        containerMemory: anotherContainerMemory,
+      ],
+    )
+    printCallStack()
+
+    // Then we expect a successfull build
+    assertJobStatusSuccess()
+
+    // And the error message is not shown
+    assertFalse(assertMethodCallContainsPattern('echo', 'ERROR: no imageName provided.'))
+
+    // No Warning issued
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING:'))
+
+    // And the correct image name is passed to buildDockerAndPublishImage
+    assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', testImageName))
+
+    // And the method "updatecli()" is called for "diff" and "apply" actions (both with the same custom config)
+    assertTrue(assertMethodCallOccurrences('updatecli', 2))
+    assertTrue(assertMethodCallContainsPattern('updatecli', 'action=diff'))
+    assertTrue(assertMethodCallContainsPattern('updatecli', 'action=apply'))
+    assertTrue(assertMethodCallContainsPattern('updatecli', 'cronTriggerExpression=@weekly'))
+    assertTrue(assertMethodCallContainsPattern('updatecli', 'containerMemory=' + anotherContainerMemory))
+  }
+
+  @Test
+  void itRunsSuccessfullyWithOutdatedUpdatecliConfig() throws Exception {
+    def script = loadScript(scriptName)
+
+    addEnvVar('BRANCH_IS_PRIMARY', 'true')
+    script.call(
+      imageName: testImageName,
+      containerMemory: anotherContainerMemory,
+      cronTriggerExpression: anotherCronTriggerExpression,
+    )
+    printCallStack()
+
+    // Then we expect a successfull build
+    assertJobStatusSuccess()
+
+    // And the error message is not shown
+    assertFalse(assertMethodCallContainsPattern('echo', 'ERROR: no imageName provided.'))
+
+    // And the correct image name is passed to buildDockerAndPublishImage
+    assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', testImageName))
+
+    // And a warning message is shown (updatecli legacy config is used)
+    assertTrue(assertMethodCallContainsPattern('echo', 'WARNING: passing the attribute'))
+
+    // And the method "updatecli()" is called for "diff" and "apply" actions (both with the same custom config)
+    assertTrue(assertMethodCallOccurrences('updatecli', 2))
+    assertTrue(assertMethodCallContainsPattern('updatecli', 'action=diff'))
+    assertTrue(assertMethodCallContainsPattern('updatecli', 'action=apply'))
     assertTrue(assertMethodCallContainsPattern('updatecli', 'cronTriggerExpression=' + anotherCronTriggerExpression))
     assertTrue(assertMethodCallContainsPattern('updatecli', 'containerMemory=' + anotherContainerMemory))
   }

--- a/vars/parallelDockerUpdatecli.groovy
+++ b/vars/parallelDockerUpdatecli.groovy
@@ -8,6 +8,7 @@ def call(userConfig = [:]) {
     credentialsId: 'updatecli-github-token',
     updatecliConfig: [:],
   ]
+  def defaultUpdatecliCronTriggerExpression = '@weekly'
 
   if (userConfig.containerMemory) {
     echo 'WARNING: passing the attribute "containerMemory" as top level argument is deprecated. Please use "updatecliConfig: [containerMemory: <value>]" instead.'
@@ -47,7 +48,7 @@ def call(userConfig = [:]) {
         updatecli(updatecliConfig)
         if (env.BRANCH_IS_PRIMARY) {
           // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
-          updatecliConfig = finalConfig.updatecliConfig << [action: 'apply', cronTriggerExpression: '@weekly']
+          updatecliConfig = finalConfig.updatecliConfig << [action: 'apply', cronTriggerExpression: defaultUpdatecliCronTriggerExpression]
           updatecli(updatecliConfig)
         }
       }

--- a/vars/parallelDockerUpdatecli.groovy
+++ b/vars/parallelDockerUpdatecli.groovy
@@ -6,17 +6,13 @@ def call(userConfig = [:]) {
     mainBranch: 'main',
     rebuildImageOnPeriodicJob: true,
     credentialsId: 'updatecli-github-token',
+    updatecliApplyCronTriggerExpression: '@weekly',
     updatecliConfig: [:],
   ]
-  def defaultUpdatecliCronTriggerExpression = '@weekly'
 
   if (userConfig.containerMemory) {
     echo 'WARNING: passing the attribute "containerMemory" as top level argument is deprecated. Please use "updatecliConfig: [containerMemory: <value>]" instead.'
     defaultConfig.updatecliConfig.containerMemory = userConfig.containerMemory
-  }
-  if (userConfig.cronTriggerExpression) {
-    echo 'WARNING: passing the attribute "cronTriggerExpression" as top level argument is deprecated. Please use "updatecliConfig: [cronTriggerExpression: <value>]" instead.'
-    defaultConfig.updatecliConfig.cronTriggerExpression = userConfig.cronTriggerExpression
   }
 
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
@@ -48,7 +44,7 @@ def call(userConfig = [:]) {
         updatecli(updatecliConfig)
         if (env.BRANCH_IS_PRIMARY) {
           // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
-          updatecliConfig = finalConfig.updatecliConfig << [action: 'apply', cronTriggerExpression: defaultUpdatecliCronTriggerExpression]
+          updatecliConfig = finalConfig.updatecliConfig << [action: 'apply', cronTriggerExpression: finalConfig.updatecliApplyCronTriggerExpression]
           updatecli(updatecliConfig)
         }
       }

--- a/vars/parallelDockerUpdatecli.txt
+++ b/vars/parallelDockerUpdatecli.txt
@@ -4,9 +4,11 @@ The following arguments are available for this function:
 - String **imageName**: (Mandatory) name of the image to built, usually referenced as the "Repository" part of a Docker image's name without any tag (Example: "builder" or "terraform").
 - String **mainBranch**: (Optional - Default: "main") name of the main branch of the repository
 - String **rebuildImageOnPeriodicJob**: (Optional - Default: true) specify if the docker image has to be rebuilt and republished when triggered by a periodic job.
-- String **cronTriggerExpression**: (Optional - Default: "@weekly") Enable periodic updatecli execution by providing a cron-like expression.
-- String **containerMemory**: (Optional - Default: "128Mi") specify the amount of memory dedicated to the updatecli container.
+- String **updatecliApplyCronTriggerExpression**: (Optional - Default: "@weekly") Enable periodic updatecli execution by providing a cron-like expression.
 - String **credentialsId**: (Optional - Default: "updatecli-github-token") specify the credentials used by updatecli to interact with github.
+- Map **updatecliConfig** (Optional - Default: empty map) specify custom parameters for the underlying "updatecli()" actions. Please look at the "updatecli()" global library documentation.
+[Deprecated]
+- String **containerMemory**: (Optional - Default: "128Mi") specify the amount of memory dedicated to the updatecli container.
 
 Examples:
 <code>


### PR DESCRIPTION
This PR allow passing custom configuration to updatecli (such as a custom Docker Image).

Former syntax is still supported but with a warning.

Tested in https://github.com/jenkins-infra/docker-openvpn/pull/139