### PR TITLE
feat(buildDockerAndPublishImage) allow building on VM agent with Docker Engine

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -10,6 +10,7 @@ TEST_HARNESS ?= $(IMAGE_DIR)/cst.yml
 
 ## Use this variable if you want to use Docker instead
 CONTAINER_BIN ?= img
+HADOLINT_BIN ?= hadolint
 
 ## Image metadatas
 GIT_COMMIT_REV ?= $(shell git log -n 1 --pretty=format:'%h')

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -26,7 +26,7 @@ all: clean lint build test ## Execute the complete process except the "deploy" s
 lint: ## Lint the $(IMAGE_DOCKERFILE) content
 	@echo "== Linting $(IMAGE_DOCKERFILE)..."
 	@echo "Writing Lint results to $(HADOLINT_REPORT)"
-	@hadolint --format=json $(IMAGE_DOCKERFILE) > $(HADOLINT_REPORT)
+	@$(HADOLINT_BIN) --format=json - < $(IMAGE_DOCKERFILE) > $(HADOLINT_REPORT)
 	@echo "== Lint ✅ Succeeded"
 
 build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE) and export it to $(IMAGE_ARCHIVE)

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -8,15 +8,24 @@ IMAGE_PLATFORM ?= linux/amd64
 HADOLINT_REPORT ?= $(IMAGE_DIR)/hadolint.json
 TEST_HARNESS ?= $(IMAGE_DIR)/cst.yml
 
-## Use this variable if you want to use Docker instead
+## Locate command line tools. Defaults to rely on PATH
 CONTAINER_BIN ?= img
 HADOLINT_BIN ?= hadolint
+CST_BIN ?= container-structure-test
 
 ## Image metadatas
 GIT_COMMIT_REV ?= $(shell git log -n 1 --pretty=format:'%h')
 GIT_SCM_URL ?= $(shell git config --get remote.origin.url)
 SCM_URI ?= $(subst git@github.com:,https://github.com/,$(GIT_SCM_URL))
 BUILD_DATE ?= $(shell date --utc '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || gdate --utc '+%Y-%m-%dT%H:%M:%S')
+
+## Test Harness settings
+CST_DRIVER ?= tar # https://github.com/GoogleContainerTools/container-structure-test#running-file-tests-without-docker
+ifeq ($(CST_DRIVER),tar)
+CST_SUT = $(IMAGE_ARCHIVE)
+else
+CST_SUT = $(IMAGE_NAME)
+endif
 
 help: ## Show this Makefile's help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -32,7 +41,7 @@ lint: ## Lint the $(IMAGE_DOCKERFILE) content
 build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE) and export it to $(IMAGE_ARCHIVE)
 	@echo "== Building $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)..."
 	@$(CONTAINER_BIN) build \
-		-t $(IMAGE_NAME) \
+		--tag $(IMAGE_NAME) \
 		--build-arg "GIT_COMMIT_REV=$(GIT_COMMIT_REV)" \
 		--build-arg "GIT_SCM_URL=$(GIT_SCM_URL)" \
 		--build-arg "BUILD_DATE=$(BUILD_DATE)" \
@@ -45,9 +54,8 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE) and expo
 		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
 		--label "org.label-schema.build-date=$(BUILD_DATE)" \
 		--platform $(IMAGE_PLATFORM) \
-		-f $(IMAGE_DOCKERFILE) \
+		--file $(IMAGE_DOCKERFILE) \
 		$(IMAGE_DIR)
-	@$(CONTAINER_BIN) save --output=$(IMAGE_ARCHIVE) $(IMAGE_NAME)
 	@echo "== Build ✅ Succeeded, image $(IMAGE_NAME) exported to $(IMAGE_ARCHIVE)."
 
 clean: ## Delete any file generated during the build steps
@@ -57,7 +65,10 @@ clean: ## Delete any file generated during the build steps
 
 test: ## Execute the test harness on the Docker Image archive at $(IMAGE_ARCHIVE)
 	@echo "== Test $(IMAGE_NAME) with $(TEST_HARNESS) from $(IMAGE_ARCHIVE)..."
-	@container-structure-test test --driver=tar --image=$(IMAGE_ARCHIVE) --config=$(TEST_HARNESS)
+ifeq ($(CST_DRIVER),tar)
+	$(CONTAINER_BIN) save --output=$(IMAGE_ARCHIVE) $(IMAGE_NAME)
+endif
+	$(CST_BIN) test --driver=$(CST_DRIVER) --image=$(CST_SUT) --config=$(TEST_HARNESS)
 	@echo "== Test ✅ Succeeded"
 
 ## This steps expects that you are logged to the Docker registry to push image into

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -11,7 +11,6 @@ TEST_HARNESS ?= $(IMAGE_DIR)/cst.yml
 ## Use this variable if you want to use Docker instead
 CONTAINER_BIN ?= img
 
-
 ## Image metadatas
 GIT_COMMIT_REV ?= $(shell git log -n 1 --pretty=format:'%h')
 GIT_SCM_URL ?= $(shell git config --get remote.origin.url)

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -114,7 +114,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   Boolean assertContainerVM(expectedNodeLabelPattern = 'docker') {
     return assertMethodCallContainsPattern('node', expectedNodeLabelPattern) \
       && assertMethodCallContainsPattern('withEnv', 'CONTAINER_BIN=docker') \
-      && assertMethodCallContainsPattern('withEnv', 'HADOLINT_BIN=docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" hadolint/hadolint hadolint') \
+      && assertMethodCallContainsPattern('withEnv', 'HADOLINT_BIN=docker run --rm hadolint/hadolint:latest hadolint') \
       && !assertContainerAgent()
   }
 

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -93,7 +93,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     }
   }
 
-  // return if the set of method expected for ALL pipeline run have been detected in the callstack
+  // Return if the set of methods expected for ALL pipeline run have been detected in the callstack
   Boolean assertBaseWorkflow() {
     return assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile') \
       && assertMethodCallContainsPattern('sh','make lint') \
@@ -103,14 +103,14 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       && assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}")
   }
 
-  // return if the mocked pipeline ran in a container agent with the `img` containerless engine
+  // Return if the mocked pipeline ran in a container agent with the `img` containerless engine
   Boolean assertContainerAgent() {
     return assertMethodCallContainsPattern('containerTemplate', 'jenkinsciinfra/builder:') \
       && assertMethodCallContainsPattern('withEnv', 'CONTAINER_BIN=img') \
       && !assertContainerVM()
   }
 
-  // return if the mocked pipeline ran in a VM agent with the Docker Engine
+  // Return if the mocked pipeline ran in a VM agent with the Docker Engine
   Boolean assertContainerVM(expectedNodeLabelPattern = 'docker') {
     return assertMethodCallContainsPattern('node', expectedNodeLabelPattern) \
       && assertMethodCallContainsPattern('withEnv', 'CONTAINER_BIN=docker') \
@@ -118,7 +118,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       && !assertContainerAgent()
   }
 
-  // return if the usual static checks had been recorded with the usual pattern
+  // Return if the usual static checks had been recorded with the usual pattern
   Boolean assertRecordIssues(String imageName = testImageName) {
     return assertMethodCallContainsPattern('recordIssues', "{enabledForFailure=true, aggregatingResults=false, tool={id=${imageName}-hadolint-${mockedTimestamp}, pattern=${imageName}-hadolint-${mockedTimestamp}.json}}")
   }
@@ -468,12 +468,12 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertTrue(assertBaseWorkflow())
     assertTrue(assertContainerVM())
 
-    // And the expected environment variable defined to their defaults
+    // And the expected environment variables set to their default values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=.'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=Dockerfile'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORM=linux/amd64'))
 
-    // And generated reports are recorded
+    // And generated reports recorded
     assertTrue(assertRecordIssues())
 
     // And the deploy step called
@@ -482,7 +482,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // But no release created automatically
     assertFalse(assertTagPushed(defaultGitTag))
 
-    // And all mocked/stubbed methods have to be called
+    // And all mocked/stubbed methods been called
     verifyMocks()
   }
 
@@ -505,21 +505,21 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertTrue(assertBaseWorkflow())
     assertTrue(assertContainerVM('docker-windows'))
 
-    // And the expected environment variable defined to their defaults
+    // And the expected environment variables set to their default values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=.'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=Dockerfile'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORM=linux/amd64'))
 
-    // And generated reports are recorded
+    // And generated reports recorded
     assertTrue(assertRecordIssues())
 
-    // But no deploy step called (not on princiopal branch)
+    // But no deploy step called (not on principal branch)
     assertFalse(assertMakeDeploy())
 
     // But no release created automatically
     assertFalse(assertTagPushed(defaultGitTag))
 
-    // And all mocked/stubbed methods have to be called
+    // And all mocked/stubbed methods been called
     verifyMocks()
   }
 }

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -114,6 +114,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   Boolean assertContainerVM(expectedNodeLabelPattern = 'docker') {
     return assertMethodCallContainsPattern('node', expectedNodeLabelPattern) \
       && assertMethodCallContainsPattern('withEnv', 'CONTAINER_BIN=docker') \
+      && assertMethodCallContainsPattern('withEnv', 'HADOLINT_BIN=docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" hadolint/hadolint hadolint') \
       && !assertContainerAgent()
   }
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -177,7 +177,10 @@ def withContainerEngineAgent(finalConfig, body) {
     }
   } else {
     node(finalConfig.agentLabels) {
-      withEnv(['CONTAINER_BIN=docker']) {
+      withEnv([
+        'CONTAINER_BIN=docker',
+        'HADOLINT_BIN=docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" hadolint/hadolint hadolint',
+        ]) {
         body.call()
       }
     }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -6,7 +6,7 @@ import java.text.DateFormat
 def call(String imageName, Map userConfig=[:]) {
   def defaultConfig = [
     useContainer: true, // Wether to use a container (with a container-less and root-less tool) or a VM (with a full-fledge Docker Engine) for executing the steps
-    agentLabels: 'docker', // String expression for the labels that the agent must match
+    agentLabels: 'docker || linux-amd64-docker', // String expression for the labels that the agent must match
     builderImage: 'jenkinsciinfra/builder:2.0.2', // Version managed by updatecli
     automaticSemanticVersioning: false, // Do not automagically increase semantic version by default
     dockerfile: 'Dockerfile', // Obvious default
@@ -179,7 +179,7 @@ def withContainerEngineAgent(finalConfig, body) {
     node(finalConfig.agentLabels) {
       withEnv([
         'CONTAINER_BIN=docker',
-        'HADOLINT_BIN=docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" hadolint/hadolint hadolint',
+        'HADOLINT_BIN=docker run --rm hadolint/hadolint:latest hadolint',
         ]) {
         body.call()
       }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -5,8 +5,8 @@ import java.text.DateFormat
 
 def call(String imageName, Map userConfig=[:]) {
   def defaultConfig = [
-    useContainer: true, // Wether to use a container (with a container-less and root-less tool) or a VM (with a full-fledge Docker Engine) for executing the steps
-    agentLabels: 'docker || linux-amd64-docker', // String expression for the labels that the agent must match
+    useContainer: true, // Wether to use a container (with a container-less and root-less tool) or a VM (with a full-fledged Docker Engine) for executing the steps
+    agentLabels: 'docker || linux-amd64-docker', // String expression for the labels the agent must match
     builderImage: 'jenkinsciinfra/builder:2.0.2', // Version managed by updatecli
     automaticSemanticVersioning: false, // Do not automagically increase semantic version by default
     dockerfile: 'Dockerfile', // Obvious default
@@ -44,7 +44,7 @@ def call(String imageName, Map userConfig=[:]) {
           sh 'echo "${DOCKER_REGISTRY_PSW}" | "${CONTAINER_BIN}" login -u "${DOCKER_REGISTRY_USR}" --password-stdin'
 
           // The makefile to use must come from the pipeline to avoid a nasty user trying to exfiltrate data from the build
-          // Even though we have mitigation trhough the multibranch job config only allowed to build PRs from repo. contributors
+          // Even though we have mitigation through the multibranch job config allowing to build PRs only from the repository contributors
           writeFile file: 'Makefile', text: makefileContent
         } // withCredentials
       } // stage
@@ -63,7 +63,7 @@ def call(String imageName, Map userConfig=[:]) {
         def hadoLintReportFile = "${hadolintReportId}.json"
         withEnv([
           "HADOLINT_REPORT=${env.WORKSPACE}/${hadoLintReportFile}",
-          'HADOLINT_BIN=docker run --rm hadolint/hadolint:latest hadolint', // Do not put the command (right part of the assignation) between quote to ensure that bash treat it as an array of string
+          'HADOLINT_BIN=docker run --rm hadolint/hadolint:latest hadolint', // Do not put the command (right part of the assignation) between quotes to ensure that bash treat it as an array of strings
         ]) {
           try {
             sh 'make lint'
@@ -162,7 +162,7 @@ def call(String imageName, Map userConfig=[:]) {
         } // stage
       } // if
 
-      // Logging out to ensure that credentials are cleanup up if the current agent is reused
+      // Logging out to ensure credentials are cleaned up if the current agent is reused
       sh '"${CONTAINER_BIN}" logout'
     } // withEnv
   }) // withContainerEngineAgent

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -5,6 +5,8 @@ import java.text.DateFormat
 
 def call(String imageName, Map userConfig=[:]) {
   def defaultConfig = [
+    useContainer: true, // Wether to use a container (with a container-less and root-less tool) or a VM (with a full-fledge Docker Engine) for executing the steps
+    agentLabels: 'docker', // String expression for the labels that the agent must match
     builderImage: 'jenkinsciinfra/builder:2.0.2', // Version managed by updatecli
     automaticSemanticVersioning: false, // Do not automagically increase semantic version by default
     dockerfile: 'Dockerfile', // Obvious default
@@ -26,139 +28,158 @@ def call(String imageName, Map userConfig=[:]) {
   DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
   final String buildDate = dateFormat.format(now)
 
-  // The podTemplate must define only a single container, named `jnlp`
-  // Ref - https://support.cloudbees.com/hc/en-us/articles/360054642231-Considerations-for-Kubernetes-Clients-Connections-when-using-Kubernetes-Plugin
-  podTemplate(
-    annotations: [
-      podAnnotation(key: 'container.apparmor.security.beta.kubernetes.io/jnlp', value: 'unconfined'),
-      podAnnotation(key: 'container.seccomp.security.alpha.kubernetes.io/jnlp', value: 'unconfined'),
-    ],
-    containers: [
-      // This container must be named `jnlp` and should use the default entrypoint/cmd (command/args) inherited from inbound-agent parent image
-      containerTemplate(
-        name: 'jnlp',
-        image: finalConfig.builderImage,
-        resourceRequestCpu: '2',
-        resourceLimitCpu: '2',
-        resourceRequestMemory: '2Gi',
-        resourceLimitMemory: '2Gi',
-      ),
-    ]
-  ) {
-    node(POD_LABEL) {
-      withEnv([
-        "BUILD_DATE=${buildDate}",
-        "IMAGE_NAME=${imageName}",
-        "IMAGE_DIR=${finalConfig.imageDir}",
-        "IMAGE_DOCKERFILE=${finalConfig.dockerfile}",
-        "IMAGE_PLATFORM=${finalConfig.platform}",
-      ]) {
-        stage("Prepare ${imageName}") {
-          withCredentials([usernamePassword(credentialsId: finalConfig.credentials, passwordVariable: 'DOCKER_REGISTRY_PSW', usernameVariable: 'DOCKER_REGISTRY_USR')]) {
-            checkout scm
+  withContainerEngineAgent(finalConfig, {
+    withEnv([
+      "BUILD_DATE=${buildDate}",
+      "IMAGE_NAME=${imageName}",
+      "IMAGE_DIR=${finalConfig.imageDir}",
+      "IMAGE_DOCKERFILE=${finalConfig.dockerfile}",
+      "IMAGE_PLATFORM=${finalConfig.platform}",
+    ]) {
+      stage("Prepare ${imageName}") {
+        withCredentials([usernamePassword(credentialsId: finalConfig.credentials, passwordVariable: 'DOCKER_REGISTRY_PSW', usernameVariable: 'DOCKER_REGISTRY_USR')]) {
+          checkout scm
 
-            // Logging in on the Dockerhub helps to avoid request limit from DockerHub
-            sh 'echo "${DOCKER_REGISTRY_PSW}" | img login -u "${DOCKER_REGISTRY_USR}" --password-stdin'
+          // Logging in on the Dockerhub helps to avoid request limit from DockerHub
+          sh 'echo "${DOCKER_REGISTRY_PSW}" | "${CONTAINER_BIN}" login -u "${DOCKER_REGISTRY_USR}" --password-stdin'
 
-            // The makefile to use must come from the pipeline to avoid a nasty user trying to exfiltrate data from the build
-            // Even though we have mitigation trhough the multibranch job config only allowed to build PRs from repo. contributors
-            writeFile file: 'Makefile', text: makefileContent
-          } // withCredentials
+          // The makefile to use must come from the pipeline to avoid a nasty user trying to exfiltrate data from the build
+          // Even though we have mitigation trhough the multibranch job config only allowed to build PRs from repo. contributors
+          writeFile file: 'Makefile', text: makefileContent
+        } // withCredentials
+      } // stage
+
+      // Automatic tagging on principal branch is not enabled by default
+      if (semVerEnabled) {
+        stage("Get Next Version of ${imageName}") {
+          nextVersion = sh(script:"${finalConfig.nextVersionCommand}", returnStdout: true).trim()
+          echo "Next Release Version = $nextVersion"
         } // stage
+      } // if
 
-        // Automatic tagging on principal branch is not enabled by default
-        if (semVerEnabled) {
-          stage("Get Next Version of ${imageName}") {
-            nextVersion = sh(script:"${finalConfig.nextVersionCommand}", returnStdout: true).trim()
-            echo "Next Release Version = $nextVersion"
-          } // stage
-        } // if
-
-        stage("Lint ${imageName}") {
-          // Define the image name as prefix to support multi images per pipeline
-          def hadolintReportId = "${imageName.replaceAll(':','-')}-hadolint-${now.getTime()}"
-          def hadoLintReportFile = "${hadolintReportId}.json"
-          withEnv(["HADOLINT_REPORT=${env.WORKSPACE}/${hadoLintReportFile}"]) {
-            try {
-              sh 'make lint'
-            } finally {
-              recordIssues(
-                enabledForFailure: true,
-                aggregatingResults: false,
-                tool: hadoLint(id: hadolintReportId, pattern: hadoLintReportFile)
-              )
-            }
+      stage("Lint ${imageName}") {
+        // Define the image name as prefix to support multi images per pipeline
+        def hadolintReportId = "${imageName.replaceAll(':','-')}-hadolint-${now.getTime()}"
+        def hadoLintReportFile = "${hadolintReportId}.json"
+        withEnv(["HADOLINT_REPORT=${env.WORKSPACE}/${hadoLintReportFile}"]) {
+          try {
+            sh 'make lint'
+          } finally {
+            recordIssues(
+              enabledForFailure: true,
+              aggregatingResults: false,
+              tool: hadoLint(id: hadolintReportId, pattern: hadoLintReportFile)
+            )
           }
-        } // stage
-
-        stage("Build ${imageName}") {
-          sh 'make build'
-        } //stage
-
-        // There can be 2 kind of tests: per image and per repository
-        [
-          "Image Test Harness": "${finalConfig.imageDir}/cst.yml",
-          "Common Test Harness": "${env.WORKSPACE}/common-cst.yml"
-        ].each { testName, testHarness ->
-          if (fileExists(testHarness)) {
-            stage("Test ${testName} for ${imageName}") {
-              withEnv(["TEST_HARNESS=${testHarness}"]) {
-                sh 'make test'
-              } // withEnv
-            } //stage
-          } // if
         }
+      } // stage
 
-        // Automatic tagging on principal branch is not enabled by default
-        if (semVerEnabled) {
-          stage("Semantic Release of ${imageName}") {
-            echo "Configuring credential.helper"
-            sh 'git config --local credential.helper "!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f"'
+      stage("Build ${imageName}") {
+        sh 'make build'
+      } //stage
 
-            withCredentials([usernamePassword(credentialsId: "${finalConfig.gitCredentials}", passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-              echo "Tagging New Version: $nextVersion"
-              sh "git tag $nextVersion"
-
-              echo "Pushing Tag"
-              sh "git push origin --tags"
-            }
-          } // stage
-        } // if
-
-        if (env.TAG_NAME || env.BRANCH_IS_PRIMARY) {
-          stage("Deploy ${imageName}") {
-            final InfraConfig infraConfig = new InfraConfig(env)
-            String imageDeployName = infraConfig.dockerRegistry + '/' + imageName
-
-            if(env.TAG_NAME) {
-              // User could specify a tag in the image name. In that case the git tag is appended. Otherwise the docker tag is set to the git tag.
-              if(imageDeployName.contains(':')) {
-                imageDeployName += "-${env.TAG_NAME}"
-              } else {
-                imageDeployName += ":${env.TAG_NAME}"
-              }
-            }
-            sh "IMAGE_DEPLOY_NAME=${imageDeployName} make deploy"
+      // There can be 2 kind of tests: per image and per repository
+      [
+        "Image Test Harness": "${finalConfig.imageDir}/cst.yml",
+        "Common Test Harness": "${env.WORKSPACE}/common-cst.yml"
+      ].each { testName, testHarness ->
+        if (fileExists(testHarness)) {
+          stage("Test ${testName} for ${imageName}") {
+            withEnv(["TEST_HARNESS=${testHarness}"]) {
+              sh 'make test'
+            } // withEnv
           } //stage
         } // if
+      }
 
-        if (env.TAG_NAME && finalConfig.automaticSemanticVersioning) {
-          stage("GitHub Release") {
-            withCredentials([usernamePassword(credentialsId: "${finalConfig.gitCredentials}", passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')]) {
-              String origin = sh(returnStdout: true, script: 'git remote -v | grep origin | grep push | sed \'s/^origin\\s//\' | sed \'s/\\s(push)//\'').trim() - '.git'
-              String org = origin.split('/')[3]
-              String repository = origin.split('/')[4]
+      // Automatic tagging on principal branch is not enabled by default
+      if (semVerEnabled) {
+        stage("Semantic Release of ${imageName}") {
+          echo "Configuring credential.helper"
+          sh 'git config --local credential.helper "!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f"'
 
-              try {
-                  String release = sh(returnStdout: true, script: "gh api /repos/${org}/${repository}/releases | jq -e -r '.[] | select(.draft == true and .name == \"next\") | .id'").trim()
-                  sh "gh api -X PATCH -F draft=false -F name=${env.TAG_NAME} -F tag_name=${env.TAG_NAME} /repos/${org}/${repository}/releases/$release"
-              } catch (err) {
-                  echo "Release named 'next' does not exist"
-              }
-            } // withCredentials
-          } // stage
-        } // if
-      } // withEnv
-    } // node
-  } // podTemplate
+          withCredentials([usernamePassword(credentialsId: "${finalConfig.gitCredentials}", passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+            echo "Tagging New Version: $nextVersion"
+            sh "git tag $nextVersion"
+
+            echo "Pushing Tag"
+            sh "git push origin --tags"
+          }
+        } // stage
+      } // if
+
+      if (env.TAG_NAME || env.BRANCH_IS_PRIMARY) {
+        stage("Deploy ${imageName}") {
+          final InfraConfig infraConfig = new InfraConfig(env)
+          String imageDeployName = infraConfig.dockerRegistry + '/' + imageName
+
+          if(env.TAG_NAME) {
+            // User could specify a tag in the image name. In that case the git tag is appended. Otherwise the docker tag is set to the git tag.
+            if(imageDeployName.contains(':')) {
+              imageDeployName += "-${env.TAG_NAME}"
+            } else {
+              imageDeployName += ":${env.TAG_NAME}"
+            }
+          }
+          sh "IMAGE_DEPLOY_NAME=${imageDeployName} make deploy"
+        } //stage
+      } // if
+
+      if (env.TAG_NAME && finalConfig.automaticSemanticVersioning) {
+        stage("GitHub Release") {
+          withCredentials([usernamePassword(credentialsId: "${finalConfig.gitCredentials}", passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')]) {
+            String origin = sh(returnStdout: true, script: 'git remote -v | grep origin | grep push | sed \'s/^origin\\s//\' | sed \'s/\\s(push)//\'').trim() - '.git'
+            String org = origin.split('/')[3]
+            String repository = origin.split('/')[4]
+
+            try {
+                String release = sh(returnStdout: true, script: "gh api /repos/${org}/${repository}/releases | jq -e -r '.[] | select(.draft == true and .name == \"next\") | .id'").trim()
+                sh "gh api -X PATCH -F draft=false -F name=${env.TAG_NAME} -F tag_name=${env.TAG_NAME} /repos/${org}/${repository}/releases/$release"
+            } catch (err) {
+                echo "Release named 'next' does not exist"
+            }
+          } // withCredentials
+        } // stage
+      } // if
+
+      // Logging out to ensure that credentials are cleanup up if the current agent is reused
+      sh '"${CONTAINER_BIN}" logout'
+    } // withEnv
+  }) // withContainerEngineAgent
 } // call
+
+def withContainerEngineAgent(finalConfig, body) {
+  if (finalConfig.useContainer) {
+    // The podTemplate must define only a single container, named `jnlp`
+    // Ref - https://support.cloudbees.com/hc/en-us/articles/360054642231-Considerations-for-Kubernetes-Clients-Connections-when-using-Kubernetes-Plugin
+    podTemplate(
+      annotations: [
+        podAnnotation(key: 'container.apparmor.security.beta.kubernetes.io/jnlp', value: 'unconfined'),
+        podAnnotation(key: 'container.seccomp.security.alpha.kubernetes.io/jnlp', value: 'unconfined'),
+      ],
+      containers: [
+        // This container must be named `jnlp` and should use the default entrypoint/cmd (command/args) inherited from inbound-agent parent image
+        containerTemplate(
+          name: 'jnlp',
+          image: finalConfig.builderImage,
+          resourceRequestCpu: '2',
+          resourceLimitCpu: '2',
+          resourceRequestMemory: '2Gi',
+          resourceLimitMemory: '2Gi',
+        ),
+      ]
+    ) {
+      node(POD_LABEL) {
+        withEnv(['CONTAINER_BIN=img']) {
+          body.call()
+        }
+      }
+    }
+  } else {
+    node(finalConfig.agentLabels) {
+      withEnv(['CONTAINER_BIN=docker']) {
+        body.call()
+      }
+    }
+  }
+}

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -6,6 +6,7 @@ The following arguments are available for this function:
 
 - String **imageName**: (Mandatory) name of the image to build, usually referenced as the "Repository" part of a Docker image name without any tag (Example: "builder" or "terraform").
 - Map **config**: (Optional) custom configuration for the image build and deploy process. This map can hold any of the following keys:
+  * Boolean **useContainer** (Optional, defaults to false) Execute the phases inside a container, using a container-less and root-less tool. If set to false, then the phases are run with Docker CE running in a VM.
   * String **dockerfile**: (Optional, defaults to "Dockerfile") Relative path to the Dockerfile to use within the repository (Example: "build.dockerfile", "docker/Dockerfile").
   * String **imageDir**: (Optional, defaults to the parent directory of "Dockerfile") Path to a directory to use as build context (Example: "docker/", "python/2.7").
   * String **credentials**: (Optional, defaults to "jenkins-dockerhub") Name of the Jenkins' credentials used to authenticate on the Docker remote registry during the full build process. (Example: "internal-registry-credential").


### PR DESCRIPTION
This PR allows executing the library `buildDockerAndPublishImage()` with Docker Engine inside a VM (instead of the container-less tool `img` inside Kuberneets Pod).

The default behavior is kept to use `img` to avoid breaking everything: let's use this on a set of predefined docker images for 1-2 weeks, and if no major issue arise, then let's switch default to Docker.

Tested on a real life example in https://github.com/jenkins-infra/docker-helmfile/pull/66 .


It allows to build images based on Alpine 3.14+ that require using a recent container engine with the correct setups.


Please note that the tests run in CST are faster when using the Docker driver instead of the tar driver, and are able to run "docker commands" (improved test harnesses).

 