### PR TITLE
fix(buildDockerAndPublishImage) add missing tools for releases

### DIFF
--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -107,15 +107,14 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   Boolean assertContainerAgent() {
     return assertMethodCallContainsPattern('containerTemplate', 'jenkinsciinfra/builder:') \
       && assertMethodCallContainsPattern('withEnv', 'CONTAINER_BIN=img') \
-      && !assertContainerVM()
+      && !assertMethodCallContainsPattern('withEnv', 'HADOLINT_BIN=docker run --rm hadolint/hadolint:latest hadolint')
   }
 
   // Return if the mocked pipeline ran in a VM agent with the Docker Engine
   Boolean assertContainerVM(expectedNodeLabelPattern = 'docker') {
     return assertMethodCallContainsPattern('node', expectedNodeLabelPattern) \
       && assertMethodCallContainsPattern('withEnv', 'CONTAINER_BIN=docker') \
-      && assertMethodCallContainsPattern('withEnv', 'HADOLINT_BIN=docker run --rm hadolint/hadolint:latest hadolint') \
-      && !assertContainerAgent()
+      && assertMethodCallContainsPattern('withEnv', 'HADOLINT_BIN=docker run --rm hadolint/hadolint:latest hadolint')
   }
 
   // Return if the usual static checks had been recorded with the usual pattern

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -171,8 +171,7 @@ def call(String imageName, Map userConfig=[:]) {
             final String platformId = "${operatingSystem}_${cpuArch}"
             final String ghUrl = "https://github.com/cli/cli/releases/download/v${ghVersion}/gh_${ghVersion}_${platformId}.tar.gz"
 
-            try {
-              withEnv([
+            withEnv([
               "platform_id=${platformId}",
               "gh_url=${ghUrl}",
             ]) {
@@ -189,11 +188,9 @@ def call(String imageName, Map userConfig=[:]) {
               fi
               '''
             }
-              String release = sh(returnStdout: true, script: "gh api /repos/${org}/${repository}/releases | jq -e -r '.[] | select(.draft == true and .name == \"next\") | .id'").trim()
-              sh "gh api -X PATCH -F draft=false -F name=${env.TAG_NAME} -F tag_name=${env.TAG_NAME} /repos/${org}/${repository}/releases/$release"
-            } catch (err) {
-                echo "Release named 'next' does not exist"
-            }
+
+            final String release = sh(returnStdout: true, script: "gh api /repos/${org}/${repository}/releases | jq -e -r '.[] | select(.draft == true and .name == \"next\") | .id'").trim()
+            sh "gh api -X PATCH -F draft=false -F name=${env.TAG_NAME} -F tag_name=${env.TAG_NAME} /repos/${org}/${repository}/releases/$release"
           } // withCredentials
         } // stage
       } // if


### PR DESCRIPTION
This PR introduces a set of fixes to the `buildDockerAndPublishImage()` library, following #311 

- Fix a bug at the `lint` phase which was using (unexpectedly) `docker run` to execute hadolint when running in docker-less environment (was blocking the last build of `docker-openvpn`)
- Fix a bug where automatic tagging and automatic releases were failing in VM environments by installing the missing tools  (`gh` and `jx-release-version`)
- Fix a bug where release builds weren't failing when the GH release wasn't found (or tooling not installed)