### PR TITLE
fix(buildDockerAndPublishImage) use tar image when testing in a containerless environment

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -9,7 +9,7 @@ HADOLINT_REPORT ?= $(IMAGE_DIR)/hadolint.json
 TEST_HARNESS ?= $(IMAGE_DIR)/cst.yml
 
 ## Locate command line tools. Defaults to rely on PATH
-CONTAINER_BIN ?= img
+CONTAINER_BIN ?= docker
 HADOLINT_BIN ?= hadolint
 CST_BIN ?= container-structure-test
 
@@ -20,7 +20,7 @@ SCM_URI ?= $(subst git@github.com:,https://github.com/,$(GIT_SCM_URL))
 BUILD_DATE ?= $(shell date --utc '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || gdate --utc '+%Y-%m-%dT%H:%M:%S')
 
 ## Test Harness settings
-CST_DRIVER ?= tar # https://github.com/GoogleContainerTools/container-structure-test#running-file-tests-without-docker
+CST_DRIVER ?= docker # https://github.com/GoogleContainerTools/container-structure-test#running-file-tests-without-docker
 ifeq ($(CST_DRIVER),tar)
 CST_SUT = $(IMAGE_ARCHIVE)
 else

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -107,6 +107,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   Boolean assertContainerAgent() {
     return assertMethodCallContainsPattern('containerTemplate', 'jenkinsciinfra/builder:') \
       && assertMethodCallContainsPattern('withEnv', 'CONTAINER_BIN=img') \
+      && assertMethodCallContainsPattern('withEnv', 'CST_DRIVER=tar') \
       && !assertMethodCallContainsPattern('withEnv', 'HADOLINT_BIN=docker run --rm hadolint/hadolint:latest hadolint')
   }
 
@@ -114,6 +115,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   Boolean assertContainerVM(expectedNodeLabelPattern = 'docker') {
     return assertMethodCallContainsPattern('node', expectedNodeLabelPattern) \
       && assertMethodCallContainsPattern('withEnv', 'CONTAINER_BIN=docker') \
+      && assertMethodCallContainsPattern('withEnv', 'CST_DRIVER=docker') \
       && assertMethodCallContainsPattern('withEnv', 'HADOLINT_BIN=docker run --rm hadolint/hadolint:latest hadolint')
   }
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -226,7 +226,7 @@ def withContainerEngineAgent(finalConfig, body) {
         withEnv([
           'CONTAINER_BIN=img',
           'CST_DRIVER=tar',
-          ]) {
+        ]) {
           body.call()
         }
       }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -223,7 +223,10 @@ def withContainerEngineAgent(finalConfig, body) {
       ]
     ) {
       node(POD_LABEL) {
-        withEnv(['CONTAINER_BIN=img']) {
+        withEnv([
+          'CONTAINER_BIN=img',
+          'CST_DRIVER=tar',
+          ]) {
           body.call()
         }
       }


### PR DESCRIPTION
This PR fixes a regression when testing a container with `container-structure-test` when the driver `tar` (container-less) is specified.

- Unit test added
- Default environement for build and test is now `docker`
- Acceptance tested in https://github.com/jenkins-infra/docker-hashicorp-tools/pull/46 with the build [#3](https://infra.ci.jenkins.io/blue/organizations/jenkins/Docker%20Builds%2Fdocker-hashicorp-tools/detail/PR-46/3/pipeline/71/) with the driver tar:

```
+ command -v container-structure-test
+ make test
== Test hashicorp-tools with ./cst.yml from ./image.tar...
img save --output=./image.tar hashicorp-tools
container-structure-test test --driver=tar --image=./image.tar --config=./cst.yml
```