### PR TITLE
feat(parallelDockerUpdatecli) allow building Docker images in VMs

### DIFF
--- a/test/groovy/ParallelDockerUpdatecliStepTests.groovy
+++ b/test/groovy/ParallelDockerUpdatecliStepTests.groovy
@@ -61,6 +61,9 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
 
     // And the correct image name is passed to buildDockerAndPublishImage
     assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', testImageName))
+    // And the correct settings
+    assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', 'automaticSemanticVersioning=true'))
+    assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', 'gitCredentials=github-app-infra'))
 
     // And updatecli(action: 'diff') is called
     assertTrue(assertMethodCallContainsPattern('updatecli', 'action=diff'))
@@ -162,6 +165,9 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
       updatecliConfig: [
         containerMemory: anotherContainerMemory,
       ],
+      buildDockerConfig: [
+        useContainer: false,
+      ],
       credentialsId: anotherCredentialsId
     )
     printCallStack()
@@ -174,6 +180,11 @@ class ParallelDockerUpdatecliStepTests extends BaseTest {
 
     // And the correct image name is passed to buildDockerAndPublishImage
     assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', testImageName))
+    // And the correct fixed settings for buildDockerAndPublishImage
+    assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', 'automaticSemanticVersioning=true'))
+    assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', 'gitCredentials=github-app-infra'))
+    // And the custom settings for buildDockerAndPublishImage
+    assertTrue(assertMethodCallContainsPattern('buildDockerAndPublishImage', 'useContainer=false'))
 
     // And updatecli(action: 'diff') is called
     assertTrue(assertMethodCallContainsPattern('updatecli', 'action=diff'))

--- a/vars/parallelDockerUpdatecli.groovy
+++ b/vars/parallelDockerUpdatecli.groovy
@@ -7,6 +7,7 @@ def call(userConfig = [:]) {
     credentialsId: 'updatecli-github-token',
     updatecliApplyCronTriggerExpression: '@weekly',
     updatecliConfig: [:],
+    buildDockerConfig: [:],
   ]
 
   if (userConfig.containerMemory) {
@@ -28,10 +29,9 @@ def call(userConfig = [:]) {
     'docker-image': {
       // Do not rebuild the image when triggered by a periodic job if the config desactivate them
       if (finalConfig.rebuildImageOnPeriodicJob || (!finalConfig.rebuildImageOnPeriodicJob && !currentBuild.getBuildCauses().contains('hudson.triggers.TimerTrigger'))) {
-        buildDockerAndPublishImage(finalConfig.imageName, [
-          automaticSemanticVersioning: true,
-          gitCredentials: 'github-app-infra'
-        ])
+        // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
+        final Map dockerBuildConfig = [automaticSemanticVersioning: true, gitCredentials: 'github-app-infra'] << finalConfig.buildDockerConfig
+        buildDockerAndPublishImage(finalConfig.imageName, dockerBuildConfig)
       }
     },
     'updatecli': {


### PR DESCRIPTION
This PR closes https://github.com/jenkins-infra/helpdesk/issues/2190 by allowing to build Docker images in VM (instead of docker-less in restricted containers with `img`).