### PR TITLE
fix: enable long paths for git to avoid problems with tests on Windows agents

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -35,7 +35,7 @@ Object checkout(String repo = null) {
 
 Object checkoutSCM(String repo = null) {
     // Enable long paths to avoid problems with tests on Windows agents 
-    git config core.longpaths true
+    sh 'git config core.longpaths true'
 
     if (env.BRANCH_NAME) {
         checkout scm

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -34,6 +34,9 @@ Object checkout(String repo = null) {
 }
 
 Object checkoutSCM(String repo = null) {
+    // Enable long paths to avoid problems with tests on Windows agents 
+    git config core.longpaths true
+
     if (env.BRANCH_NAME) {
         checkout scm
     } else if ((env.BRANCH_NAME == null) && (repo)) {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -36,7 +36,7 @@ Object checkout(String repo = null) {
 Object checkoutSCM(String repo = null) {
     // Enable long paths to avoid problems with tests on Windows agents 
     if (!isUnix()) {
-        bat 'git config core.longpaths true'
+        bat 'git config --global core.longpaths true'
     }
 
     if (env.BRANCH_NAME) {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -35,7 +35,9 @@ Object checkout(String repo = null) {
 
 Object checkoutSCM(String repo = null) {
     // Enable long paths to avoid problems with tests on Windows agents 
-    sh 'git config core.longpaths true'
+    if (!isUnix()) {
+        bat 'git config core.longpaths true'
+    }
 
     if (env.BRANCH_NAME) {
         checkout scm


### PR DESCRIPTION
To solve https://github.com/jenkins-infra/helpdesk/issues/2847 in the short term, here is a proposition to add the git config command to the pipeline library, called [here](https://github.com/jenkins-infra/pipeline-library/blob/216eee69ae367cf11871013fb52b0dfae61b73ee/vars/buildPlugin.groovy#L64) when using the `buildPlugins` shared pipeline.

I'll add this command to the agents in following PRs.

cc @jtnord