### PR TITLE
fix: use new github credentials in terraform shared library

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -203,5 +203,5 @@ def getInfraSharedTools(String sharedToolsSubDir) {
   checkout changelog: false, poll: false,
     scm: [$class: 'GitSCM', branches: [[name: '*/main']],
     extensions: [[$class: 'CleanBeforeCheckout', deleteUntrackedNestedRepositories: true], [$class: 'RelativeTargetDirectory', relativeTargetDir: sharedToolsSubDir],
-      [$class: 'GitSCMStatusChecksExtension', skip: true]], userRemoteConfigs: [[credentialsId: 'github-app-infra', url: 'https://github.com/jenkins-infra/shared-tools.git']]]
+      [$class: 'GitSCMStatusChecksExtension', skip: true]], userRemoteConfigs: [[credentialsId: 'github-app-updatecli-on-jenkins-infra', url: 'https://github.com/jenkins-infra/shared-tools.git']]]
 }


### PR DESCRIPTION
Ref: 'repository not found' updatecli error on https://github.com/jenkins-infra/fastly/pull/5

Took the same credentials as in the updatecli shared pipeline.