### PR TITLE
fix(buildDockerAndPublishImage) always fetch the latest git tags to avoid dependency on job configuration

### DIFF
--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -73,8 +73,8 @@ def call(String imageName, Map userConfig=[:]) {
               '''
             }
           }
-
-          nextVersion = sh(script:"${finalConfig.nextVersionCommand}", returnStdout: true).trim()
+          sh 'git fetch --all --tags' // Ensure that all the tags are retrieved (uncoupling from job configuration, wether tags are fetched or not)
+          nextVersion = sh(script: finalConfig.nextVersionCommand, returnStdout: true).trim()
           echo "Next Release Version = $nextVersion"
         } // stage
       } // if


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/2840, a new job configuration was applied on infra.ci.jenkins.io.

It made clear that the Jenkins job behavior of discovering git tags is not always set up (or subject to bug?).

This PR fixes the docker shared library by always fetching the tags from the origin git repository.

The overhead of this operation is ~1s (even with a lot of tags) so the impact should be minimum. 


Tested with success on 2 builds:
- https://infra.ci.jenkins.io/job/docker-jobs/job/docker-jenkins-lts/job/main/3/console
- https://infra.ci.jenkins.io/job/docker-jobs/job/docker-jenkins-lts/job/main/4/console