### PR TITLE
chore(buildPlugin) improve idiomatic way to call git command in 'never-fail' mode

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -67,19 +67,23 @@ def call(Map params = [:]) {
                             incrementals = fileExists('.mvn/extensions.xml') &&
                                     readFile('.mvn/extensions.xml').contains('git-changelist-maven-extension')
                             final String gitUnavailableMessage = "[buildPlugin] Git CLI may not be available"
-                            if (incrementals) { // Incrementals needs 'git status -s' to be empty at start of job
-                                if (isUnix()) {
-                                    sh 'git clean -xffd || echo "${gitUnavailableMessage}"'
-                                } else {
-                                    bat 'git clean -xffd || echo "${gitUnavailableMessage}"'
+                            withEnv(["GITUNAVAILABLEMESSAGE=${gitUnavailableMessage}"]) {
+                                if (incrementals) { // Incrementals needs 'git status -s' to be empty at start of job
+                                    if (isUnix()) {
+                                        sh 'git clean -xffd || echo "$GITUNAVAILABLEMESSAGE"'
+                                    } else {
+                                        bat 'git clean -xffd || echo %GITUNAVAILABLEMESSAGE%'
+                                    }
                                 }
-                            }
 
-                            if (gitDefaultBranch) {
-                                if (isUnix()) {
-                                    sh "git config --global init.defaultBranch '${gitDefaultBranch}' || echo '${gitUnavailableMessage}'"
-                                } else {
-                                    bat "git config --global init.defaultBranch '${gitDefaultBranch}' || echo '${gitUnavailableMessage}'"
+                                if (gitDefaultBranch) {
+                                    withEnv(["GITDEFAULTBRANCH=${gitDefaultBranch}"]) {
+                                        if (isUnix()) {
+                                            sh 'git config --global init.defaultBranch "$GITDEFAULTBRANCH" || echo "$GITDEFAULTBRANCH"'
+                                        } else {
+                                            bat 'git config --global init.defaultBranch %GITDEFAULTBRANCH% || echo %GITDEFAULTBRANCH%'
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -66,27 +66,20 @@ def call(Map params = [:]) {
                             isMaven = fileExists('pom.xml')
                             incrementals = fileExists('.mvn/extensions.xml') &&
                                     readFile('.mvn/extensions.xml').contains('git-changelist-maven-extension')
+                            final String gitUnavailableMessage = "[buildPlugin] Git CLI may not be available"
                             if (incrementals) { // Incrementals needs 'git status -s' to be empty at start of job
                                 if (isUnix()) {
-                                    sh(script: 'git clean -xffd > /dev/null 2>&1',
-                                       label: 'Clean for incrementals',
-                                       returnStatus: true) // Ignore failure if CLI git is not available
+                                    sh 'git clean -xffd || echo "${gitUnavailableMessage}"'
                                 } else {
-                                    bat(script: 'git clean -xffd 1> nul 2>&1',
-                                        label: 'Clean for incrementals',
-                                        returnStatus: true) // Ignore failure if CLI git is not available
+                                    bat 'git clean -xffd || echo "${gitUnavailableMessage}"'
                                 }
                             }
 
                             if (gitDefaultBranch) {
                                 if (isUnix()) {
-                                    sh(script: "git config --global init.defaultBranch '${gitDefaultBranch}'",
-                                       label: 'Set default branch for git',
-                                       returnStatus: true) // Ignore failure if CLI git is not available
+                                    sh "git config --global init.defaultBranch '${gitDefaultBranch}' || echo '${gitUnavailableMessage}'"
                                 } else {
-                                    bat(script: "git config --global init.defaultBranch '${gitDefaultBranch}'",
-                                        label: 'Set default branch for git',
-                                        returnStatus: true) // Ignore failure if CLI git is not available
+                                    bat "git config --global init.defaultBranch '${gitDefaultBranch}' || echo '${gitUnavailableMessage}'"
                                 }
                             }
                         }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -79,9 +79,9 @@ def call(Map params = [:]) {
                                 if (gitDefaultBranch) {
                                     withEnv(["GITDEFAULTBRANCH=${gitDefaultBranch}"]) {
                                         if (isUnix()) {
-                                            sh 'git config --global init.defaultBranch "$GITDEFAULTBRANCH" || echo "$GITDEFAULTBRANCH"'
+                                            sh 'git config --global init.defaultBranch "$GITDEFAULTBRANCH" || echo "$GITUNAVAILABLEMESSAGE"'
                                         } else {
-                                            bat 'git config --global init.defaultBranch %GITDEFAULTBRANCH% || echo %GITDEFAULTBRANCH%'
+                                            bat 'git config --global init.defaultBranch %GITDEFAULTBRANCH% || echo %GITUNAVAILABLEMESSAGE%'
                                         }
                                     }
                                 }


### PR DESCRIPTION
Ref.  https://github.com/jenkins-infra/pipeline-library/pull/247#pullrequestreview-927497269

For bat commands: https://stackoverflow.com/questions/22046780/whats-the-windows-command-shell-equivalent-of-bashs-true-command
(TL;DR; add `|| VER >NUL` that keeps printing the error message but set the exit code to 0)