### PR TITLE
chore(updatecli) switch from GH action to plain old binary with version controlled

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -14,25 +14,31 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Updatecli Version
-        uses: updatecli/updatecli-action@v1.30.0
-        with:
-          command: version
-          flags: ""
+      - name: Install updatecli CLI
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_VERSION: "0.23.2"
+        run: |
+          curl --silent --location --show-error --output /tmp/updatecli.tgz \
+            "https://github.com/updatecli/updatecli/releases/download/v${UPDATECLI_VERSION}/updatecli_$(uname -s)_$(uname -m).tar.gz"
+          tar xzf /tmp/updatecli.tgz -C /usr/local/bin/ updatecli
+          rm -f /tmp/updatecli.tgz
       - name: Diff
-        uses: updatecli/updatecli-action@v1.30.0
-        with:
-          command: diff
-          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"
+        continue-on-error: true
+        run: |
+          updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ## This step allows to generate a short-lived token which is allowed to modify GitHub Workflow files (that the default GITHUB_TOKEN cannot)
+      ## Please make sure that the 2 secrets are defined (usually at organization level, with a per-repository access)
+      - uses: tibdex/github-app-token@v1.5
+        id: generate_token
+        if: github.ref == 'refs/heads/production'
+        with:
+          app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
+          private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
       - name: Apply
-        uses: updatecli/updatecli-action@v1.30.0
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
-        with:
-          command: apply
-          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"
+        if: github.ref == 'refs/heads/production'
+        run: |
+          updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.yaml
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/updatecli/updatecli.d/docker-helmfile.yml
+++ b/updatecli/updatecli.d/docker-helmfile.yml
@@ -44,7 +44,7 @@ targets:
         'jenkinsciinfra/helmfile:(.*)'
       replacepattern: >-
         'jenkinsciinfra/helmfile:{{ source `lastVersion` }}'
-    scmID: default
+    scmid: default
   updateDoc:
     name: Update docker-helmfile in documentation
     kind: file
@@ -52,13 +52,13 @@ targets:
       file: vars/updatecli.txt
       matchpattern: jenkinsciinfra/helmfile:(\d+\.\d+\.\d+)\"
       replacepattern: jenkinsciinfra/helmfile:{{ source `lastVersion` }}"
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
     title: Bump docker-helmfile version on shared library resources to {{ source "lastVersion" }}
-    scmID: default
+    scmid: default
     targets:
       - updateGroovyCode
       - updateDoc

--- a/updatecli/updatecli.d/terraform-hashicorp.yml
+++ b/updatecli/updatecli.d/terraform-hashicorp.yml
@@ -40,12 +40,12 @@ targets:
         'jenkinsciinfra/hashicorp-tools:(.*)'
       replacepattern: >-
         'jenkinsciinfra/hashicorp-tools:{{ source `dockerHashicorpToolsImageVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateTerraformFile
     spec:

--- a/updatecli/updatecli.d/updatecli.yaml
+++ b/updatecli/updatecli.d/updatecli.yaml
@@ -1,0 +1,50 @@
+title: "Update updatecli version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestUpdatecliVersion:
+    kind: githubRelease
+    name: Get the latest stable updatecli version
+    spec:
+      owner: "updatecli"
+      repository: "updatecli"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: semver
+
+conditions:
+  checkIfUpdateCliBinaryIsPublished:
+    name: "Ensure that the updatecli Linux Intel binary is published"
+    disablesourceinput: true
+    kind: shell
+    spec:
+      command: curl --location --head --fail --silent --show-error https://github.com/updatecli/updatecli/releases/download/v{{ source `latestUpdatecliVersion`}}/updatecli_Linux_x86_64.tar.gz
+
+targets:
+  setUpdatecliVersion:
+    name: "Set the updatecli version in the github workflow"
+    sourceid: latestUpdatecliVersion
+    kind: yaml
+    spec:
+      file: ".github/workflows/updatecli.yaml"
+      key: "jobs.updatecli.steps[1].env.UPDATECLI_VERSION"
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - setUpdatecliVersion


### PR DESCRIPTION
Allow to have the updatecli version that we want (depending on the action means waiting for dependadabot to kick off).

Should help around https://github.com/jenkins-infra/helm-charts/pull/117