### PR TITLE
Print flags specified on command line or set by ergonomics

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -190,6 +190,10 @@ Object runWithJava(String command, String jdk = 8, List<String> extraEnv = null,
         env.addAll(extraEnv)
     }
 
+    if (!env.any { it.startsWith('MAVEN_OPTS=') }) {
+        env += 'MAVEN_OPTS=-XX:+PrintCommandLineFlags'
+    }
+
     withEnv(env) {
         if (isUnix()) { // TODO JENKINS-44231 candidate for simplification
             sh command


### PR DESCRIPTION
This information can be essential when reasoning about memory usage by multiple JVMs within a single VM or container. This change gets us that information for the primary Maven JVM, and https://github.com/jenkinsci/jenkins-test-harness/pull/425 gets us that information for agents launched by tests. Remaining observability gaps include the Remoting JVM used to start Maven and JVMs forked by Maven (i.e., compiler JVMs or Surefire JVMs), but this is a start.