### PR TITLE
Publish checks when invoking deprecated functionality

### DIFF
--- a/test/groovy/mock/Infra.groovy
+++ b/test/groovy/mock/Infra.groovy
@@ -41,4 +41,6 @@ class Infra implements Serializable {
   }
 
   public void maybePublishIncrementals() { }
+
+  void publishDeprecationCheck(String deprecationSummary, String deprecationMessage) { }
 }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -15,9 +15,7 @@ def call(Map params = [:]) {
 
   def useContainerAgent = params.containsKey('useContainerAgent') ? params.useContainerAgent : false
   if (params.containsKey('useAci')) {
-    deprecationMessage = 'The parameter "useAci" is deprecated. Please use "useContainerAgent" instead as per https://issues.jenkins.io/browse/INFRA-2918.'
-    echo "WARNING: ${deprecationMessage}"
-    publishChecks name: 'pipeline-library', summary: 'Replace useAci with useContainerAgent', conclusion: 'NEUTRAL', text: deprecationMessage
+    infra.publishDeprecationCheck('Replace useAci with useContainerAgent', 'The parameter "useAci" is deprecated. Please use "useContainerAgent" instead as per https://issues.jenkins.io/browse/INFRA-2918.')
     useContainerAgent = params.containsKey('useAci')
   }
   if (timeoutValue > 180) {
@@ -33,7 +31,7 @@ def call(Map params = [:]) {
     String jdk = config.jdk
     String jenkinsVersion = config.jenkins
     if (config.containsKey('javaLevel')) {
-      echo 'WARNING: Ignoring deprecated "javaLevel" parameter. This parameter should be removed from your "Jenkinsfile".'
+      infra.publishDeprecationCheck('Remove javaLevel', 'Ignoring deprecated "javaLevel" parameter. This parameter should be removed from your "Jenkinsfile".')
     }
 
     String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
@@ -132,7 +130,7 @@ def call(Map params = [:]) {
                   }
                 }
               } else {
-                echo 'WARNING: Gradle mode for buildPlugin() is deprecated, please use buildPluginWithGradle()'
+                infra.publishDeprecationCheck('Replace buildPlugin with buildPluginWithGradle', 'Gradle mode for buildPlugin() is deprecated, please use buildPluginWithGradle()')
                 List<String> gradleOptions = [
                   '--no-daemon',
                   'cleanTest',

--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -21,7 +21,6 @@ def call(Map params = [:]) {
     String label = config.platform
     String jdk = config.jdk
     String jenkinsVersion = config.jenkins
-    String javaLevel = config.javaLevel
 
     String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
     boolean skipTests = params?.tests?.skip
@@ -40,8 +39,8 @@ def call(Map params = [:]) {
           }
 
           stage("Build (${stageIdentifier})") {
-            if (javaLevel != null) {
-              echo "WARNING: 'javaLevel' parameter is not supported in buildPluginWithGradle(). It will be ignored"
+            if (config.containsKey('javaLevel')) {
+              infra.publishDeprecationCheck('Remove javaLevel', 'Ignoring deprecated "javaLevel" parameter. This parameter should be removed from your "Jenkinsfile".')
             }
             //TODO(oleg-nenashev): Once supported by Gradle JPI Plugin, pass jenkinsVersion
             if (jenkinsVersion != null) {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -328,3 +328,8 @@ void maybePublishIncrementals() {
     echo 'Skipping deployment to Incrementals'
   }
 }
+
+void publishDeprecationCheck(String deprecationSummary, String deprecationMessage) {
+  echo "WARNING: ${deprecationMessage}"
+  publishChecks name: 'pipeline-library', summary: deprecationSummary, conclusion: 'NEUTRAL', text: deprecationMessage
+}


### PR DESCRIPTION
Publishing a check when deprecated functionality is invoked is a useful way to draw attention to the usage and ensure that it gets updated, so let us abstract this into a common method and use it in more places.