### PR TITLE
fix(buildDockerAndPublishImage) annotated tags

### DIFF
--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -131,7 +131,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   Boolean assertTagPushed(String newVersion) {
     return assertMethodCallContainsPattern('echo','Configuring credential.helper') \
       && assertMethodCallContainsPattern('echo','Configuring git user and email') \
-      && assertMethodCallContainsPattern('sh','git config user.name "jenkins"') \
+      && assertMethodCallContainsPattern('sh','git config user.name "${GIT_USERNAME}"') \
       && assertMethodCallContainsPattern('sh','git config user.email "jenkins-infra@googlegroups.com"') \
       && assertMethodCallContainsPattern('echo',"Tagging New Version: ${newVersion}") \
       && assertMethodCallContainsPattern('sh',"git tag -a ${newVersion} -m ${testImageName}") \

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -44,7 +44,6 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     helper.addShMock('git remote -v | grep origin | grep push | sed \'s/^origin\\s//\' | sed \'s/\\s(push)//\'', 'https://github.com/org/repository.git', 0)
     helper.addShMock('gh api /repos/org/repository/releases | jq -e -r \'.[] | select(.draft == true and .name == "next") | .id\'', '12345', 0)
     addEnvVar('WORKSPACE', '/tmp')
-    addEnvVar('IMAGE_NAME', testImageName)
 
     // Define mocks/stubs for the data objects
     infraConfigMock = new StubFor(InfraConfig.class)

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -44,6 +44,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     helper.addShMock('git remote -v | grep origin | grep push | sed \'s/^origin\\s//\' | sed \'s/\\s(push)//\'', 'https://github.com/org/repository.git', 0)
     helper.addShMock('gh api /repos/org/repository/releases | jq -e -r \'.[] | select(.draft == true and .name == "next") | .id\'', '12345', 0)
     addEnvVar('WORKSPACE', '/tmp')
+    addEnvVar('IMAGE_NAME', testImageName)
 
     // Define mocks/stubs for the data objects
     infraConfigMock = new StubFor(InfraConfig.class)
@@ -131,7 +132,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   Boolean assertTagPushed(String newVersion) {
     return assertMethodCallContainsPattern('echo','Configuring credential.helper') \
       && assertMethodCallContainsPattern('echo',"Tagging New Version: ${newVersion}") \
-      && assertMethodCallContainsPattern('sh',"git tag ${newVersion}") \
+      && assertMethodCallContainsPattern('sh',"git tag -a ${newVersion} -m ${testImageName}") \
       && assertMethodCallContainsPattern('echo','Pushing Tag') \
       && assertMethodCallContainsPattern('sh','git push origin --tags')
   }

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -130,6 +130,9 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
 
   Boolean assertTagPushed(String newVersion) {
     return assertMethodCallContainsPattern('echo','Configuring credential.helper') \
+      && assertMethodCallContainsPattern('echo','Configuring git user and email') \
+      && assertMethodCallContainsPattern('sh','git config user.name "jenkins"') \
+      && assertMethodCallContainsPattern('sh','git config user.email "jenkins-infra@googlegroups.com"') \
       && assertMethodCallContainsPattern('echo',"Tagging New Version: ${newVersion}") \
       && assertMethodCallContainsPattern('sh',"git tag -a ${newVersion} -m ${testImageName}") \
       && assertMethodCallContainsPattern('echo','Pushing Tag') \

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -138,7 +138,7 @@ def call(String imageName, Map userConfig=[:]) {
             usernamePassword(credentialsId: "${finalConfig.gitCredentials}", passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')
           ]) {
             echo "Tagging New Version: $nextVersion"
-            sh "git tag -a $nextVersion -m $IMAGE_NAME"
+            sh "git tag -a $nextVersion -m ${imageName}"
 
             echo 'Pushing Tag'
             sh 'git push origin --tags'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -138,7 +138,7 @@ def call(String imageName, Map userConfig=[:]) {
             usernamePassword(credentialsId: "${finalConfig.gitCredentials}", passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')
           ]) {
             echo "Configuring git user and email"
-            sh 'git config user.name "jenkins"'
+            sh 'git config user.name "${GIT_USERNAME}"'
             sh 'git config user.email "jenkins-infra@googlegroups.com"'
 
             echo "Tagging New Version: $nextVersion"

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -137,6 +137,10 @@ def call(String imageName, Map userConfig=[:]) {
           withCredentials([
             usernamePassword(credentialsId: "${finalConfig.gitCredentials}", passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')
           ]) {
+            echo "Configuring git user and email"
+            sh 'git config user.name "jenkins"'
+            sh 'git config user.email "jenkins-infra@googlegroups.com"'
+
             echo "Tagging New Version: $nextVersion"
             sh "git tag -a $nextVersion -m ${imageName}"
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -138,7 +138,7 @@ def call(String imageName, Map userConfig=[:]) {
             usernamePassword(credentialsId: "${finalConfig.gitCredentials}", passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')
           ]) {
             echo "Tagging New Version: $nextVersion"
-            sh "git tag $nextVersion"
+            sh "git tag -a $nextVersion -m $IMAGE_NAME"
 
             echo 'Pushing Tag'
             sh 'git push origin --tags'


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/helpdesk/issues/2887 by annotating the tag so it's an object itself with its date, and not just a reference attached to the last commit