### PR TITLE
Clean up `infra.ensureInNode`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -131,16 +131,16 @@ if (infra.isTrusted()) {
 }
 ----
 
-=== infra.ensureInNode(env, nodeLabels, body)
+=== infra.ensureInNode(nodeLabels, body)
 
 Ensures that the given code block is runs in a node with the specified labels
 
 .Jenkinsfile
 [source,groovy]
 ----
-infra.ensureInNode(env, "docker,java", {
-    sh "docker -v"
-})
+infra.ensureInNode('docker,java') {
+    sh 'docker -v'
+}
 ----
 
 === infra.stashJenkinsWar(jenkins, stashName)

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -261,11 +261,10 @@ void stashJenkinsWar(String jenkins, String stashName = 'jenkinsWar') {
  * Please note that this step is not able to manage complex labels and checks for them literally, so do not try to use labels like 'docker,(lowmemory&&linux)' as it will result in
  * the step launching a new node as is unable to find the label '(lowmemory&amp;&amp;linux)' in the list of labels for the current node
  *
- * @param env The run environment, used to access the current node labels
  * @param nodeLabels The node labels, a string containing the comma separated labels
  * @param body The code to run in the desired node
  */
-void ensureInNode(env, nodeLabels, body) {
+void ensureInNode(nodeLabels, body) {
   def inCorrectNode = true
   def splitted = nodeLabels.split(',')
   if (env.NODE_LABELS == null) {

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -71,7 +71,7 @@
     Gets a specification for a jenkins version or war and downloads and stashes it under the name provided
 </p>
 
-<strong>infra.ensureInNode(env, nodeLabels, body)</strong>
+<strong>infra.ensureInNode(nodeLabels, body)</strong>
 
 <p>
     Runs a code block in a node with the all the specified nodeLabels as labels, if already running in that node it simply

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -30,7 +30,7 @@ def call(Map params = [:]) {
 
   def localPluginsStashName = env.RUN_ATH_LOCAL_PLUGINS_STASH_NAME ?: 'localPlugins'
 
-  infra.ensureInNode(env, env.RUN_ATH_SOURCES_AND_VALIDATION_NODE ?: 'docker-highmem', {
+  infra.ensureInNode(env.RUN_ATH_SOURCES_AND_VALIDATION_NODE ?: 'docker-highmem') {
     if (!fileExists(metadataFile)) {
       echo "Skipping ATH execution because the metadata file does not exist. Current value is ${metadataFile}."
       skipExecution = true
@@ -86,9 +86,9 @@ def call(Map params = [:]) {
       }
 
     }
-  })
+  }
 
-  infra.ensureInNode(env, env.RUN_ATH_DOCKER_NODE ?: 'docker-highmem', {
+  infra.ensureInNode(env.RUN_ATH_DOCKER_NODE ?: 'docker-highmem') {
     if (skipExecution) {
       return
     }
@@ -185,7 +185,7 @@ def call(Map params = [:]) {
 
       parallel testingbranches
     }
-  })
+  }
 }
 
 private void test(discriminator, commandBase, localSnapshots, localPluginsStashName, containerArgs, athContainerImage, javaOptions) {

--- a/vars/runPCT.groovy
+++ b/vars/runPCT.groovy
@@ -26,7 +26,7 @@ def call(Map params = [:]) {
 
   def localPluginsStashName = env.RUN_PCT_LOCAL_PLUGIN_SOURCES_STASH_NAME ?: 'localPlugins'
 
-  infra.ensureInNode(env, env.RUN_PCT_SOURCES_AND_VALIDATION_NODE ?: 'docker', {
+  infra.ensureInNode(env.RUN_PCT_SOURCES_AND_VALIDATION_NODE ?: 'docker') {
 
     if (!fileExists(metadataFile)) {
       echo "Skipping PCT execution because the metadata file does not exist. Current value is ${metadataFile}."
@@ -81,14 +81,13 @@ def call(Map params = [:]) {
         }
       }
     }
-  })
+  }
 
   if (skipExecution) {
     return
   }
 
-  infra.ensureInNode(env, env.RUN_PCT_DOCKER_NODE ?: 'docker', {
-
+  infra.ensureInNode(env.RUN_PCT_DOCKER_NODE ?: 'docker') {
     stage('Running PCT') {
       if (!isPublishedImage) {
         dir('pctSources') {
@@ -154,6 +153,5 @@ def call(Map params = [:]) {
       // TODO provide a mechanism for HTML report archiving and aggregation
       parallel testingBranches
     }
-
-  })
+  }
 }


### PR DESCRIPTION
This makes several changes to clean up `infra.ensureInNode`.

First we removed the `env` argument. This is unneeded, as `env` is a global variable available from all Pipeline jobs. Furthermore, taking it as an explicit argument is inconsistent with all the other methods in this file, which do not take it as an explicit argument but use it anyway. This is technically an API change, but I updated all consumers within this repository and verified there were no consumers outside this repository with these two queries:

- https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+ensureInNode
- https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkins-infra+ensureInNode

The other change I made was to make the code more idiomatic Groovy: if the closure is the last argument for a method we can put the closure outside the argument list. This is the way Groovy is intended to be used and makes the code read more like a DSL.