### PR TITLE
Remove unused argument in `retrieveMavenSettingsFile`

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -52,7 +52,7 @@ Object checkoutSCM(String repo = null) {
  * @param jdk Version of JDK to be used (no longer used)
  * @return {@code true} if the file has been defined
  */
-boolean retrieveMavenSettingsFile(String settingsXml, String jdk = 8) {
+boolean retrieveMavenSettingsFile(String settingsXml) {
   if (env.MAVEN_SETTINGS_FILE_ID != null) {
     configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE_ID, variable: 'mvnSettingsFile')]) {
       if (isUnix()) {


### PR DESCRIPTION
This argument was unused and also made no sense because it was declared of type string but its default value was of type integer. Technically an API change, but I verified all existing callers only use the single-argument version:

- https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+retrieveMavenSettingsFile
- https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkins-infra+retrieveMavenSettingsFile