### PR TITLE
feat: switch mirror to HTTPS on get.jenkins.io (Jenkins WAR retrieval)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -145,7 +145,7 @@ infra.ensureInNode('docker,java') {
 
 === infra.stashJenkinsWar(jenkins, stashName)
 
-Given a version of jenkins downloads it if neccesary and stashes it under the given name (which defaults to "jenkinsWar",
+Given a version of jenkins downloads it if necessary and stashes it under the given name (which defaults to "jenkinsWar",
 see the step doc for more documentation about he allowed versions
 
 .Jenkinsfile
@@ -175,7 +175,7 @@ The docker image used for the environment where to run the ATH. Defaults to "jen
 `metadataFile`::
  A String indicating the file path (relative to where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. *Defaults to `essentials.yml` at the location where this step is invoked*
 `jenkins`::
- URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. *Can be overriden from the metadata file*
+ URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. *Can be overridden from the metadata file*
  `jdks`::
  Java versions to use when running ATH. Defaults to 8. Only 8 and 11 are supported. *Can be overridden from the metadata file*
 `configFile`::
@@ -319,7 +319,7 @@ The PCT revision to use in case that pctUrl points to a github destination, can 
 `metadataFile`::
  A String indicating the file path (relative to where this step is executed) to use as metadata file for the build, more details about the metadata file are provided belows. *Defaults to `essentials.yml` at the location where this step is invoked*
 `jenkins`::
- URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. *Can be overriden from the metadata file*
+ URI to the jenkins.war, Jenkins version or one of "latest", "latest-rc", "lts" and "lts-rc". Defaults to "latest". For local war files use the file:// protocol in the URI. *Can be overridden from the metadata file*
 `pctExtraOptions`::
  List of extra PCT options to be passed to the PCT executable. Defaults to empty list.
 `javaOptions`::
@@ -332,7 +332,7 @@ The PCT revision to use in case that pctUrl points to a github destination, can 
 .Step call example
 [source,groovy]
 ----
-runPCT(metadataFile:"metadata.yml", pctUrl:"docker://mynamspace/pct", jenkins: "2.110")
+runPCT(metadataFile:"metadata.yml", pctUrl:"docker://mynamespace/pct", jenkins: "2.110")
 ----
 
 

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -234,7 +234,7 @@ Object runWithJava(String command, String jdk = '8', List<String> extraEnv = nul
 void stashJenkinsWar(String jenkins, String stashName = 'jenkinsWar') {
   def isVersionNumber = (jenkins =~ /^\d+([.]\d+)*(-rc[0-9]+[.][0-9a-f]{12})?$/).matches()
   def isLocalJenkins = jenkins.startsWith('file://')
-  def mirror = 'http://mirrors.jenkins.io/'
+  def mirror = 'https://get.jenkins.io/'
 
   def jenkinsURL
 

--- a/vars/runATH.groovy
+++ b/vars/runATH.groovy
@@ -14,7 +14,6 @@ def call(Map params = [:]) {
   def configFile = params.get('configFile', null)
   def defaultJavaOptions = params.get('javaOptions', [])
 
-  def mirror = "http://mirrors.jenkins.io/"
   def defaultCategory = "org.jenkinsci.test.acceptance.junit.SmokeTest"
   def metadata
   def athContainerImage


### PR DESCRIPTION
This change request is motivated by https://github.com/jenkins-infra/helpdesk/issues/2888.

It switches the WAR retrieval from HTTP-only on the legacy (and on the verge of depreciation) mirror system `mirror.jenkins.io`.

The new URL uses the actual mirroring service `get.jenkins.io` which has the following benefits:

- Uses HTTPS
  - former service `mirror.jenkins.io` is HTTP only
- Highly available (scalable horizontally, on the Kubernetes cluster `prodpublick8s` on Azure)
  - former service `mirror.jenkins.io` is hosted on a standalone VM, which is also used for update center and packaging
- Better performances (dsitributed requests + a real life table of mirrors)
  - former service `mirror.jenkins.io` have an irregular response time, often peaks above 10s as per https://github.com/jenkins-infra/helpdesk/issues/2888
  - former service `mirror.jenkins.io` always redirect the WAR download to `archives.jenkins.io` (which acts as a fallback), while get.jenkins.io choose a mirror near the HTTP client (and only fall backs to `archives.jenkins.io` for older WAR version not mirrored)


This change request also cleans up the README and the `runAth()` from an unused variable mentionning `mirror.jenkins.io`.


The following project could be impacted by this change:

- Any call to the method `stashJenkinsWar()` of the global library `infra`
- Transitively:
  - Any project using the `runAth()` method because it uses the method `stashJenkinsWar()`
    - jenkinsci/jenkins main build: https://github.com/jenkinsci/jenkins/blob/master/Jenkinsfile#L158
  - Any project using the `runPct()` method because it uses the method `stashJenkinsWar()`
  - Any project using the method `essentialsTest()` because it uses both `runAth()` and `runPct()`


About the impacts:
- The 4 URLs  (for WAR retrieval) that are changed have been tested successfully: they all redirects to  working WAR file with the same checksum as the old URLs when writing these lines


ETA: this PR will be merged the 09th of May 2022 if approved, unless there is a strong reason to cancel it.