### PR TITLE
feat: buildDockerAndPublishImage compatible with Windows

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -1,13 +1,14 @@
 # Windows detection
 ifeq '$(findstring ;,$(PATH))' ';'
 	FixPath = $(subst /,\,$1)
+	IMAGE_DIR = $(WORKSPACE)
 else
 	FixPath = $1
+	IMAGE_DIR = $(PWD)
 endif
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= $(IMAGE_NAME)
-IMAGE_DIR = $(WORKSPACE)
 IMAGE_PLATFORM ?= linux/amd64
 # Paths
 IMAGE_DOCKERFILE ?= $(IMAGE_DIR)/Dockerfile

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -1,14 +1,13 @@
 # Windows detection
 ifeq '$(findstring ;,$(PATH))' ';'
 	FixPath = $(subst /,\,$1)
-	IMAGE_DIR = $(WORKSPACE)
 else
 	FixPath = $1
-	IMAGE_DIR = $(PWD)
 endif
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= $(IMAGE_NAME)
+IMAGE_DIR = $(WORKSPACE)
 IMAGE_PLATFORM ?= linux/amd64
 # Paths
 IMAGE_DOCKERFILE ?= $(IMAGE_DIR)/Dockerfile
@@ -61,7 +60,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 		--label "org.label-schema.vcs-ref=$(GIT_COMMIT_REV)" \
 		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
 		--label "org.label-schema.build-date=$(BUILD_DATE)" \
-		-- platform $(IMAGE_PLATFORM) \
+		--platform $(IMAGE_PLATFORM) \
 		--file "$(call FixPath,$(IMAGE_DOCKERFILE))" \
 		"$(IMAGE_DIR)"
 	@echo "== Build succeeded"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -8,7 +8,7 @@ endif
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= $(IMAGE_NAME)
-IMAGE_DIR = $(PWD)
+IMAGE_DIR ?= $(PWD)
 IMAGE_PLATFORM ?= linux/amd64
 # Paths
 IMAGE_DOCKERFILE ?= $(IMAGE_DIR)/Dockerfile

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -1,16 +1,14 @@
 # Windows detection
 ifeq '$(findstring ;,$(PATH))' ';'
 	FixPath = $(subst /,\,$1)
-	IMAGE_DIR = $(WORKSPACE)
-	IMAGE_PLATFORM_ARG = --platform "windows/amd64"
 else
 	FixPath = $1
-	IMAGE_DIR ?= $(PWD)
-	IMAGE_PLATFORM_ARG ?= --platform "linux/amd64"
 endif
 
 IMAGE_NAME ?= helloworld
-IMAGE_DEPLOY_NAME ?= example/$(IMAGE_NAME)
+IMAGE_DEPLOY_NAME ?= $(IMAGE_NAME)
+IMAGE_DIR = $(WORKSPACE)
+IMAGE_PLATFORM ?= linux/amd64
 # Paths
 IMAGE_DOCKERFILE ?= $(IMAGE_DIR)/Dockerfile
 IMAGE_ARCHIVE ?= $(IMAGE_DIR)/image.tar
@@ -62,7 +60,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 		--label "org.label-schema.vcs-ref=$(GIT_COMMIT_REV)" \
 		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
 		--label "org.label-schema.build-date=$(BUILD_DATE)" \
-		$(IMAGE_PLATFORM_ARG) \
+		-- platform $(IMAGE_PLATFORM) \
 		--file "$(call FixPath,$(IMAGE_DOCKERFILE))" \
 		"$(IMAGE_DIR)"
 	@echo "== Build succeeded"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -1,10 +1,19 @@
+# Windows detection
+ifeq '$(findstring ;,$(PATH))' ';'
+	FixPath = $(subst /,\,$1)
+	IMAGE_DIR = $(WORKSPACE)
+	IMAGE_PLATFORM_ARG = --platform "windows/amd64"
+else
+	FixPath = $1
+	IMAGE_DIR ?= $(PWD)
+	IMAGE_PLATFORM_ARG ?= --platform "linux/amd64"
+endif
 
 IMAGE_NAME ?= helloworld
-IMAGE_DEPLOY_NAME ?= $(IMAGE_NAME)
-IMAGE_DIR ?= $(PWD)
+IMAGE_DEPLOY_NAME ?= example/$(IMAGE_NAME)
+# Paths
 IMAGE_DOCKERFILE ?= $(IMAGE_DIR)/Dockerfile
 IMAGE_ARCHIVE ?= $(IMAGE_DIR)/image.tar
-IMAGE_PLATFORM ?= linux/amd64
 HADOLINT_REPORT ?= $(IMAGE_DIR)/hadolint.json
 TEST_HARNESS ?= $(IMAGE_DIR)/cst.yml
 
@@ -28,19 +37,19 @@ CST_SUT = $(IMAGE_NAME)
 endif
 
 help: ## Show this Makefile's help
+	@echo "Help:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 all: clean lint build test ## Execute the complete process except the "deploy" step
 
 lint: ## Lint the $(IMAGE_DOCKERFILE) content
-	@echo "== Linting $(IMAGE_DOCKERFILE)..."
-	@echo "Writing Lint results to $(HADOLINT_REPORT)"
-	@$(HADOLINT_BIN) --format=json - < $(IMAGE_DOCKERFILE) > $(HADOLINT_REPORT)
-	@echo "== Lint ✅ Succeeded"
+	@echo "== Linting $(DOCKERFILE_FULL_PATH) with $(HADOLINT_BIN):"
+	$(HADOLINT_BIN) --format=json "$(IMAGE_DOCKERFILE)" > "$(call FixPath,$(HADOLINT_REPORT))"
+	@echo "== Lint succeeded"
 
-build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE) and export it to $(IMAGE_ARCHIVE)
-	@echo "== Building $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)..."
-	@$(CONTAINER_BIN) build \
+build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
+	@echo "== Building $(IMAGE_NAME) from $(call FixPath,$(IMAGE_DOCKERFILE)) with $(CONTAINER_BIN):"
+	$(CONTAINER_BIN) build \
 		--tag $(IMAGE_NAME) \
 		--build-arg "GIT_COMMIT_REV=$(GIT_COMMIT_REV)" \
 		--build-arg "GIT_SCM_URL=$(GIT_SCM_URL)" \
@@ -53,29 +62,30 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE) and expo
 		--label "org.label-schema.vcs-ref=$(GIT_COMMIT_REV)" \
 		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
 		--label "org.label-schema.build-date=$(BUILD_DATE)" \
-		--platform $(IMAGE_PLATFORM) \
-		--file $(IMAGE_DOCKERFILE) \
-		$(IMAGE_DIR)
-	@echo "== Build ✅ Succeeded, image $(IMAGE_NAME) exported to $(IMAGE_ARCHIVE)."
+		$(IMAGE_PLATFORM_ARG) \
+		--file "$(call FixPath,$(IMAGE_DOCKERFILE))" \
+		"$(IMAGE_DIR)"
+	@echo "== Build succeeded"
 
 clean: ## Delete any file generated during the build steps
-	@echo "== Cleaning working directory from generated artefacts..."
-	@rm -f $(IMAGE_DIR)/*.tar $(HADOLINT_REPORT)
-	@echo "== Cleanup ✅ Succeeded"
+	@echo "== Cleaning working directory $(IMAGE_DIR) from generated artefacts:"
+	rm -f "$(call FixPath,$(IMAGE_DIR)/*.tar)" "$(HADOLINT_REPORT)"
+	@echo "== Cleanup succeeded"
 
-test: ## Execute the test harness on the Docker Image archive at $(IMAGE_ARCHIVE)
-	@echo "== Test $(IMAGE_NAME) with $(TEST_HARNESS) from $(IMAGE_ARCHIVE)..."
+test: ## Execute the test harness on the Docker Image (archived as $(IMAGE_ARCHIVE) if using tar CST driver)
+	@echo "== Test $(IMAGE_NAME) with $(call FixPath,$(TEST_HARNESS)) from $(CST_SUT) with $(CST_BIN):"
 ifeq ($(CST_DRIVER),tar)
-	$(CONTAINER_BIN) save --output=$(IMAGE_ARCHIVE) $(IMAGE_NAME)
+	@echo "== Image $(IMAGE_NAME) archived to $(call FixPath,$(IMAGE_ARCHIVE)) for test."
+	$(CONTAINER_BIN) save --output="$(call FixPath,$(IMAGE_ARCHIVE))" $(IMAGE_NAME)
 endif
-	$(CST_BIN) test --driver=$(CST_DRIVER) --image=$(CST_SUT) --config=$(TEST_HARNESS)
-	@echo "== Test ✅ Succeeded"
+	$(CST_BIN) test --driver=$(CST_DRIVER) --image="$(call FixPath,$(CST_SUT))" --config="$(call FixPath,$(TEST_HARNESS))"
+	@echo "== Test succeeded"
 
 ## This steps expects that you are logged to the Docker registry to push image into
 deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
-	@echo "== Deploying $(IMAGE_NAME) to $(IMAGE_DEPLOY_NAME)..."
+	@echo "== Deploying $(IMAGE_NAME) to $(IMAGE_DEPLOY_NAME) with $(CONTAINER_BIN):"
 	$(CONTAINER_BIN) tag $(IMAGE_NAME) $(IMAGE_DEPLOY_NAME)
 	$(CONTAINER_BIN) push $(IMAGE_DEPLOY_NAME)
-	@echo "== Deploy ✅ Succeeded"
+	@echo "== Deploy succeeded"
 
 .PHONY: all clean lint build test deploy

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -1,13 +1,14 @@
-# Windows detection
+# Detect Windows (only OS separating paths in $PATH with ";") to set specific variable and function to get compatible paths
 ifeq '$(findstring ;,$(PATH))' ';'
 	FixPath = $(subst /,\,$1)
+	PWD=$(shell @echo %cd%)
 else
 	FixPath = $1
 endif
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= $(IMAGE_NAME)
-IMAGE_DIR = $(WORKSPACE)
+IMAGE_DIR = $(PWD)
 IMAGE_PLATFORM ?= linux/amd64
 # Paths
 IMAGE_DOCKERFILE ?= $(IMAGE_DIR)/Dockerfile

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -42,8 +42,8 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     helper.registerAllowedMethod('fileExists', [String.class], { true })
     binding.setVariable('infra', ['withDockerPullCredentials': {body -> body()}, 'withDockerPushCredentials': {body ->body()}])
     helper.addShMock('jx-release-version', defaultGitTag , 0)
-    helper.addShMock('git remote -v | grep origin | grep push | sed \'s/^origin\\s//\' | sed \'s/\\s(push)//\'', 'https://github.com/org/repository.git', 0)
-    helper.addShMock('gh api /repos/org/repository/releases | jq -e -r \'.[] | select(.draft == true and .name == "next") | .id\'', '12345', 0)
+    helper.addShMock('git remote get-url origin', 'https://github.com/org/repository.git', 0)
+    helper.addShMock('gh api ${GH_RELEASES_API_URI} | jq -e -r \'[ .[] | select(.draft == true and .name == "next").id] | max\'', '12345', 0)
     addEnvVar('WORKSPACE', '/tmp')
 
     // Define mocks/stubs for the data objects

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -36,7 +36,7 @@ def call(String imageName, Map userConfig=[:]) {
     if (!finalConfig.agentLabels.contains('windows') && finalConfig.platform.contains('windows')) {
       echo "WARNING: The 'platform' is set to '${finalConfig.platform}', but there isn't any 'windows' agent requested."
     }
-    if (useContainer) {
+    if (finalConfig.useContainer) {
       echo "WARNING: You're building a Windows image in a container, you should set 'useContainer' to 'false'."
     }
     cstConfigSuffix = '-windows'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -113,10 +113,10 @@ def call(String imageName, Map userConfig=[:]) {
         if (semVerEnabled) {
           stage("Semantic Release of ${imageName}") {
             echo "Configuring credential.helper"
-            if (operatingSystem == 'windows') {
-              powershell 'git config --local credential.helper "!f() { echo username=%GIT_USERNAME%; echo password=%GIT_PASSWORD% }; f"'
-            } else {
+            if (isUnix) {
               sh 'git config --local credential.helper "!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f"'
+            } else {
+              powershell 'git config --local credential.helper "!f() { echo username=%GIT_USERNAME%; echo password=%GIT_PASSWORD% }; f"'
             }
 
             withCredentials([

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -36,6 +36,9 @@ def call(String imageName, Map userConfig=[:]) {
     if (!finalConfig.agentLabels.contains('windows') && finalConfig.platform.contains('windows')) {
       echo "WARNING: The 'platform' is set to '${finalConfig.platform}', but there isn't any 'windows' agent requested."
     }
+    if (useContainer) {
+      echo "WARNING: You're building a Windows image in a container, you should set 'useContainer' to 'false'."
+    }
     cstConfigSuffix = '-windows'
   }
   def operatingSystem = finalConfig.platform.split('/')[0]

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -27,12 +27,18 @@ def call(String imageName, Map userConfig=[:]) {
   DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
   final String buildDate = dateFormat.format(now)
 
+  // Fix potential Linux/Windows contradictions between platform & agentLabels, and set the Windows config suffix for CST files
   def cstConfigSuffix = ''
-  if (finalConfig.agentLabels.contains('windows')) {
-    if (finalConfig.platform.contains('linux')) {
-      echo "WARNING: a 'Windows' agent is requested, but the 'platform' is set to '${finalConfig.platform}'"
+  if (finalConfig.agentLabels.contains('windows') || finalConfig.platform.contains('windows')) {
+    if (finalConfig.agentLabels.contains('windows') && !finalConfig.platform.contains('windows')) {
+      echo "WARNING: A 'windows' agent is requested, but the 'platform' is set to '${finalConfig.platform}'."
       echo "Setting 'platform' to 'windows/amd64'"
       finalConfig.platform = 'windows/amd64'
+    }
+    if (!finalConfig.agentLabels.contains('windows') && finalConfig.platform.contains('windows')) {
+      echo "WARNING: The 'platform' is set to '${finalConfig.platform}', but there isn't any 'windows' agent requested."
+      echo "Adding 'windows' to the agent labels"
+      finalConfig.agentLabels += ' || windows'
     }
     cstConfigSuffix = '-windows'
   }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -27,18 +27,14 @@ def call(String imageName, Map userConfig=[:]) {
   DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
   final String buildDate = dateFormat.format(now)
 
-  // Fix potential Linux/Windows contradictions between platform & agentLabels, and set the Windows config suffix for CST files
+  // Warn about potential Linux/Windows contradictions between platform & agentLabels, and set the Windows config suffix for CST files
   def cstConfigSuffix = ''
   if (finalConfig.agentLabels.contains('windows') || finalConfig.platform.contains('windows')) {
     if (finalConfig.agentLabels.contains('windows') && !finalConfig.platform.contains('windows')) {
       echo "WARNING: A 'windows' agent is requested, but the 'platform' is set to '${finalConfig.platform}'."
-      echo "Setting 'platform' to 'windows/amd64'"
-      finalConfig.platform = 'windows/amd64'
     }
     if (!finalConfig.agentLabels.contains('windows') && finalConfig.platform.contains('windows')) {
       echo "WARNING: The 'platform' is set to '${finalConfig.platform}', but there isn't any 'windows' agent requested."
-      echo "Adding 'windows' to the agent labels"
-      finalConfig.agentLabels += ' || windows'
     }
     cstConfigSuffix = '-windows'
   }
@@ -113,7 +109,7 @@ def call(String imageName, Map userConfig=[:]) {
         if (semVerEnabled) {
           stage("Semantic Release of ${imageName}") {
             echo "Configuring credential.helper"
-            if (isUnix) {
+            if (infra.isUnix) {
               sh 'git config --local credential.helper "!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f"'
             } else {
               powershell 'git config --local credential.helper "!f() { echo username=%GIT_USERNAME%; echo password=%GIT_PASSWORD% }; f"'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -60,7 +60,6 @@ def call(String imageName, Map userConfig=[:]) {
           // The makefile to use must come from the pipeline to avoid a nasty user trying to exfiltrate data from the build
           // Even though we have mitigation through the multibranch job config allowing to build PRs only from the repository contributors
           writeFile file: 'Makefile', text: makefileContent
-
         } // stage
 
         // Automatic tagging on principal branch is not enabled by default

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -28,7 +28,7 @@ def call(String imageName, Map userConfig=[:]) {
   final String buildDate = dateFormat.format(now)
 
   // Warn about potential Linux/Windows contradictions between platform & agentLabels, and set the Windows config suffix for CST files
-  def cstConfigSuffix = ''
+  String cstConfigSuffix = ''
   if (finalConfig.agentLabels.contains('windows') || finalConfig.platform.contains('windows')) {
     if (finalConfig.agentLabels.contains('windows') && !finalConfig.platform.contains('windows')) {
       echo "WARNING: A 'windows' agent is requested, but the 'platform' is set to '${finalConfig.platform}'."
@@ -41,7 +41,7 @@ def call(String imageName, Map userConfig=[:]) {
     }
     cstConfigSuffix = '-windows'
   }
-  def operatingSystem = finalConfig.platform.split('/')[0]
+  String operatingSystem = finalConfig.platform.split('/')[0]
 
   withContainerEngineAgent(finalConfig, {
     withEnv([

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -27,13 +27,16 @@ def call(String imageName, Map userConfig=[:]) {
   DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
   final String buildDate = dateFormat.format(now)
 
-  def operatingSystem = finalConfig.platform.split('/')[0]
-  def cpuArch = finalConfig.platform.split('/')[1]
   def cstConfigSuffix = ''
   if (finalConfig.agentLabels.contains('windows')) {
-    operatingSystem = 'Windows'
+    if (finalConfig.platform.contains('linux')) {
+      echo "WARNING: a 'Windows' agent is requested, but the 'platform' is set to '${finalConfig.platform}'"
+      echo "Setting 'platform' to 'windows/amd64'"
+      finalConfig.platform = 'windows/amd64'
+    }
     cstConfigSuffix = '-windows'
   }
+  def operatingSystem = finalConfig.platform.split('/')[0]
 
   withContainerEngineAgent(finalConfig, {
     withEnv([
@@ -105,7 +108,7 @@ def call(String imageName, Map userConfig=[:]) {
         if (semVerEnabled) {
           stage("Semantic Release of ${imageName}") {
             echo "Configuring credential.helper"
-            if (operatingSystem == 'Windows') {
+            if (operatingSystem == 'windows') {
               powershell 'git config --local credential.helper "!f() { echo username=%GIT_USERNAME%; echo password=%GIT_PASSWORD% }; f"'
             } else {
               sh 'git config --local credential.helper "!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f"'

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -6,15 +6,15 @@ The following arguments are available for this function:
 
 - String **imageName**: (Mandatory) name of the image to build, usually referenced as the "Repository" part of a Docker image name without any tag (Example: "builder" or "terraform").
 - Map **config**: (Optional) custom configuration for the image build and deploy process. This map can hold any of the following keys:
-  * Boolean **useContainer** (Optional, defaults to false) Execute the phases inside a container, using a container-less and root-less tool. If set to false, then the phases are run with Docker CE running in a VM.
-  * String **dockerfile**: (Optional, defaults to "Dockerfile") Relative path to the Dockerfile to use within the repository (Example: "build.dockerfile", "docker/Dockerfile").
-  * String **imageDir**: (Optional, defaults to the parent directory of "Dockerfile") Path to a directory to use as build context (Example: "docker/", "python/2.7").
-  * String **credentials**: (Optional, defaults to "jenkins-dockerhub") Name of the Jenkins' credentials used to authenticate on the Docker remote registry during the full build process. (Example: "internal-registry-credential").
+  * Boolean **useContainer** (Optional, defaults to true) Execute the phases inside a container, using a container-less and root-less tool. If set to false, then the phases are run with Docker CE running in a VM.
+  * String **agentLabels** (Optional, defaults to "docker || linux-amd64-docker") String expression for the labels the agent must match.
   * String **builderImage**: (Optional, defaults to "jenkinsciinfra/builder:2.0.2") Docker Image to be used for the container "builder" of the CI pod template.
-  * String **platform**: (Optional, defaults to "linux/amd64") Name of the docker platform to use when building this image. For multiple platforms use a comma separated list (Example: "linux/amd64,linux/arm64").
   * Boolean **automaticSemanticVersioning**: (Optional, defaults to "false") Should a release be created for every merge to the mainBranch. This uses "jx-release-version" to determine the version number based on the commit history.
-  * String **gitCredentials**: (Optional, defaults to "") If "automaticSemanticVersioning" is set, name of the credential to use when tagging the git repository. Support user/password or GitHub App credential types.
+  * String **dockerfile**: (Optional, defaults to "Dockerfile") Relative path to the Dockerfile to use within the repository (Example: "build.dockerfile", "docker/Dockerfile").
+  * String **platform**: (Optional, defaults to "linux/amd64") Name of the docker platform to use when building this image. For multiple platforms use a comma separated list (Example: "linux/amd64,linux/arm64").
   * String **nextVersionCommand** (Optional, defaults to "jx-release-version") If "automaticSemanticVersioning" is set, this is the command to retrieve the next version (to use for tagging and releasing)
+  * String **gitCredentials**: (Optional, defaults to "") If "automaticSemanticVersioning" is set, name of the credential to use when tagging the git repository. Support user/password or GitHub App credential types.
+  * String **imageDir**: (Optional, defaults to ".", the parent directory of the Dockerfile) Path to a directory to use as build context (Example: "docker/", "python/2.7").
 
 The lint phase generates a report when it fails, recorded by the hadolint tool in your Jenkins instance.
 
@@ -24,7 +24,8 @@ The build phase adds build arguments you can use in your Dockerfile:
 - **GIT_SCM_URL** - Url to repo
 - **BUILD_DATE** - Date of the image build (now)
 
-The test phase is only executed if a file `cst.yml` is found at the root of the repository with the "TAR" driver for security concerns.
+The test phase is only executed if a file `common-cst.yml` or `<imageDir>/cst.yml` is found at the root of the repository with the "TAR" driver for security concerns.
+If the build concerns a Windows image, a prefix `-windows` is expected (`common-cst-windows.yml` or `<imageDir>/cst-windows.yml`)
 Please reference to https://github.com/GoogleContainerTools/container-structure-test.
 
 Publication of the Docker image only happens when the build is triggered by:
@@ -36,28 +37,22 @@ Publication of the Docker image only happens when the build is triggered by:
 Example Usages
 
 <pre><code>
-buildDockerAndPublishImage('terraform', [
-  dockerfile: 'docker/Dockerfile',
-  registry: 'docker4eval'
-])
+buildDockerAndPublishImage('terraform')
 </code></pre>
 
 <pre><code>
 parallel(
   failFast: true,
-  'docker': {
-    buildDockerAndPublishImage('docker', [
-      dockerfile: 'docker/Dockerfile',
-    ])
+  'maven-jdk8': {
+    buildDockerAndPublishImage('maven-jdk8', [imageDir: 'maven/jdk8'])
   },
-  'golang': {
-    buildDockerAndPublishImage('golang', [
-      dockerfile: 'golang/Dockerfile',
-    ])
-  },
-  'coreruntime-2.2': {
-    buildDockerAndPublishImage('coreruntime-2.2', [
-      dockerfile: 'coreruntime/22/Dockerfile',
+  'maven-jdk8-nanoserver': {
+    buildDockerAndPublishImage('maven-jdk8-nanoserver', [
+      imageDir: 'maven/jdk8',
+      dockerfile: 'Dockerfile.nanoserver',
+      platform: 'windows/amd64',
+      agentLabels: 'windows',
+      useContainer: false,
     ])
   },
 )


### PR DESCRIPTION
After [adding GNU tools to Windows packer images](https://github.com/jenkins-infra/packer-images/pull/230), I've adapted the Makefile to be compatible with Linux and Windows, then the `buildDockerAndPublishImage` shared pipeline library function.

I've also removed all tools installations since [they are included in packer images](https://github.com/jenkins-infra/packer-images/pull/216).

Tested in: https://github.com/jenkins-infra/docker-inbound-agents/pull/21
Supercede: https://github.com/jenkins-infra/pipeline-library/pull/372
Ref: https://github.com/jenkins-infra/helpdesk/issues/2873