### PR TITLE
fix(buildDockerAndPublishImage): use the complete tag as previous-version arg

### DIFF
--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -75,11 +75,11 @@ def call(String imageName, Map userConfig=[:]) {
                 echo "Including the image name '${imageName}' in the next version"
                 // Retrieving the semver part from the last tag including the image name
                 String currentTagScript = 'git tag --list \"*' + imageInTag + '\" --sort=-v:refname | head -1'
-                String currentSemVerVersionPart = sh(script: currentTagScript, returnStdout: true).trim().replace(imageInTag, '')
-                echo "Current semver version part is '${currentSemVerVersionPart}'"
+                String currentSemVerVersion = sh(script: currentTagScript, returnStdout: true).trim()
+                echo "Current semver version is '${currentSemVerVersion}'"
                 // Set a default value if there isn't any tag for the current image yet (https://groovy-lang.org/operators.html#_elvis_operator)
-                currentSemVerVersionPart = currentSemVerVersionPart ?: '0.0.0'
-                String nextVersionScript = finalConfig.nextVersionCommand + ' -debug --previous-version=' + currentSemVerVersionPart
+                currentSemVerVersion = currentSemVerVersion ?: '0.0.0-' + imageInTag
+                String nextVersionScript = finalConfig.nextVersionCommand + ' -debug --previous-version=' + currentSemVerVersion
                 String nextVersionSemVerPart = sh(script: nextVersionScript, returnStdout: true).trim()
                 echo "Next semver version part is '${nextVersionSemVerPart}'"
                 nextVersion =  nextVersionSemVerPart + imageInTag
@@ -92,11 +92,11 @@ def call(String imageName, Map userConfig=[:]) {
                 echo "Including the image name '${imageName}' in the next version"
                 // Retrieving the semver part from the last tag including the image name
                 String currentTagScript = 'git tag --list \"*' + imageInTag + '\" --sort=-v:refname | head -1'
-                String currentSemVerVersionPart = powershell(script: currentTagScript, returnStdout: true).trim().replace(imageInTag, '')
-                echo "Current semver version part is '${currentSemVerVersionPart}'"
+                String currentSemVerVersion = powershell(script: currentTagScript, returnStdout: true).trim().replace(imageInTag, '')
+                echo "Current semver version is '${currentSemVerVersion}'"
                 // Set a default value if there isn't any tag for the current image yet (https://groovy-lang.org/operators.html#_elvis_operator)
-                currentSemVerVersionPart = currentSemVerVersionPart ?: '0.0.0'
-                String nextVersionScript = finalConfig.nextVersionCommand + ' -debug --previous-version=' + currentSemVerVersionPart
+                currentSemVerVersion = currentSemVerVersion ?: '0.0.0-' + imageInTag
+                String nextVersionScript = finalConfig.nextVersionCommand + ' -debug --previous-version=' + currentSemVerVersion
                 String nextVersionSemVerPart = powershell(script: nextVersionScript, returnStdout: true).trim()
                 echo "Next semver version part is '${nextVersionSemVerPart}'"
                 nextVersion =  nextVersionSemVerPart + imageInTag

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -92,7 +92,7 @@ def call(String imageName, Map userConfig=[:]) {
                 echo "Including the image name '${imageName}' in the next version"
                 // Retrieving the semver part from the last tag including the image name
                 String currentTagScript = 'git tag --list \"*' + imageInTag + '\" --sort=-v:refname | head -1'
-                String currentSemVerVersion = powershell(script: currentTagScript, returnStdout: true).trim().replace(imageInTag, '')
+                String currentSemVerVersion = powershell(script: currentTagScript, returnStdout: true).trim()
                 echo "Current semver version is '${currentSemVerVersion}'"
                 // Set a default value if there isn't any tag for the current image yet (https://groovy-lang.org/operators.html#_elvis_operator)
                 currentSemVerVersion = currentSemVerVersion ?: '0.0.0-' + imageInTag


### PR DESCRIPTION
Failed test in this replay: https://infra.ci.jenkins.io/blue/organizations/jenkins/docker-jobs%2Fdocker-inbound-agents/detail/main/21/pipeline, `jx-release-version` see the commit associated with the tag hasn't changed, doesn't take in account the commit message(s) and bump only a patch:

<img width="1491" alt="image" src="https://user-images.githubusercontent.com/91831478/172886438-50495028-7d67-49f2-a565-86e64b833a26.png">


Another test in this replay: https://infra.ci.jenkins.io/blue/organizations/jenkins/docker-jobs%2Fdocker-inbound-agents/detail/PR-26/2/pipeline ✅ 

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/91831478/172886278-140fc9e2-3c27-4e66-9fdc-0d96fdbd99e9.png">


Follow-up of https://github.com/jenkins-infra/pipeline-library/pull/408