### PR TITLE
Discover the reference build before recording code coverage

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -127,6 +127,7 @@ def call(Map params = [:]) {
                     if (!skipTests) {
                       junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml')
                       if (first) {
+                        discoverReferenceBuild()
                         publishCoverage calculateDiffForChangeRequests: true, adapters: [jacocoAdapter('**/target/site/jacoco/jacoco.xml')]
                       }
                     }
@@ -162,11 +163,9 @@ def call(Map params = [:]) {
                 }
 
                 if (first) {
-                  folders = env.JOB_NAME.split('/')
-                  if (folders.length > 1) {
-                    discoverGitReferenceBuild(scm: folders[1])
+                  if (skipTests) { // otherwise the reference build has been computed already
+                    discoverReferenceBuild()
                   }
-
                   echo "Recording static analysis results on '${stageIdentifier}'"
 
                   recordIssues(
@@ -279,6 +278,13 @@ def call(Map params = [:]) {
   parallel(tasks)
   if (publishingIncrementals) {
     infra.maybePublishIncrementals()
+  }
+}
+
+private void discoverReferenceBuild() {
+  folders = env.JOB_NAME.split('/')
+  if (folders.length > 1) {
+    discoverGitReferenceBuild(scm: folders[1])
   }
 }
 


### PR DESCRIPTION
In [release 3.0.0](https://github.com/jenkinsci/code-coverage-api-plugin/releases/tag/v3.0.0) the code coverage plugin  introduces a new feature to compute the delta coverage of pull requests. In order to compute this coverage the reference build must be computed before the coverage recording step. Otherwise we cannot compute the delta coverage of a pull request.