### PR TITLE
chore(updatecli) fix depreciation warnings for 0.28.x version

### DIFF
--- a/updatecli/updatecli.d/docker-helmfile.yml
+++ b/updatecli/updatecli.d/docker-helmfile.yml
@@ -15,7 +15,7 @@ scms:
 
 sources:
   lastVersion:
-    kind: githubRelease
+    kind: githubrelease
     name: Get the latest updatecli version
     spec:
       owner: "jenkins-infra"
@@ -28,7 +28,7 @@ sources:
 conditions:
   checkIfDockerImageIsPublished:
     name: "Check if the Docker Image is published"
-    kind: dockerImage
+    kind: dockerimage
     spec:
       image: "jenkinsciinfra/helmfile"
       architecture: amd64

--- a/updatecli/updatecli.d/terraform-hashicorp.yml
+++ b/updatecli/updatecli.d/terraform-hashicorp.yml
@@ -14,7 +14,7 @@ scms:
 
 sources:
   dockerHashicorpToolsImageVersion:
-    kind: githubRelease
+    kind: githubrelease
     spec:
       owner: "jenkins-infra"
       repository: "docker-hashicorp-tools"
@@ -24,7 +24,7 @@ sources:
 conditions:
   checkIfDockerImageIsPublished:
     name: "Check if the Docker Image is published"
-    kind: dockerImage
+    kind: dockerimage
     spec:
       image: "jenkinsciinfra/hashicorp-tools"
       architecture: amd64

--- a/updatecli/updatecli.d/updatecli.yaml
+++ b/updatecli/updatecli.d/updatecli.yaml
@@ -14,7 +14,7 @@ scms:
 
 sources:
   latestUpdatecliVersion:
-    kind: githubRelease
+    kind: githubrelease
     name: Get the latest stable updatecli version
     spec:
       owner: "updatecli"


### PR DESCRIPTION
This PR fixes the depreciation warning introduced with recent updatecli versions:

```console
Loading Pipeline "updatecli/updatecli.d/docker-helmfile.yml"
WARNING: kind value "dockerImage" must be lowercase
WARNING: kind value "githubRelease" must be lowercase
Loading Pipeline "updatecli/updatecli.d/terraform-hashicorp.yml"
WARNING: kind value "dockerImage" must be lowercase
WARNING: kind value "githubRelease" must be lowercase
Loading Pipeline "updatecli/updatecli.d/updatecli.yaml"
WARNING: kind value "githubRelease" must be lowercase
```

https://github.com/jenkins-infra/pipeline-library/runs/7498122474?check_suite_focus=true


No functional changes