### PR TITLE
Refine check for Maven vs. Gradle

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -62,7 +62,7 @@ def call(Map params = [:]) {
 
               stage("Checkout (${stageIdentifier})") {
                 infra.checkoutSCM(repo)
-                isMaven = fileExists('pom.xml')
+                isMaven = !fileExists('gradlew')
                 incrementals = fileExists('.mvn/extensions.xml') &&
                     readFile('.mvn/extensions.xml').contains('git-changelist-maven-extension')
                 final String gitUnavailableMessage = '[buildPlugin] Git CLI may not be available'


### PR DESCRIPTION
In https://ci.jenkins.io/job/Plugins/job/workflow-durable-task-step-plugin/job/PR-257/4/console from https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/257 I was surprised to see the build failing trying to run `gradlew` when this is a Maven-based plugin. I think something weird happens when a build is run right when a PR is closed. `fileExists` probably breaks at that moment. Also

> WARNING: Gradle mode for buildPlugin() is deprecated, please use buildPluginWithGradle()

So let us err on the side of assuming Maven-based plugins. Note

```console
$ for p in *-plugin; do if [ -f $p/gradlew -a -f $p/pom.xml ]; then echo $p; fi; done
build-flow-plugin
```

and that plugin is long dead so I think there is not much risk of misidentification.
