### PR TITLE
Add placeholders for LATEST and LATEST_LTS jenkins versions

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -98,6 +98,19 @@ class BuildPluginStepTests extends BaseTest {
   }
 
   @Test
+  void test_getConfigurations_implicit_with_latest_jenkinsVersions() throws Exception {
+    def script = loadScript(scriptName)
+    def configurations = script.getConfigurations(jenkinsVersions: ['LATEST', 'LATEST_LTS'])
+    assertEquals(configurations.size, 4)
+    URL latest = new URL('https://updates.jenkins.io/current/latestCore.txt')
+    URL latestLts = new URL('https://updates.jenkins.io/stable/latestCore.txt')
+    assertNotNull(configurations.find{it.jenkins.equals(latest.text)})
+    assertNotNull(configurations.find{it.jenkins.equals(latestLts.text)})
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_getConfigurations_implicit_with_jdkVersions() throws Exception {
     def script = loadScript(scriptName)
     def configurations = script.getConfigurations(jdkVersions: ['1.4', '1.3'])

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -1,4 +1,5 @@
 #!/usr/bin/env groovy
+
 /**
  * Simple wrapper step for building a plugin
  */
@@ -321,6 +322,13 @@ List<Map<String, String>> getConfigurations(Map params) {
   for (p in platforms) {
     for (jdk in jdkVersions) {
       for (jenkins in jenkinsVersions) {
+        if (jenkins.equals('LATEST')) {
+          URL updateSite = new URL('https://updates.jenkins.io/current/latestCore.txt')
+          jenkins = updateSite.text
+        } else if (jenkins.equals('LATEST_LTS')) {
+          URL updateSite = new URL('https://updates.jenkins.io/stable/latestCore.txt')
+          jenkins = updateSite.text
+        }
         ret << [
           'platform': p,
           'jdk': jdk,


### PR DESCRIPTION
IMHO it should be common practice to test plugins against the minimal Jenkins version by setting the corresponding buildPlugin() configuration to `null`. Further one should be testing against the latest stable LTS release and the cutting edge latest releases as well. It is very cumbersome to always update the corresponding configurations manually in my Jenkinsfile and trying to update it via Dependabot or similar does not seem very feasible.

This is why I propose to introduce placeholders `LATEST` and `LATEST_LTS` that will automatically be replaced with the information from the Jenkins Update Sites (https://github.com/jenkins-infra/update-center2/blob/master/site/LAYOUT.md) by the pipeline-library.
This way it could be easily encouraged to always include these versions in a plugin build in order to identify compatibility issues early.

If the general idea is accepted I'd of course add the corresponding documentation for it in this PR!