### PR TITLE
feat(buildDockerAndPublishImage): add 'unstash' parameter

### DIFF
--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -14,7 +14,7 @@ def call(String imageShortName, Map userConfig=[:]) {
     gitCredentials: 'github-app-infra', // Credential ID for tagging and creating release
     imageDir: '.', // Relative path to the context directory for the Docker build
     registryNamespace: '', // Empty by default (means "autodiscover based on the current controller")
-    skipCheckout: false, // Allow to skip the `checkout scm` instruction in case it's already been done previously and we want to keep generated artifacts
+    unstash: '', // Allow to unstash files if not empty
   ]
 
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
@@ -63,7 +63,9 @@ def call(String imageShortName, Map userConfig=[:]) {
       infra.withDockerPullCredentials{
         String nextVersion = ''
         stage("Prepare ${imageName}") {
-          if (!finalConfig.skipCheckout) {
+          if (finalConfig.unstash != '') {
+            unstash finalConfig.unstash
+          } else {
             checkout scm
           }
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -14,6 +14,7 @@ def call(String imageShortName, Map userConfig=[:]) {
     gitCredentials: 'github-app-infra', // Credential ID for tagging and creating release
     imageDir: '.', // Relative path to the context directory for the Docker build
     registryNamespace: '', // Empty by default (means "autodiscover based on the current controller")
+    skipCheckout: false, // Allow to skip the `checkout scm` instruction in case it's already been done previously and we want to keep generated artifacts
   ]
 
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
@@ -62,7 +63,9 @@ def call(String imageShortName, Map userConfig=[:]) {
       infra.withDockerPullCredentials{
         String nextVersion = ''
         stage("Prepare ${imageName}") {
-          checkout scm
+          if (!skipCheckout) {
+            checkout scm
+          }
 
           // The makefile to use must come from the pipeline to avoid a nasty user trying to exfiltrate data from the build
           // Even though we have mitigation through the multibranch job config allowing to build PRs only from the repository contributors

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -63,7 +63,7 @@ def call(String imageShortName, Map userConfig=[:]) {
       infra.withDockerPullCredentials{
         String nextVersion = ''
         stage("Prepare ${imageName}") {
-          if (!skipCheckout) {
+          if (!finalConfig.skipCheckout) {
             checkout scm
           }
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -63,10 +63,9 @@ def call(String imageShortName, Map userConfig=[:]) {
       infra.withDockerPullCredentials{
         String nextVersion = ''
         stage("Prepare ${imageName}") {
+          checkout scm
           if (finalConfig.unstash != '') {
             unstash finalConfig.unstash
-          } else {
-            checkout scm
           }
 
           // The makefile to use must come from the pipeline to avoid a nasty user trying to exfiltrate data from the build

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -15,7 +15,7 @@ The following arguments are available for this function:
   * String **gitCredentials**: (Optional, defaults to "") If "automaticSemanticVersioning" is set, name of the credential to use when tagging the git repository. Support user/password or GitHub App credential types.
   * String **imageDir**: (Optional, defaults to ".", the parent directory of the Dockerfile) Path to a directory to use as build context (Example: "docker/", "python/2.7").
   * String **registry**: (Optional, defaults to "" which defines the registry based on the current controller setup) Container registry to deploy this image to (Example: "ghcr.io", "python/2.7").
-  * Boolean **unstash**: (Optional, default to "") Allow to unstash files if not empty
+  * Boolean **unstash**: (Optional, default to "") Allow to restore files from a previously saved stash if not empty.
 
 The lint phase generates a report when it fails, recorded by the hadolint tool in your Jenkins instance.
 

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -15,6 +15,7 @@ The following arguments are available for this function:
   * String **gitCredentials**: (Optional, defaults to "") If "automaticSemanticVersioning" is set, name of the credential to use when tagging the git repository. Support user/password or GitHub App credential types.
   * String **imageDir**: (Optional, defaults to ".", the parent directory of the Dockerfile) Path to a directory to use as build context (Example: "docker/", "python/2.7").
   * String **registry**: (Optional, defaults to "" which defines the registry based on the current controller setup) Container registry to deploy this image to (Example: "ghcr.io", "python/2.7").
+  * Boolean **skipCheckout**: (Optional, default to "false") Allow to skip the `checkout scm` instruction in case it's already been done previously and we want to keep generated artifacts
 
 The lint phase generates a report when it fails, recorded by the hadolint tool in your Jenkins instance.
 

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -15,7 +15,7 @@ The following arguments are available for this function:
   * String **gitCredentials**: (Optional, defaults to "") If "automaticSemanticVersioning" is set, name of the credential to use when tagging the git repository. Support user/password or GitHub App credential types.
   * String **imageDir**: (Optional, defaults to ".", the parent directory of the Dockerfile) Path to a directory to use as build context (Example: "docker/", "python/2.7").
   * String **registry**: (Optional, defaults to "" which defines the registry based on the current controller setup) Container registry to deploy this image to (Example: "ghcr.io", "python/2.7").
-  * Boolean **skipCheckout**: (Optional, default to "false") Allow to skip the `checkout scm` instruction in case it's already been done previously and we want to keep generated artifacts
+  * Boolean **unstash**: (Optional, default to "") Allow to unstash files if not empty
 
 The lint phase generates a report when it fails, recorded by the hadolint tool in your Jenkins instance.
 


### PR DESCRIPTION
Allow to unstash artifacts generated previously, like the .jar of a Java app we want to make a Docker image for. (Ex: https://github.com/jenkins-infra/plugin-health-scoring/pull/36)