### PR TITLE
feat: implement `artifact-caching-proxy` in `buildPlugin`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,6 +40,8 @@ buildPlugin()
   only available for Maven projects)
 * `configurations`: An alternative way to specify `platforms`, `jdkVersions` and `jenkinsVersions` (that can not be combined
   with any of them).
+* `artifactCachingProxyEnabled`: (default: `false`) - if set to `true`, artifacts will be downloaded using one of the artifact caching proxy depending on the agent provider (Azure, DigitalOcean or AWS).
+
 ** Those options will run the build for all combinations of their values. While that is desirable in
   many cases, `configurations` permit to provide a specific combinations of label and java/jenkins versions to use
 +

--- a/resources/artifact-caching-proxy-settings.xml
+++ b/resources/artifact-caching-proxy-settings.xml
@@ -1,0 +1,26 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>PROVIDER-artifact-caching-proxy</id>
+            <username>SERVER-USERNAME</username>
+            <password>SERVER-PASSWORD</password>
+        </server>
+        <server>
+            <id>PROVIDER-incrementals-artifact-caching-proxy</id>
+            <username>SERVER-USERNAME</username>
+            <password>SERVER-PASSWORD</password>
+        </server>
+    </servers>
+    <mirrors>
+    <mirror>
+        <id>PROVIDER-artifact-caching-proxy</id>
+        <url>https://repo.PROVIDER.jenkins.io/public/</url>
+        <mirrorOf>repo.jenkins-ci.org</mirrorOf>
+    </mirror>
+    <mirror>
+        <id>PROVIDER-incrementals-artifact-caching-proxy</id>
+        <url>https://repo.PROVIDER.jenkins.io/incrementals/</url>
+        <mirrorOf>incrementals</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -9,6 +9,11 @@ import static org.junit.Assert.assertTrue
 
 class BuildPluginStepTests extends BaseTest {
   static final String scriptName = 'vars/buildPlugin.groovy'
+  static final String defaultArtifactCachingProxyProvider = 'azure'
+  static final String unavailableArtifactCachingProxyProvider = 'foo'
+  static final String artifactCachingProxyProviderDifferentFromDefaultOne = 'do'
+  static final String artifactCachingProxyUsername = 'myArtifactCachingProxyUsername'
+  static final String artifactCachingProxyPassword = 'myArtifactCachingProxyPassword'
 
   @Override
   @Before
@@ -18,6 +23,8 @@ class BuildPluginStepTests extends BaseTest {
     helper.registerAllowedMethod('fileExists', [String.class], { s -> return s.equals('pom.xml') })
     env.NODE_LABELS = 'docker'
     env.JOB_NAME = 'build/plugin/test'
+    env.ARTIFACT_CACHING_PROXY_USERNAME = artifactCachingProxyUsername
+    env.ARTIFACT_CACHING_PROXY_PASSWORD = artifactCachingProxyPassword
   }
 
   @Test
@@ -309,5 +316,74 @@ class BuildPluginStepTests extends BaseTest {
     printCallStack()
     // then it runs the fingerprint
     assertTrue(assertMethodCallContainsPattern('fingerprint', '**/*-rc*.*/*-rc*.*'))
+  }
+
+  @Test
+  void test_buildPlugin_with_artifact_caching_proxy_enabled_and_no_provider_specified() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with artifactCachingProxyEnabled set to true and no provider is specified
+    script.call(['artifactCachingProxyEnabled': true])
+    printCallStack()
+    // then it notices no valid artifact caching provider has been specified and that it will set it to the default one
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: no valid artifact caching proxy provider specified, set to '${defaultArtifactCachingProxyProvider}' by default."))
+    // then it tells it will use the default artifact caching proxy provider
+    assertTrue(assertMethodCallContainsPattern('echo', "Setting up Maven to use artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider..."))
+    // then it writes settings.xml in the user .m2 folder
+    assertTrue(assertMethodCallContainsPattern('writeFile', "mavenSettings.xml"))
+    // then settings.xml contains the default artifact caching proxy provider url
+    assertTrue(assertMethodCallContainsPattern('writeFile', "<url>https://repo.${defaultArtifactCachingProxyProvider}.jenkins.io/public/</url>"))
+    // then settings.xml does not contains the artifact caching proxy provider url placeholder
+    assertFalse(assertMethodCallContainsPattern('writeFile', '<url>https://repo.PROVIDER.jenkins.io/public/</url>'))
+    // then settings.xml contains the artifact caching proxy username
+    assertTrue(assertMethodCallContainsPattern('writeFile', "<username>${artifactCachingProxyUsername}</username>"))
+    // then settings.xml does not contain the server username placeholder
+    assertFalse(assertMethodCallContainsPattern('writeFile', '<username>SERVER-USERNAME</username>'))
+    // then settings.xml does not contain the server password placeholder
+    assertFalse(assertMethodCallContainsPattern('writeFile', '<password>SERVER-PASSWORD</password>'))
+    // then it tells it uses the default artifact caching proxy provider
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_with_artifact_caching_proxy_enabled_and_empty_provider_specified() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with artifactCachingProxyEnabled set to true and an empty provider is specified
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = ''
+    script.call(['artifactCachingProxyEnabled': true])
+    printCallStack()
+    // then it notices no valid artifact caching provider has been specified and that it will set it to the default one
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: no valid artifact caching proxy provider specified, set to '${defaultArtifactCachingProxyProvider}' by default."))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_with_artifact_caching_proxy_enabled_and_unavailable_provider_specified() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with artifactCachingProxyEnabled set to true and an unavailable provider is specified
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = unavailableArtifactCachingProxyProvider
+    script.call(['artifactCachingProxyEnabled': true])
+    printCallStack()
+    // then it notices no valid artifact caching provider has been specified and that it will set it to the default one
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: no valid artifact caching proxy provider specified, set to '${defaultArtifactCachingProxyProvider}' by default."))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_with_artifact_caching_proxy_enabled_and_provider_different_from_default_one_specified() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with artifactCachingProxyEnabled set to true and a provider different from the default one is specified
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = artifactCachingProxyProviderDifferentFromDefaultOne
+    script.call(['artifactCachingProxyEnabled': true])
+    printCallStack()
+    // then it does not notice no valid artifact caching provider has been specified and that it will set it to the default one
+    assertFalse(assertMethodCallContainsPattern('echo', "INFO: no valid artifact caching proxy provider specified, set to '${defaultArtifactCachingProxyProvider}' by default."))
+    // then it tells it will use the specified artifact caching proxy provider
+    assertTrue(assertMethodCallContainsPattern('echo', "Setting up Maven to use artifact caching proxy from '${artifactCachingProxyProviderDifferentFromDefaultOne}' provider..."))
+    // then settings.xml contains the specified artifact caching proxy provider url
+    assertTrue(assertMethodCallContainsPattern('writeFile', "<url>https://repo.${artifactCachingProxyProviderDifferentFromDefaultOne}.jenkins.io/public/</url>"))
+    // then it tells it uses the specified artifact caching proxy provider
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${artifactCachingProxyProviderDifferentFromDefaultOne}' provider."))
+    assertJobStatusSuccess()
   }
 }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -113,8 +113,7 @@ def call(Map params = [:]) {
                       final String defaultProxyProvider = 'azure'
                       def availableProxyProviders = ['azure', 'do', 'aws']
                       String requestedProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER
-                      String mavenSettings = libraryResource 'artifact-caching-proxy/settings.xml'
-                      String mavenSettingsSecurity = libraryResource 'artifact-caching-proxy/settings-security.xml'
+                      String mavenSettings = libraryResource 'artifact-caching-proxy-settings.xml'
 
                       // As azure VM agents don't have this env var, setting a default provider if none is specified or if the provider isn't available
                       if (requestedProvider == null || requestedProvider == '' || !availableProxyProviders.contains(requestedProvider)) {


### PR DESCRIPTION
This PR add an `artifactCachingProxyEnabled` parameter to the `buildPlugin` function to allow using one of [the artifact caching proxies](https://github.com/jenkins-infra/helm-charts/tree/main/charts/artifact-caching-proxy) deployed on each provider ([AWS](https://github.com/jenkins-infra/kubernetes-management/blob/1b11606e66822bcb60d31e3fcd23fafdc7b92d13/clusters/eks-public.yaml#L91-L101), [Azure](https://github.com/jenkins-infra/kubernetes-management/blob/1b11606e66822bcb60d31e3fcd23fafdc7b92d13/clusters/prodpublick8s.yaml) and [DigitalOcean](https://github.com/jenkins-infra/kubernetes-management/blob/1b11606e66822bcb60d31e3fcd23fafdc7b92d13/clusters/doks-public.yaml#L59-L69)) by specifying a Maven settings file with the basic auth required to access a artifact caching proxy (they all have the same credentials).

The choice of the proxy provider depends on the `ARTIFACT_CACHING_PROXY` environment variable [defined on every agent](https://github.com/jenkins-infra/jenkins-infra/pull/2351), except the Azure VM ones as the corresponding plugin doesn't allow setting env var. (This is also why the default artifact caching proxy provider is [set to `azure`](https://github.com/jenkins-infra/pipeline-library/pull/499/files#diff-db2794773b738dbb5566313f115cdf3ff1f45e13e57cbc37aa1bd181819ed5fbR113))

Supersedes #458 & #498 as [no Maven settings encryption is needed](https://github.com/jenkins-infra/pipeline-library/pull/498#discussion_r999413158).

For now I'm putting this functionality as opt-in for testing.
When this testing will be done, I intend to put it as opt-out by modifying the default value of the `artifactCachingProxyEnabled` parameter from `false` to `true`.

Successfully tested on Linux and Windows: https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/44 & https://ci.jenkins.io/job/Plugins/job/jenkins-infra-test-plugin/job/PR-44/126/

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752 