### PR TITLE
feat: implement `artifact-caching-proxy` in `buildPlugin` with config-file-provider

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,6 +40,8 @@ buildPlugin()
   only available for Maven projects)
 * `configurations`: An alternative way to specify `platforms`, `jdkVersions` and `jenkinsVersions` (that can not be combined
   with any of them).
+* `artifactCachingProxyEnabled`: (default: `false`) - if set to `true`, artifacts will be downloaded using one of the artifact caching proxy depending on the agent provider (Azure, DigitalOcean or AWS).
+
 ** Those options will run the build for all combinations of their values. While that is desirable in
   many cases, `configurations` permit to provide a specific combinations of label and java/jenkins versions to use
 +

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -363,6 +363,8 @@ class BuildPluginStepTests extends BaseTest {
     env.ARTIFACT_CACHING_PROXY_PROVIDER = availableArtifactCachingProxyProviderDifferentFromDefaultOne
     script.call(['artifactCachingProxyEnabled': true])
     printCallStack()
+    // then it notices the specified artifact caching provider will be used
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${availableArtifactCachingProxyProviderDifferentFromDefaultOne}' provider."))
     // then configFile contains the specified artifact caching proxy provider id
     assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${availableArtifactCachingProxyProviderDifferentFromDefaultOne}"))
     // then configFileProvider is correctly set

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -12,6 +12,8 @@ def call(Map params = [:]) {
   def failFast = params.containsKey('failFast') ? params.failFast : true
   def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
   def gitDefaultBranch = params.containsKey('gitDefaultBranch') ? params.gitDefaultBranch : null
+  // This functionnality is set as opt-in for now
+  def artifactCachingProxyEnabled = params.containsKey('artifactCachingProxyEnabled') ? params.artifactCachingProxyEnabled : false
 
   def useContainerAgent = params.containsKey('useContainerAgent') ? params.useContainerAgent : false
   if (params.containsKey('useAci')) {
@@ -121,7 +123,28 @@ def call(Map params = [:]) {
                   }
                   mavenOptions += 'clean install'
                   try {
-                    infra.runMaven(mavenOptions, jdk, null, null, addToolEnv)
+                    if (artifactCachingProxyEnabled) {
+                      // As azure VM agents don't have this env var, setting a default provider if none is specified or if the provider isn't available
+                      final String defaultProxyProvider = 'azure'
+                      def availableProxyProviders = ['azure', 'do', 'aws']
+                      String requestedProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER
+                      if (requestedProvider == null || requestedProvider == '' || !availableProxyProviders.contains(requestedProvider)) {
+                        requestedProvider = defaultProxyProvider
+                        echo "INFO: no valid artifact caching proxy provider specified, set to '$defaultProxyProvider' by default."
+                      } else {
+                        echo "INFO: using artifact caching proxy from '${requestedProvider}' provider."
+                      }
+
+                      configFileProvider(
+                          [configFile(fileId: "artifact-caching-proxy-${requestedProvider}", variable: 'MAVEN_SETTINGS')]) {
+                            infra.runMaven(mavenOptions, jdk, null, env.MAVEN_SETTINGS, addToolEnv)
+                          }
+                    } else {
+                      echo 'NOTICE: artifacts will be downloaded directly from https://repo.jenkins-ci.org.'
+                      // TODO: uncomment the line below when `artifactCachingProxyEnabled` is set as true by default (for opt-in)
+                      // echo 'Consider enabling the artifact caching proxy with "artifactCachingProxyEnabled: true".'
+                      infra.runMaven(mavenOptions, jdk, null, null, addToolEnv)
+                    }
                   } finally {
                     if (!skipTests) {
                       junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml')

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -140,9 +140,6 @@ def call(Map params = [:]) {
                             infra.runMaven(mavenOptions, jdk, null, env.MAVEN_SETTINGS, addToolEnv)
                           }
                     } else {
-                      echo 'NOTICE: artifacts will be downloaded directly from https://repo.jenkins-ci.org.'
-                      // TODO: uncomment the line below when `artifactCachingProxyEnabled` is set as true by default (for opt-in)
-                      // echo 'Consider enabling the artifact caching proxy with "artifactCachingProxyEnabled: true".'
                       infra.runMaven(mavenOptions, jdk, null, null, addToolEnv)
                     }
                   } finally {


### PR DESCRIPTION
This PR add an `artifactCachingProxyEnabled` parameter to the `buildPlugin` function to allow using one of [the artifact caching proxies](https://github.com/jenkins-infra/helm-charts/tree/main/charts/artifact-caching-proxy) deployed on each provider ([AWS](https://github.com/jenkins-infra/kubernetes-management/blob/1b11606e66822bcb60d31e3fcd23fafdc7b92d13/clusters/eks-public.yaml#L91-L101), [Azure](https://github.com/jenkins-infra/kubernetes-management/blob/1b11606e66822bcb60d31e3fcd23fafdc7b92d13/clusters/prodpublick8s.yaml) and [DigitalOcean](https://github.com/jenkins-infra/kubernetes-management/blob/1b11606e66822bcb60d31e3fcd23fafdc7b92d13/clusters/doks-public.yaml#L59-L69)) by specifying a [Maven settings file](https://github.com/jenkins-infra/kubernetes-management/pull/3078/).

Unlike my previous attempts as generating myself the Maven settings file, I'm now using the [Config File Provider](https://plugins.jenkins.io/config-file-provider/) to patch the settings with the basic auth required to access an artifact caching proxy (they all have the same credentials). As a result, the logic here is simpler.

The choice of the proxy provider depends on the `ARTIFACT_CACHING_PROXY` environment variable [defined on every agent](https://github.com/jenkins-infra/jenkins-infra/pull/2351), except the Azure VM ones as the corresponding plugin doesn't allow setting env var. (This is also why the default artifact caching proxy provider is [set to `azure`](https://github.com/jenkins-infra/pipeline-library/pull/499/files#diff-db2794773b738dbb5566313f115cdf3ff1f45e13e57cbc37aa1bd181819ed5fbR113)).

Needs https://github.com/jenkins-infra/kubernetes-management/pull/3078 and the equivalent on https://github.com/jenkins-infra/jenkins-infra (incoming PR)

Supersedes https://github.com/jenkins-infra/pipeline-library/pull/499 (thanks @jglick for the advises and inspiration!)

Tested on [jenkinsci/jenkins-infra-test-plugin](https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/44) with [`useContainerAgent: false`](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fjenkins-infra-test-plugin/detail/PR-44/131/pipeline) and [`useContainerAgent: true`](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fjenkins-infra-test-plugin/detail/PR-44/132/pipeline)

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752