### PR TITLE
chore: remove 'aws' artifact-caching-proxy

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -126,7 +126,7 @@ def call(Map params = [:]) {
                     if (artifactCachingProxyEnabled) {
                       // As azure VM agents don't have this env var, setting a default provider if none is specified or if the provider isn't available
                       final String defaultProxyProvider = 'azure'
-                      def availableProxyProviders = ['azure', 'do', 'aws']
+                      def availableProxyProviders = ['azure', 'do']
                       String requestedProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER
                       if (requestedProvider == null || requestedProvider == '' || !availableProxyProviders.contains(requestedProvider)) {
                         requestedProvider = defaultProxyProvider


### PR DESCRIPTION
We've got some issues restoring the service after the eks-public cluster upgrade to Kubernetes 1.23, removing the 'aws' provider while we're fixing it.