### PR TITLE
feat(buildPlugin): fallback to repo.jenkins-ci.org if the artifact caching proxy healcheck fails

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -334,10 +334,13 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_empty_provider_specified() throws Exception {
     def script = loadScript(scriptName)
+    final String healthCheckScript = "curl --fail https://repo.${defaultArtifactCachingProxyProvider}.jenkins.io/healthz"
     // when running with artifactCachingProxyEnabled set to true and an empty provider is specified
     env.ARTIFACT_CACHING_PROXY_PROVIDER = ''
     script.call(['artifactCachingProxyEnabled': true])
     printCallStack()
+    // then an healthcheck is performed on the provider
+    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScript) || assertMethodCallContainsPattern('bat', healthCheckScript))
     // then it notices the use of the default artifact caching provider
     assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
     // then it succeeds
@@ -401,6 +404,44 @@ class BuildPluginStepTests extends BaseTest {
     printCallStack()
     // then it notices invalid or unavailable artifact caching provider has been specified and that it will fallback to repo.jenkins-ci.org
     assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' specified, will use repo.jenkins-ci.org"))
+    // then there is no call to configFile containing the specified artifact caching proxy provider id
+    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_with_artifact_caching_proxy_enabled_and_reachable_provider_specified() throws Exception {
+    def script = loadScript(scriptName)
+    final String healthCheckScript = "curl --fail https://repo.${anotherArtifactCachingProxyProvider}.jenkins.io/healthz"
+    // when running with artifactCachingProxyEnabled set to true and a reachable provider is specified
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+    script.call(['artifactCachingProxyEnabled': true])
+    printCallStack()
+    // then an healthcheck is performed on the provider
+    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScript) || assertMethodCallContainsPattern('bat', healthCheckScript))
+    // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
+    assertFalse(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
+    // then there is no call to configFile containing the specified artifact caching proxy provider id
+    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_with_artifact_caching_proxy_enabled_and_unreachable_provider_specified() throws Exception {
+    def script = loadScript(scriptName)
+    final String healthCheckScript = "curl --fail https://repo.${anotherArtifactCachingProxyProvider}.jenkins.io/healthz"
+    // Mock an healthcheck fail
+    helper.addShMock(healthCheckScript, '', 1)
+    // when running with artifactCachingProxyEnabled set to true and an unreachable provider is specified
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+    script.call(['artifactCachingProxyEnabled': true])
+    printCallStack()
+    // then an healthcheck is performed on the provider
+    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScript) || assertMethodCallContainsPattern('bat', healthCheckScript))
+    // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
+    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
     // then there is no call to configFile containing the specified artifact caching proxy provider id
     assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
     // then it succeeds

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -334,7 +334,7 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_empty_provider_specified() throws Exception {
     def script = loadScript(scriptName)
-    final String healthCheckScript = "curl --fail https://repo.${defaultArtifactCachingProxyProvider}.jenkins.io/healthz"
+    final String healthCheckScript = 'curl --fail $HEALTHCHECK'
     // when running with artifactCachingProxyEnabled set to true and an empty provider is specified
     env.ARTIFACT_CACHING_PROXY_PROVIDER = ''
     script.call(['artifactCachingProxyEnabled': true])
@@ -413,7 +413,7 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_reachable_provider_specified() throws Exception {
     def script = loadScript(scriptName)
-    final String healthCheckScript = "curl --fail https://repo.${anotherArtifactCachingProxyProvider}.jenkins.io/healthz"
+    final String healthCheckScript = 'curl --fail $HEALTHCHECK'
     // when running with artifactCachingProxyEnabled set to true and a reachable provider is specified
     env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
     script.call(['artifactCachingProxyEnabled': true])
@@ -431,7 +431,7 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_unreachable_provider_specified() throws Exception {
     def script = loadScript(scriptName)
-    final String healthCheckScript = "curl --fail https://repo.${anotherArtifactCachingProxyProvider}.jenkins.io/healthz"
+    final String healthCheckScript = 'curl --fail $HEALTHCHECK'
     // Mock an healthcheck fail
     helper.addShMock(healthCheckScript, '', 1)
     // when running with artifactCachingProxyEnabled set to true and an unreachable provider is specified

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -128,7 +128,7 @@ def call(Map params = [:]) {
                       // As the env var ARTIFACT_CACHING_PROXY_PROVIDER can't be set on Azure VM agents,
                       // we're using 'azure' as default provider if none is specified
                       final String requestedProxyProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure'
-                      final String validProxyProviders = ['aws', 'azure', 'do']
+                      final String[] validProxyProviders = ['aws', 'azure', 'do']
                       final String configuredAvailableProxyProviders = env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS
                       if (configuredAvailableProxyProviders != null && configuredAvailableProxyProviders != '') {
                         final String[] availableProxyProviders = configuredAvailableProxyProviders.split(',')

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -135,11 +135,12 @@ def call(Map params = [:]) {
                         // Configure Maven settings if the requested provider is valid and available
                         if (validProxyProviders.contains(requestedProxyProvider) && availableProxyProviders.contains(requestedProxyProvider)) {
                           boolean healthCheckOK = false
-                          final String healthCheckScript = "curl --fail https://repo.${requestedProxyProvider}.jenkins.io/healthz"
-                          if (isUnix()) {
-                            healthCheckOK = sh(script: healthCheckScript, returnStatus: true) == 0
-                          } else {
-                            healthCheckOK = bat(script: healthCheckScript, returnStatus: true) == 0
+                          withEnv(["HEALTHCHECK=https://repo.${requestedProxyProvider}.jenkins.io/healthz"]) {
+                            if (isUnix()) {
+                              healthCheckOK = sh(script: 'curl --fail $HEALTHCHECK', returnStatus: true) == 0
+                            } else {
+                              healthCheckOK = bat(script: 'curl --fail $HEALTHCHECK', returnStatus: true) == 0
+                            }
                           }
                           if (healthCheckOK) {
                             echo "INFO: using artifact caching proxy from '${requestedProxyProvider}' provider."

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -131,7 +131,7 @@ def call(Map params = [:]) {
                       final String validProxyProviders = ['aws', 'azure', 'do']
                       final String configuredAvailableProxyProviders = env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS
                       if (configuredAvailableProxyProviders != null && configuredAvailableProxyProviders != '') {
-                        final String availableProxyProviders = configuredAvailableProxyProviders.split(',')
+                        final String[] availableProxyProviders = configuredAvailableProxyProviders.split(',')
                         // Configure Maven settings if the requested provider is valid and available
                         if (validProxyProviders.contains(requestedProxyProvider) && availableProxyProviders.contains(requestedProxyProvider)) {
                           boolean healthCheckOK = false


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/pipeline-library/pull/502 and https://github.com/jenkins-infra/helm-charts/pull/279, this PR add a simple health check request on the requested provider before using it, and fallback to repo.jenkins-ci.org if there is an issue.

Note: `curl` is available on all our Linux and Windows agents.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752