### PR TITLE
feat(buildPlugin): set default available artifact caching proxy providers to valid ones

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -365,15 +365,15 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_no_providers_env_var() throws Exception {
     def script = loadScript(scriptName)
-    // when running with artifactCachingProxyEnabled set to true and an available provider different from the default one is specified
+    // when running with artifactCachingProxyEnabled set to true and an available provider different from the default one is specified, without ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
     env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
     env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = null
     script.call(['artifactCachingProxyEnabled': true])
     printCallStack()
-    // then it warns the env var is incorrectly or not set
-    assertTrue(assertMethodCallContainsPattern('echo', 'WARNING: the value of ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS environment variable is not set on the controller, will use repo.jenkins-ci.org'))
+    // then it notices the use of the specified artifact caching provider
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
     // then there is no call to configFile containing the specified artifact caching proxy provider id
-    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
     // then it succeeds
     assertJobStatusSuccess()
   }

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -365,29 +365,47 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_no_providers_env_var() throws Exception {
     def script = loadScript(scriptName)
-    // when running with artifactCachingProxyEnabled set to true and an available provider different from the default one is specified, without ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
+    // when running with artifactCachingProxyEnabled set to true and an available provider different from the default one is specified
+    // without ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
     env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
     env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = null
     script.call(['artifactCachingProxyEnabled': true])
     printCallStack()
     // then it notices the use of the specified artifact caching provider
     assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
-    // then there is no call to configFile containing the specified artifact caching proxy provider id
+    // then there is a call to configFile containing the specified artifact caching proxy provider id
     assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
     // then it succeeds
     assertJobStatusSuccess()
   }
 
-  // @Test
+  @Test
+  void test_buildPlugin_with_artifact_caching_proxy_enabled_and_empty_providers_env_var() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with artifactCachingProxyEnabled set to true and an available provider different from the default one is specified
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = ''
+    script.call(['artifactCachingProxyEnabled': true])
+    printCallStack()
+    // then it notices the use of the specified artifact caching provider
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
+    // then there is a call to configFile containing the specified artifact caching proxy provider id
+    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_invalid_providers_env_var() throws Exception {
     def script = loadScript(scriptName)
     // when running with artifactCachingProxyEnabled set to true and an available provider different from the default one is specified
+    // with an invalid provider configured with ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
     env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
     env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = invalidArtifactCachingProxyProvider
     script.call(['artifactCachingProxyEnabled': true])
     printCallStack()
     // then it notices invalid or unavailable artifact caching provider has been specified and that it will fallback to repo.jenkins-ci.org
-    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${invalidArtifactCachingProxyProvider}' specified, will use repo.jenkins-ci.org"))
+    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' specified, will use repo.jenkins-ci.org"))
     // then there is no call to configFile containing the specified artifact caching proxy provider id
     assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
     // then it succeeds
@@ -397,7 +415,7 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_unavailable_provider_specified() throws Exception {
     def script = loadScript(scriptName)
-    // when running with artifactCachingProxyEnabled set to true and an invalid provider is specified
+    // when running with artifactCachingProxyEnabled set to true and an unavailable provider is specified
     env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
     env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = 'aws,azure' // without anotherArtifactCachingProxyProvider
     script.call(['artifactCachingProxyEnabled': true])

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -21,7 +21,6 @@ class BuildPluginStepTests extends BaseTest {
     helper.registerAllowedMethod('fileExists', [String.class], { s -> return s.equals('pom.xml') })
     env.NODE_LABELS = 'docker'
     env.JOB_NAME = 'build/plugin/test'
-    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = 'aws,azure,do'
   }
 
   @Test

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -128,8 +128,9 @@ def call(Map params = [:]) {
                       // As the env var ARTIFACT_CACHING_PROXY_PROVIDER can't be set on Azure VM agents,
                       // we're using 'azure' as default provider if none is specified
                       final String requestedProxyProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure'
-                      final String[] validProxyProviders = ['aws', 'azure', 'do']
-                      final String configuredAvailableProxyProviders = env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS
+                      final String validProxyProviders = ['aws', 'azure', 'do']
+                      // Useful when a provider is in maintainance (or similar cases), add a global env var in Jenkins controller settings to restrict them
+                      final String configuredAvailableProxyProviders = env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS ?: validProxyProviders
                       if (configuredAvailableProxyProviders != null && configuredAvailableProxyProviders != '') {
                         final String[] availableProxyProviders = configuredAvailableProxyProviders.split(',')
                         // Configure Maven settings if the requested provider is valid and available

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -128,33 +128,29 @@ def call(Map params = [:]) {
                       // As the env var ARTIFACT_CACHING_PROXY_PROVIDER can't be set on Azure VM agents,
                       // we're using 'azure' as default provider if none is specified
                       final String requestedProxyProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure'
-                      final String validProxyProviders = ['aws', 'azure', 'do']
+                      final String[] validProxyProviders = ['aws', 'azure', 'do']
                       // Useful when a provider is in maintainance (or similar cases), add a global env var in Jenkins controller settings to restrict them
-                      final String configuredAvailableProxyProviders = env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS ?: validProxyProviders
-                      if (configuredAvailableProxyProviders != null && configuredAvailableProxyProviders != '') {
-                        final String[] availableProxyProviders = configuredAvailableProxyProviders.split(',')
-                        // Configure Maven settings if the requested provider is valid and available
-                        if (validProxyProviders.contains(requestedProxyProvider) && availableProxyProviders.contains(requestedProxyProvider)) {
-                          boolean healthCheckOK = false
-                          withEnv(["HEALTHCHECK=https://repo.${requestedProxyProvider}.jenkins.io/healthz"]) {
-                            if (isUnix()) {
-                              healthCheckOK = sh(script: 'curl --fail $HEALTHCHECK', returnStatus: true) == 0
-                            } else {
-                              healthCheckOK = bat(script: 'curl --fail $HEALTHCHECK', returnStatus: true) == 0
-                            }
-                          }
-                          if (healthCheckOK) {
-                            echo "INFO: using artifact caching proxy from '${requestedProxyProvider}' provider."
-                            usingArtifactCachingProxy = true
-                            configFileProvider(
-                                [configFile(fileId: "artifact-caching-proxy-${requestedProxyProvider}", variable: 'MAVEN_SETTINGS')]) {
-                                  infra.runMaven(mavenOptions, jdk, null, env.MAVEN_SETTINGS, addToolEnv)
-                                }
+                      final String configuredAvailableProxyProviders = env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS ?: validProxyProviders.join(',')
+                      final String[] availableProxyProviders = configuredAvailableProxyProviders.split(',')
+                      // Configure Maven settings if the requested provider is valid and available
+                      if (validProxyProviders.contains(requestedProxyProvider) && availableProxyProviders.contains(requestedProxyProvider)) {
+                        boolean healthCheckOK = false
+                        withEnv(["HEALTHCHECK=https://repo.${requestedProxyProvider}.jenkins.io/healthz"]) {
+                          if (isUnix()) {
+                            healthCheckOK = sh(script: 'curl --fail $HEALTHCHECK', returnStatus: true) == 0
                           } else {
-                            echo "WARNING: the artifact caching proxy from '${requestedProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"
+                            healthCheckOK = bat(script: 'curl --fail $HEALTHCHECK', returnStatus: true) == 0
                           }
+                        }
+                        if (healthCheckOK) {
+                          echo "INFO: using artifact caching proxy from '${requestedProxyProvider}' provider."
+                          usingArtifactCachingProxy = true
+                          configFileProvider(
+                              [configFile(fileId: "artifact-caching-proxy-${requestedProxyProvider}", variable: 'MAVEN_SETTINGS')]) {
+                                infra.runMaven(mavenOptions, jdk, null, env.MAVEN_SETTINGS, addToolEnv)
+                              }
                         } else {
-                          echo "WARNING: invalid or unavailable artifact caching proxy provider '${requestedProxyProvider}' specified, will use repo.jenkins-ci.org"
+                          echo "WARNING: the artifact caching proxy from '${requestedProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"
                         }
                       } else {
                         echo "WARNING: invalid or unavailable artifact caching proxy provider '${requestedProxyProvider}' specified, will use repo.jenkins-ci.org"

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -157,7 +157,7 @@ def call(Map params = [:]) {
                           echo "WARNING: invalid or unavailable artifact caching proxy provider '${requestedProxyProvider}' specified, will use repo.jenkins-ci.org"
                         }
                       } else {
-                        echo 'WARNING: the value of ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS environment variable is not set on the controller, will use repo.jenkins-ci.org'
+                        echo "WARNING: invalid or unavailable artifact caching proxy provider '${requestedProxyProvider}' specified, will use repo.jenkins-ci.org"
                       }
                     }
                     if (!usingArtifactCachingProxy) {


### PR DESCRIPTION
So we only have to set a global env var on the controller when we need to restrict available providers.

Follow-up of #505