### PR TITLE
chore(buildPlugin): better curl call for the artifact caching proxy healthcheck

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -12,6 +12,7 @@ class BuildPluginStepTests extends BaseTest {
   static final String defaultArtifactCachingProxyProvider = 'azure'
   static final String anotherArtifactCachingProxyProvider = 'do'
   static final String invalidArtifactCachingProxyProvider = 'foo'
+  static final String healthCheckScript = 'curl --fail --silent --show-error --location $HEALTHCHECK'
 
   @Override
   @Before
@@ -333,7 +334,6 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_empty_provider_specified() throws Exception {
     def script = loadScript(scriptName)
-    final String healthCheckScript = 'curl --fail $HEALTHCHECK'
     // when running with artifactCachingProxyEnabled set to true and an empty provider is specified
     env.ARTIFACT_CACHING_PROXY_PROVIDER = ''
     script.call(['artifactCachingProxyEnabled': true])
@@ -430,7 +430,6 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_reachable_provider_specified() throws Exception {
     def script = loadScript(scriptName)
-    final String healthCheckScript = 'curl --fail $HEALTHCHECK'
     // when running with artifactCachingProxyEnabled set to true and a reachable provider is specified
     env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
     script.call(['artifactCachingProxyEnabled': true])
@@ -448,7 +447,6 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_unreachable_provider_specified() throws Exception {
     def script = loadScript(scriptName)
-    final String healthCheckScript = 'curl --fail $HEALTHCHECK'
     // Mock an healthcheck fail
     helper.addShMock(healthCheckScript, '', 1)
     // when running with artifactCachingProxyEnabled set to true and an unreachable provider is specified

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -137,9 +137,9 @@ def call(Map params = [:]) {
                         boolean healthCheckOK = false
                         withEnv(["HEALTHCHECK=https://repo.${requestedProxyProvider}.jenkins.io/healthz"]) {
                           if (isUnix()) {
-                            healthCheckOK = sh(script: 'curl --fail $HEALTHCHECK', returnStatus: true) == 0
+                            healthCheckOK = sh(script: 'curl --fail --silent --show-error --location $HEALTHCHECK', returnStatus: true) == 0
                           } else {
-                            healthCheckOK = bat(script: 'curl --fail $HEALTHCHECK', returnStatus: true) == 0
+                            healthCheckOK = bat(script: 'curl --fail --silent --show-error --location $HEALTHCHECK', returnStatus: true) == 0
                           }
                         }
                         if (healthCheckOK) {


### PR DESCRIPTION
`--location`: in case there is a redirection behind repo.jenkins-ci.org
`--silent`: don't show the transfert progress
`--show-error`:  display errors if any