### PR TITLE
Ensure gradlew permissions are sufficient to be executable on Linux

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -178,11 +178,14 @@ def call(Map params = [:]) {
                   if (skipTests) {
                     gradleOptions += '--exclude-task test'
                   }
+                  File gradleWrapper = new File("${pwd()}/gradlew")
+                  if (gradleWrapper.exists() && isUnix() && !gradleWrapper.canExecute()) {
+                    gradleWrapper.setExecutable(true)
+                  }
                   command = "gradlew ${gradleOptions.join(' ')}"
                   if (isUnix()) {
                     command = './' + command
                   }
-
                   try {
                     infra.runWithJava(command, jdk, null, addToolEnv)
                   } finally {


### PR DESCRIPTION
Generating the wrapper ships a low permission set, often not being sufficient when building on Linux or not being detected at all, e.g., you are using Windows and are not prone to file permissions.
The change proposed makes the wrapper executable for the run and doesn't interrupt the workflow.