### PR TITLE
breaking(buildPlugin) switch default JDK from 8 to 11

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ buildPlugin()
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel
-* `jdkVersions` (default: `[8]`) - JDK version numbers, must match a version
+* `jdkVersions` (default: `[11]`) - JDK version numbers, must match a version
   number jdk tool installed
 * `jenkinsVersions`: (default: `[null]`) - a matrix of Jenkins baseline versions to build/test against in parallel (null means default,
   only available for Maven projects)
@@ -48,9 +48,8 @@ buildPlugin()
 [source,groovy]
 ----
 buildPlugin(/*...*/, configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: "2.150" ]
+  [ platform: "linux", jdk: "11", jenkins: "2.375.1" ],
+  [ platform: "windows", jdk: "17" ]
 ])
 ----
 
@@ -73,7 +72,7 @@ Usage:
 [source,groovy]
 ----
 buildPlugin(platforms: ['linux'],
-        jdkVersions: [7, 8],
+        jdkVersions: [11],
         checkstyle: [qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]],
         pmd: [trendChartType: 'TOOLS_ONLY', qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]])
 ----
@@ -193,7 +192,7 @@ buildDockerImage_k8s('plugins-site-api')
 
 === Requirements
 
-* (Open)JDK v8
-* Maven 3.6.x
+* (Open)JDK v11
+* Maven 3.8.x
 
 ===

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -71,8 +71,8 @@ class BuildPluginStepTests extends BaseTest {
     def configurations = script.getConfigurations([:])
 
     def expected = [
-      ['platform': 'linux', 'jdk': '8', 'jenkins': null],
-      ['platform': 'windows', 'jdk': '8', 'jenkins': null],
+      ['platform': 'linux', 'jdk': '11', 'jenkins': null],
+      ['platform': 'windows', 'jdk': '11', 'jenkins': null],
     ]
     assertEquals(expected, configurations)
     printCallStack()

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -366,7 +366,7 @@ List<Map<String, String>> getConfigurations(Map params) {
   }
 
   def platforms = params.containsKey('platforms') ? params.platforms : ['linux', 'windows']
-  def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : ['8']
+  def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : ['11']
   def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]
 
   def ret = []


### PR DESCRIPTION
As per the discussion on https://groups.google.com/g/jenkinsci-dev/c/pjfvsMw-EMM/m/Y7JhtkBsAQAJ?utm_medium=email&utm_source=footer, since https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.52 has been released with JDK 8 being deprecated, we want to ensure the best contributor experience and use JDK11 by default for any default plugin build configuration (e.g. when calling `buildPlugin()` as per https://www.jenkins.io/doc/developer/tutorial-improve/add-a-jenkinsfile/.