### PR TITLE
feat(buildPlugin): skip ACP if a `skip-artifact-caching-proxy` label has been applied to the pull request

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -15,8 +15,8 @@ class BuildPluginStepTests extends BaseTest {
   static final String healthCheckScriptSh = 'curl --fail --silent --show-error --location $HEALTHCHECK'
   static final String healthCheckScriptBat = 'curl --fail --silent --show-error --location %HEALTHCHECK%'
   static final String changeUrlWithSkipACPLabel = 'https://api.github.com/repos/jenkins-infra/pipeline-library/pull/123'
-  static final String prLabelsContainSkipACPScriptSh = 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | grep --ignore-case \'"skip-artifact-caching-proxy"\''
-  static final String prLabelsContainSkipACPScriptBat = 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | findstr /i \'"skip-artifact-caching-proxy"\''
+  static final String prLabelsContainSkipACPScriptSh = 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | grep --ignore-case \'"skip-artifact-caching-proxy"\''
+  static final String prLabelsContainSkipACPScriptBat = 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | findstr /i \'"skip-artifact-caching-proxy"\''
 
   @Override
   @Before

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -15,8 +15,8 @@ class BuildPluginStepTests extends BaseTest {
   static final String healthCheckScriptSh = 'curl --fail --silent --show-error --location $HEALTHCHECK'
   static final String healthCheckScriptBat = 'curl --fail --silent --show-error --location %HEALTHCHECK%'
   static final String changeUrlWithSkipACPLabel = 'https://api.github.com/repos/jenkins-infra/pipeline-library/pull/123'
-  static final String prLabelsContainSkipACPScriptSh = 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | grep --ignore-case \'"skip-artifact-caching-proxy"\''
-  static final String prLabelsContainSkipACPScriptBat = 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | findstr /i \'"skip-artifact-caching-proxy"\''
+  static final String prLabelsContainSkipACPScriptSh = 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | grep --ignore-case "skip-artifact-caching-proxy"'
+  static final String prLabelsContainSkipACPScriptBat = 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | findstr /i "skip-artifact-caching-proxy"'
 
   @Override
   @Before

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -12,8 +12,10 @@ class BuildPluginStepTests extends BaseTest {
   static final String defaultArtifactCachingProxyProvider = 'azure'
   static final String anotherArtifactCachingProxyProvider = 'do'
   static final String invalidArtifactCachingProxyProvider = 'foo'
-  static final String healthCheckScriptLinux = 'curl --fail --silent --show-error --location $HEALTHCHECK'
-  static final String healthCheckScriptWindows = 'curl --fail --silent --show-error --location %HEALTHCHECK%'
+  static final String healthCheckScriptSh = 'curl --fail --silent --show-error --location $HEALTHCHECK'
+  static final String healthCheckScriptBat = 'curl --fail --silent --show-error --location %HEALTHCHECK%'
+  static final String prLabelsContainSkipACPScriptSh = 'gh pr view $CHANGE_URL --json labels | grep --ignore-case \'"skip-artifact-caching-proxy"\''
+  static final String prLabelsContainSkipACPScriptBat = 'gh pr view $CHANGE_URL --json labels | findstr /i \'"skip-artifact-caching-proxy"\''
 
   @Override
   @Before
@@ -23,6 +25,8 @@ class BuildPluginStepTests extends BaseTest {
     helper.registerAllowedMethod('fileExists', [String.class], { s -> return s.equals('pom.xml') })
     env.NODE_LABELS = 'docker'
     env.JOB_NAME = 'build/plugin/test'
+    // Testing by default on the primary branch
+    env.BRANCH_IS_PRIMARY = true
   }
 
   @Test
@@ -340,7 +344,7 @@ class BuildPluginStepTests extends BaseTest {
     script.call(['artifactCachingProxyEnabled': true])
     printCallStack()
     // then an healthcheck is performed on the provider
-    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptLinux) || assertMethodCallContainsPattern('bat', healthCheckScriptWindows))
+    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
     // then it notices the use of the default artifact caching provider
     assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
     // then it succeeds
@@ -436,7 +440,7 @@ class BuildPluginStepTests extends BaseTest {
     script.call(['artifactCachingProxyEnabled': true])
     printCallStack()
     // then an healthcheck is performed on the provider
-    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptLinux) || assertMethodCallContainsPattern('bat', healthCheckScriptWindows))
+    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
     // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
     assertFalse(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
     // then there is no call to configFile containing the specified artifact caching proxy provider id
@@ -449,18 +453,61 @@ class BuildPluginStepTests extends BaseTest {
   void test_buildPlugin_with_artifact_caching_proxy_enabled_and_unreachable_provider_specified() throws Exception {
     def script = loadScript(scriptName)
     // Mock an healthcheck fail
-    helper.addShMock(healthCheckScriptLinux, '', 1)
-    helper.addBatMock(healthCheckScriptWindows, '', 1)
+    helper.addShMock(healthCheckScriptSh, '', 1)
+    helper.addBatMock(healthCheckScriptBat, '', 1)
+
     // when running with artifactCachingProxyEnabled set to true and an unreachable provider is specified
     env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
     script.call(['artifactCachingProxyEnabled': true])
     printCallStack()
     // then an healthcheck is performed on the provider
-    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptLinux) || assertMethodCallContainsPattern('bat', healthCheckScriptWindows))
+    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
     // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
     assertTrue(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
     // then there is no call to configFile containing the specified artifact caching proxy provider id
     assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_with_skip_artifact_caching_proxy_label_applied_to_pull_request() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when running with artifactCachingProxyEnabled set to true, on a pull request with a "skip-artifact-caching-proxy" label
+    env.BRANCH_IS_PRIMARY = false
+    // Mock a "skip-artifact-caching-proxy" label
+    helper.addShMock(prLabelsContainSkipACPScriptSh, '', 0)
+    helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 0)
+    script.call(['artifactCachingProxyEnabled': true])
+    printCallStack()
+    // then a check is performed on the pull request labels
+    assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
+    // then it notices the skipping of artifact-caching-proxy
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
+    // then there is no call to configFile containing the default artifact caching proxy provider id
+    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_without_skip_artifact_caching_proxy_label_applied_to_pull_request() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when running with artifactCachingProxyEnabled set to true, on a pull request without a "skip-artifact-caching-proxy" label
+    env.BRANCH_IS_PRIMARY = false
+    // Mock the absence of "skip-artifact-caching-proxy" label
+    helper.addShMock(prLabelsContainSkipACPScriptSh, '', 1)
+    helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 1)
+    script.call(['artifactCachingProxyEnabled': true])
+    printCallStack()
+    // then a check is performed on the pull request labels
+    assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
+    // then it doesn't notice the skipping of artifact-caching-proxy
+    assertFalse(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
+    // then there is a call to configFile containing the default artifact caching proxy provider id
+    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
     // then it succeeds
     assertJobStatusSuccess()
   }

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -14,8 +14,9 @@ class BuildPluginStepTests extends BaseTest {
   static final String invalidArtifactCachingProxyProvider = 'foo'
   static final String healthCheckScriptSh = 'curl --fail --silent --show-error --location $HEALTHCHECK'
   static final String healthCheckScriptBat = 'curl --fail --silent --show-error --location %HEALTHCHECK%'
-  static final String prLabelsContainSkipACPScriptSh = 'gh pr view $CHANGE_URL --json labels | grep --ignore-case \'"skip-artifact-caching-proxy"\''
-  static final String prLabelsContainSkipACPScriptBat = 'gh pr view $CHANGE_URL --json labels | findstr /i \'"skip-artifact-caching-proxy"\''
+  static final String changeUrlWithSkipACPLabel = 'https://api.github.com/repos/jenkins-infra/pipeline-library/pull/123'
+  static final String prLabelsContainSkipACPScriptSh = 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | grep --ignore-case \'"skip-artifact-caching-proxy"\''
+  static final String prLabelsContainSkipACPScriptBat = 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | findstr /i \'"skip-artifact-caching-proxy"\''
 
   @Override
   @Before
@@ -476,6 +477,7 @@ class BuildPluginStepTests extends BaseTest {
 
     // when running with artifactCachingProxyEnabled set to true, on a pull request with a "skip-artifact-caching-proxy" label
     env.BRANCH_IS_PRIMARY = false
+    env.CHANGE_URL = changeUrlWithSkipACPLabel
     // Mock a "skip-artifact-caching-proxy" label
     helper.addShMock(prLabelsContainSkipACPScriptSh, '', 0)
     helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 0)
@@ -497,6 +499,7 @@ class BuildPluginStepTests extends BaseTest {
 
     // when running with artifactCachingProxyEnabled set to true, on a pull request without a "skip-artifact-caching-proxy" label
     env.BRANCH_IS_PRIMARY = false
+    env.CHANGE_URL = 'https://api.github.com/repos/jenkins-infra/pipeline-library/pull/123'
     // Mock the absence of "skip-artifact-caching-proxy" label
     helper.addShMock(prLabelsContainSkipACPScriptSh, '', 1)
     helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 1)

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -148,7 +148,7 @@ def call(Map params = [:]) {
                         usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
                       ]) {
                         // Creating the correct API URL to retrieve pull request labels from the $CHANGE_URL 
-                        final String pullrequestLabelsApiURL = (env.CHANGE_URL).replace('/pull/', '/issues/').replace('/github.com/', '/api.github.com/') + '/labels'
+                        final String pullrequestLabelsApiURL = (env.CHANGE_URL).replace('/pull/', '/issues/').replace('/github.com/', '/api.github.com/repos/') + '/labels'
                         if (isUnix()) {
                           prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         } else {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -152,6 +152,8 @@ def call(Map params = [:]) {
                         if (isUnix()) {
                           prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         } else {
+                          resultPrLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStdout: true)
+                          echo "resultPrLabelsContainSkipACP: $resultPrLabelsContainSkipACP"
                           prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStdout: true) != ''
                         }
                       }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -152,7 +152,7 @@ def call(Map params = [:]) {
                         if (isUnix()) {
                           prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         } else {
-                          prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStdout: true) != ''
                         }
                       }
                       if (prLabelsContainSkipACP) {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -154,7 +154,7 @@ def call(Map params = [:]) {
                         if (isUnix()) {
                           prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case "skip-artifact-caching-proxy"', returnStatus: true) == 0
                         } else {
-                          prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i "skip-artifact-caching-proxy"', returnStdout: true) != ''
+                          prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i "skip-artifact-caching-proxy"', returnStatus: true) == 0
                         }
                       }
                       if (prLabelsContainSkipACP) {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -171,7 +171,7 @@ def call(Map params = [:]) {
                       // Configure Maven settings if the requested provider is valid and available
                       if (validProxyProviders.contains(requestedProxyProvider) && availableProxyProviders.contains(requestedProxyProvider)) {
                         boolean healthCheckOK = false
-                        withEnv(["HEALTHCHECK=https://repo.${requestedProxyProvider}.jenkins.io/healthz"]) {
+                        withEnv(["HEALTHCHECK=https://repo.${requestedProxyProvider}.jenkins.io/health"]) {
                           if (isUnix()) {
                             healthCheckOK = sh(script: 'curl --fail --silent --show-error --location $HEALTHCHECK', returnStatus: true) == 0
                           } else {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -145,7 +145,7 @@ def call(Map params = [:]) {
                     final String skipACPLabel = 'skip-artifact-caching-proxy'
                     if (!env.BRANCH_IS_PRIMARY) {
                       withCredentials([
-                        usernamePassword(credentialsId: 'github-app-infra', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
+                        usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
                       ]) {
                         if (isUnix()) {
                           prLabelsContainSkipACP = sh(script: 'gh pr view $CHANGE_URL --json labels | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -147,7 +147,7 @@ def call(Map params = [:]) {
                       withCredentials([
                         usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
                       ]) {
-                        // Creating the correct API URL to retrieve pull request labels from the $CHANGE_URL 
+                        // Creating the correct API URL to retrieve pull request labels from the $CHANGE_URL
                         final String pullrequestLabelsApiURL = (env.CHANGE_URL).replace('/pull/', '/issues/').replace('/github.com/', '/api.github.com/repos/') + '/labels'
                         if (isUnix()) {
                           prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case "skip-artifact-caching-proxy"', returnStatus: true) == 0

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -152,9 +152,9 @@ def call(Map params = [:]) {
                         if (isUnix()) {
                           prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         } else {
-                          resultPrLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL, returnStdout: true)
+                          resultPrLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr "skip-artifact-caching-proxy"', returnStdout: true)
                           echo "resultPrLabelsContainSkipACP: $resultPrLabelsContainSkipACP"
-                          prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStdout: true) != ''
+                          prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i "skip-artifact-caching-proxy"', returnStdout: true) != ''
                         }
                       }
                       if (prLabelsContainSkipACP) {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -145,6 +145,8 @@ def call(Map params = [:]) {
                     final String skipACPLabel = 'skip-artifact-caching-proxy'
                     if (!env.BRANCH_IS_PRIMARY) {
                       withCredentials([
+                        // This credential only exists on ci.jenkins.io and allows to check for GitHub PR labels
+                        // Would not be needed if GitHub Branch Sources plugin was be able to provide labels in an environment variable
                         usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
                       ]) {
                         // Creating the correct API URL to retrieve pull request labels from the $CHANGE_URL

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -147,11 +147,12 @@ def call(Map params = [:]) {
                       withCredentials([
                         usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
                       ]) {
-                        final String issuesChangeURL = (env.CHANGE_URL).replace('/pull/', '/issues/')
+                        // Creating the correct API URL to retrieve pull request labels from the $CHANGE_URL 
+                        final String pullrequestLabelsApiURL = (env.CHANGE_URL).replace('/pull/', '/issues/').replace('/github.com/', '/api.github.com') + '/labels'
                         if (isUnix()) {
-                          prLabelsContainSkipACP = sh(script: 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + issuesChangeURL + '/labels | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = sh(script: 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         } else {
-                          prLabelsContainSkipACP = bat(script: 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + issuesChangeURL + '/labels | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = bat(script: 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         }
                       }
                       if (prLabelsContainSkipACP) {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -147,11 +147,11 @@ def call(Map params = [:]) {
                       withCredentials([
                         usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
                       ]) {
-                        curlCommand = 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + (env.CHANGE_URL).replace('/pull/', '/issues/') + '/labels'
+                        final String issuesChangeURL = (env.CHANGE_URL).replace('/pull/', '/issues/')
                         if (isUnix()) {
-                          prLabelsContainSkipACP = sh(script: curlCommand + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = sh(script: 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + issuesChangeURL + '/labels | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         } else {
-                          prLabelsContainSkipACP = bat(script: curlCommand + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = bat(script: 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + issuesChangeURL + '/labels | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         }
                       }
                       if (prLabelsContainSkipACP) {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -144,12 +144,14 @@ def call(Map params = [:]) {
                     boolean prLabelsContainSkipACP = false
                     final String skipACPLabel = 'skip-artifact-caching-proxy'
                     if (!env.BRANCH_IS_PRIMARY) {
-                      withCredentials([usernamePassword(credentialsId: 'github-app-infra', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')]) {
-                          if (isUnix()) {
-                            prLabelsContainSkipACP = sh(script: 'gh pr view $CHANGE_URL --json labels | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
-                          } else {
-                            prLabelsContainSkipACP = bat(script: 'gh pr view $CHANGE_URL --json labels | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
-                          }
+                      withCredentials([
+                        usernamePassword(credentialsId: 'github-app-infra', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
+                      ]) {
+                        if (isUnix()) {
+                          prLabelsContainSkipACP = sh(script: 'gh pr view $CHANGE_URL --json labels | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                        } else {
+                          prLabelsContainSkipACP = bat(script: 'gh pr view $CHANGE_URL --json labels | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                        }
                       }
                       if (prLabelsContainSkipACP) {
                         echo "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -152,7 +152,7 @@ def call(Map params = [:]) {
                         if (isUnix()) {
                           prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         } else {
-                          resultPrLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStdout: true)
+                          resultPrLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL, returnStdout: true)
                           echo "resultPrLabelsContainSkipACP: $resultPrLabelsContainSkipACP"
                           prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStdout: true) != ''
                         }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -150,10 +150,8 @@ def call(Map params = [:]) {
                         // Creating the correct API URL to retrieve pull request labels from the $CHANGE_URL 
                         final String pullrequestLabelsApiURL = (env.CHANGE_URL).replace('/pull/', '/issues/').replace('/github.com/', '/api.github.com/repos/') + '/labels'
                         if (isUnix()) {
-                          prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case "skip-artifact-caching-proxy"', returnStatus: true) == 0
                         } else {
-                          resultPrLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr "skip-artifact-caching-proxy"', returnStdout: true)
-                          echo "resultPrLabelsContainSkipACP: $resultPrLabelsContainSkipACP"
                           prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i "skip-artifact-caching-proxy"', returnStdout: true) != ''
                         }
                       }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -148,11 +148,11 @@ def call(Map params = [:]) {
                         usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
                       ]) {
                         // Creating the correct API URL to retrieve pull request labels from the $CHANGE_URL 
-                        final String pullrequestLabelsApiURL = (env.CHANGE_URL).replace('/pull/', '/issues/').replace('/github.com/', '/api.github.com') + '/labels'
+                        final String pullrequestLabelsApiURL = (env.CHANGE_URL).replace('/pull/', '/issues/').replace('/github.com/', '/api.github.com/') + '/labels'
                         if (isUnix()) {
-                          prLabelsContainSkipACP = sh(script: 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         } else {
-                          prLabelsContainSkipACP = bat(script: 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         }
                       }
                       if (prLabelsContainSkipACP) {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -147,10 +147,11 @@ def call(Map params = [:]) {
                       withCredentials([
                         usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
                       ]) {
+                        curlCommand = 'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + (env.CHANGE_URL).replace('/pull/', '/issues/') + '/labels'
                         if (isUnix()) {
-                          prLabelsContainSkipACP = sh(script: 'gh pr view $CHANGE_URL --json labels | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = sh(script: curlCommand + ' | grep --ignore-case \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         } else {
-                          prLabelsContainSkipACP = bat(script: 'gh pr view $CHANGE_URL --json labels | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
+                          prLabelsContainSkipACP = bat(script: curlCommand + ' | findstr /i \'"skip-artifact-caching-proxy"\'', returnStatus: true) == 0
                         }
                       }
                       if (prLabelsContainSkipACP) {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -145,8 +145,8 @@ def call(Map params = [:]) {
                     final String skipACPLabel = 'skip-artifact-caching-proxy'
                     if (!env.BRANCH_IS_PRIMARY) {
                       withCredentials([
-                        // This credential only exists on ci.jenkins.io and allows to check for GitHub PR labels
-                        // Would not be needed if GitHub Branch Sources plugin was be able to provide labels in an environment variable
+                        // This credential only exists on ci.jenkins.io and allows to check for GitHub PR labels on @jenkinsci GitHub organisation.
+                        // Would not be needed if there was a way to retrieve pull request labels natively.
                         usernamePassword(credentialsId: 'app-ci.jenkins.io', usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
                       ]) {
                         // Creating the correct API URL to retrieve pull request labels from the $CHANGE_URL


### PR DESCRIPTION
This PR add the possibility for contributors to disable the Artifact Caching Proxy temporary on their pull requests by applying a `skip-artifact-caching-proxy` label to them.

It comes in complement of the possibility for ci.jenkins.io admins to disable some or all ACP providers via the `ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS` global settings. (cf https://github.com/jenkins-infra/helpdesk/issues/3302#issuecomment-1357319280)

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752