### PR TITLE
cleanup: remove `infra.retrieveMavenSettingsFile`

### DIFF
--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -172,18 +172,6 @@ class InfraStepTests extends BaseTest {
   }
 
   @Test
-  void testRetrieveMavenSettingsFileWithEnvVariable() throws Exception {
-    def script = loadScript(scriptName)
-    env.MAVEN_SETTINGS_FILE_ID = 'foo.id'
-    def result = script.retrieveMavenSettingsFile('foo.xml')
-    assertTrue(result)
-    printCallStack()
-    assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('sh', 'settings.xml foo.xml'))
-    assertTrue(assertMethodCallContainsPattern('configFile', 'foo.id'))
-  }
-
-  @Test
   void testWithArtifactCachingProxy() throws Exception {
     def script = loadScript(scriptName)
     def isOK = false

--- a/test/groovy/mock/Infra.groovy
+++ b/test/groovy/mock/Infra.groovy
@@ -11,10 +11,6 @@ class Infra implements Serializable {
 
   public void checkoutSCM(String repo = null) { }
 
-  public String retrieveMavenSettingsFile(String location) {
-    return location
-  }
-
   public Object withArtifactCachingProxy(Closure body) {
     if (buildError) {
       throw new RuntimeException('build error')

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -79,33 +79,6 @@ Object checkoutSCM(String repo = null) {
 }
 
 /**
- * Retrieves Settings file to be used with Maven.
- * If {@code MAVEN_SETTINGS_FILE_ID} variable is defined, the file will be retrieved from the specified
- * configuration ID provided by Config File Provider Plugin.
- * Otherwise it will fallback to some unspecified file for Jenkins infrastructure (currently empty).
- * @param settingsXml Absolute path to the destination settings file
- * @param jdk Version of JDK to be used (no longer used)
- * @return {@code true} if the file has been defined
- */
-boolean retrieveMavenSettingsFile(String settingsXml) {
-  if (env.MAVEN_SETTINGS_FILE_ID) {
-    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE_ID, variable: 'mvnSettingsFile')]) {
-      if (isUnix()) {
-        sh "cp ${mvnSettingsFile} ${settingsXml}"
-      } else {
-        bat "copy ${mvnSettingsFile} ${settingsXml}"
-      }
-    }
-    return true
-  } else if (new InfraConfig(env).isRunningOnJenkinsInfra()) {
-    echo 'NOTE: infra.retrieveMavenSettingsFile currently writes an empty settings file.'
-    writeFile file: settingsXml, text: libraryResource('settings.xml')
-    return true
-  }
-  return false
-}
-
-/**
  * Retrieve the current credentialsId used by the build
  */
 @NonCPS
@@ -198,7 +171,6 @@ Object withArtifactCachingProxy(Closure body) {
  * @param jdk JDK to be used
  * @param options Options to be passed to the Maven command
  * @param extraEnv Extra environment variables to be passed when invoking the command
- * @see #retrieveMavenSettingsFile(String)
  */
 Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = true) {
   List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors', '--no-transfer-progress']
@@ -217,7 +189,6 @@ Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = 
  * @param Major version of JDK to be used (integer)
  * @param options Options to be passed to the Maven command
  * @param extraEnv Extra environment variables to be passed when invoking the command
- * @see #retrieveMavenSettingsFile(String)
  */
 Object runMaven(List<String> options, Integer jdk, List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = true) {
   runMaven(options, jdk.toString(), extraEnv, settingsFile, addToolEnv)

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -31,19 +31,6 @@
     Either this must be used as part of a Multibranch Pipeline or a repository argument must be provided.
 </p>
 
-<strong>infra.retrieveMavenSettingsFile(String settingsXml)</strong>
-
-<p>
-    Retrieve a custom Maven settings file to the specified path if needed
-    (depending on the environment where the Pipeline runs),
-    returning true if the file has been retrieved.
-    <strong>Note:</strong> currently does not return an interesting file.
-</p>
-
-<p>
-    See the method Javadoc in the repository for more information.
-</p>
-
 <strong>infra.withArtifactCachingProxy(Closure body)</strong>
 
 <p>


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/pipeline-library/pull/583, https://github.com/jenkinsci/bom/pull/1741, https://github.com/jenkins-infra/backend-extension-indexer/pull/47 & https://github.com/jenkinsci/ci.jenkins.io-runner/pull/463

As this function isn't used anywhere else, this PR removes it from the shared pipeline library.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752