### PR TITLE
feat(`infra.runMaven`): use Artifact Caching Proxy

### DIFF
--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -401,19 +401,4 @@ class InfraStepTests extends BaseTest {
     // then it succeeds
     assertJobStatusSuccess()
   }
-
-  @Test
-  void testRunMaven() throws Exception {
-    def script = loadScript(scriptName)
-    script.runMaven(['clean'])
-    printCallStack()
-    // then it notices the use of the default artifact caching provider
-    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
-    // then configFile contains the default artifact caching proxy provider id
-    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
-    // then configFileProvider is correctly set
-    assertTrue(assertMethodCallContainsPattern('configFileProvider', '[OK]'))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
 }

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -29,155 +29,383 @@ class InfraStepTests extends BaseTest {
     helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 1)
   }
 
-  @Test
-  void testIsRunningOnJenkinsInfra() throws Exception {
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://ci.jenkins.io/'
-    assertTrue(script.isRunningOnJenkinsInfra())
-  }
+  // @Test
+  // void testIsRunningOnJenkinsInfra() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
+  //   assertTrue(script.isRunningOnJenkinsInfra())
+  // }
+
+  // @Test
+  // void testIsTrusted() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   env.JENKINS_URL = 'https://trusted.ci.jenkins.io:1443/'
+  //   binding.setVariable('env', env)
+  //   assertTrue(script.isTrusted())
+  // }
+
+  // @Test
+  // void testWithDockerCredentials() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
+  //   def isOK = false
+  //   script.withDockerCredentials() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithDockerCredentialsOutsideInfra() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   env.JENKINS_URL = 'https://foo/'
+  //   def isOK = false
+  //   script.withDockerCredentials() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertFalse(isOK)
+  //   assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environment'))
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithDockerPushCredentials() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
+  //   def isOK = false
+  //   script.withDockerPushCredentials() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithDockerPushCredentialsOutsideInfra() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   env.JENKINS_URL = 'https://foo/'
+  //   def isOK = false
+  //   script.withDockerPushCredentials() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertFalse(isOK)
+  //   assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environments'))
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithDockerPullCredentials() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
+  //   def isOK = false
+  //   script.withDockerPullCredentials() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   assertJobStatusSuccess()
+  //   assertTrue(assertMethodCallContainsPattern('sh', 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'))
+  // }
+
+  // @Test
+  // void testWithDockerPullCredentialsWindows() throws Exception {
+  //   helper.registerAllowedMethod('isUnix', [], { false })
+  //   def script = loadScript(scriptName)
+  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
+  //   def isOK = false
+  //   script.withDockerPullCredentials() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   assertJobStatusSuccess()
+  //   assertTrue(assertMethodCallContainsPattern('powershell', 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW}"'))
+  // }
+
+  // @Test
+  // void testWithDockerPullCredentialsOutsideInfra() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   env.JENKINS_URL = 'https://foo/'
+  //   def isOK = false
+  //   script.withDockerPullCredentials() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertFalse(isOK)
+  //   assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environments'))
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testCheckoutWithEnvVariable() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   env.BRANCH_NAME = 'BRANCH'
+  //   script.checkoutSCM()
+  //   printCallStack()
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testCheckoutWithArgument() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   script.checkoutSCM('foo.git')
+  //   printCallStack()
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testCheckoutWithoutArgument() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   try {
+  //     script.checkoutSCM()
+  //   } catch(e) {
+  //     //NOOP
+  //   }
+  //   printCallStack()
+  //   assertTrue(assertMethodCallContainsPattern('error', 'buildPlugin must be used as part of a Multibranch Pipeline *or* a `repo` argument must be provided'))
+  //   assertJobStatusFailure()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxy() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then it notices the use of the default artifact caching provider
+  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
+  //   // then configFile contains the default artifact caching proxy provider id
+  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
+  //   // then configFileProvider is correctly set
+  //   assertTrue(assertMethodCallContainsPattern('configFileProvider', '[OK]'))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxyNoProvidersEnvVar() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   // when running with an available provider different from the default requested one
+  //   // without ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
+  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+  //   env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = null
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then it notices the use of the requested artifact caching provider
+  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
+  //   // then there is a call to configFile containing the requested artifact caching proxy provider id
+  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxyEmptyProvidersEnvVar() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   // when running with an available provider different from the default requested one
+  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+  //   env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = ''
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then it notices the use of the requested artifact caching provider
+  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
+  //   // then there is a call to configFile containing the requested artifact caching proxy provider id
+  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxyInvalidProvidersEnvVar() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   // when running with an available provider different from the default requested one
+  //   // with an invalid provider configured with ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
+  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+  //   env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = invalidArtifactCachingProxyProvider
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
+  //   assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
+  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
+  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxyEmptyRequestedProvider() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   // when running with an empty artifact caching proxy provider requested
+  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = ''
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then an healthcheck is performed on the provider
+  //   assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
+  //   // then it notices the use of the default artifact caching provider
+  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxyInvalidRequestedProvider() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   // when running with an invalid artifact caching proxy provider requested
+  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = invalidArtifactCachingProxyProvider
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
+  //   assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${invalidArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
+  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
+  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${invalidArtifactCachingProxyProvider}"))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+  // @Test
+  // void testWithArtifactCachingProxyUnavailableRequestedProvider() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   // when running with an unavailable requested provider
+  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+  //   env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = artifactCachingProxyProvidersWithoutAnotherProvider
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
+  //   assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
+  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
+  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxyWithoutSkipArtifactCachingProxyOnPullRequest() throws Exception {
+  //   def script = loadScript(scriptName)
+
+  //   // when running on a pull request without a "skip-artifact-caching-proxy" label
+  //   env.BRANCH_IS_PRIMARY = false
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then a check is performed on the pull request labels
+  //   assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
+  //   // then it doesn't notice the skipping of artifact-caching-proxy
+  //   assertFalse(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
+  //   // then there is a call to configFile containing the default artifact caching proxy provider id
+  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxySkipArtifactCachingProxyOnPullRequest() throws Exception {
+  //   def script = loadScript(scriptName)
+
+  //   // when running on a pull request with a "skip-artifact-caching-proxy" label
+  //   env.BRANCH_IS_PRIMARY = false
+  //   // Mock a "skip-artifact-caching-proxy" label
+  //   helper.addShMock(prLabelsContainSkipACPScriptSh, '', 0)
+  //   helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 0)
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then a check is performed on the pull request labels
+  //   assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
+  //   // then it notices the skipping of artifact-caching-proxy
+  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
+  //   // then there is no call to configFile containing the default artifact caching proxy provider id
+  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxyReachableRequestedProvider() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   // when running with a reachable requested provider
+  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then an healthcheck is performed on the provider
+  //   assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
+  //   // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
+  //   assertFalse(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
+  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
+  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
+
+  // @Test
+  // void testWithArtifactCachingProxyUnreachableRequestedProvider() throws Exception {
+  //   def script = loadScript(scriptName)
+  //   // Mock an healthcheck fail
+  //   helper.addShMock(healthCheckScriptSh, '', 1)
+  //   helper.addBatMock(healthCheckScriptBat, '', 1)
+
+  //   // when running with an unreachable requested provider
+  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+  //   def isOK = false
+  //   script.withArtifactCachingProxy() {
+  //     isOK = true
+  //   }
+  //   printCallStack()
+  //   assertTrue(isOK)
+  //   // then an healthcheck is performed on the provider
+  //   assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
+  //   // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
+  //   assertTrue(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
+  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
+  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+  //   // then it succeeds
+  //   assertJobStatusSuccess()
+  // }
 
   @Test
-  void testIsTrusted() throws Exception {
+  void testRunMaven() throws Exception {
     def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://trusted.ci.jenkins.io:1443/'
-    binding.setVariable('env', env)
-    assertTrue(script.isTrusted())
-  }
-
-  @Test
-  void testWithDockerCredentials() throws Exception {
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://ci.jenkins.io/'
-    def isOK = false
-    script.withDockerCredentials() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithDockerCredentialsOutsideInfra() throws Exception {
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://foo/'
-    def isOK = false
-    script.withDockerCredentials() {
-      isOK = true
-    }
-    printCallStack()
-    assertFalse(isOK)
-    assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environment'))
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithDockerPushCredentials() throws Exception {
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://ci.jenkins.io/'
-    def isOK = false
-    script.withDockerPushCredentials() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithDockerPushCredentialsOutsideInfra() throws Exception {
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://foo/'
-    def isOK = false
-    script.withDockerPushCredentials() {
-      isOK = true
-    }
-    printCallStack()
-    assertFalse(isOK)
-    assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environments'))
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithDockerPullCredentials() throws Exception {
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://ci.jenkins.io/'
-    def isOK = false
-    script.withDockerPullCredentials() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('sh', 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'))
-  }
-
-  @Test
-  void testWithDockerPullCredentialsWindows() throws Exception {
-    helper.registerAllowedMethod('isUnix', [], { false })
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://ci.jenkins.io/'
-    def isOK = false
-    script.withDockerPullCredentials() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('powershell', 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW}"'))
-  }
-
-  @Test
-  void testWithDockerPullCredentialsOutsideInfra() throws Exception {
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://foo/'
-    def isOK = false
-    script.withDockerPullCredentials() {
-      isOK = true
-    }
-    printCallStack()
-    assertFalse(isOK)
-    assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environments'))
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testCheckoutWithEnvVariable() throws Exception {
-    def script = loadScript(scriptName)
-    env.BRANCH_NAME = 'BRANCH'
-    script.checkoutSCM()
-    printCallStack()
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testCheckoutWithArgument() throws Exception {
-    def script = loadScript(scriptName)
-    script.checkoutSCM('foo.git')
-    printCallStack()
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testCheckoutWithoutArgument() throws Exception {
-    def script = loadScript(scriptName)
-    try {
-      script.checkoutSCM()
-    } catch(e) {
-      //NOOP
-    }
-    printCallStack()
-    assertTrue(assertMethodCallContainsPattern('error', 'buildPlugin must be used as part of a Multibranch Pipeline *or* a `repo` argument must be provided'))
-    assertJobStatusFailure()
-  }
-
-  @Test
-  void testWithArtifactCachingProxy() throws Exception {
-    def script = loadScript(scriptName)
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
+    script.runMaven(['clean'])
     printCallStack()
     assertTrue(isOK)
     // then it notices the use of the default artifact caching provider
@@ -186,218 +414,6 @@ class InfraStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
     // then configFileProvider is correctly set
     assertTrue(assertMethodCallContainsPattern('configFileProvider', '[OK]'))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithArtifactCachingProxyNoProvidersEnvVar() throws Exception {
-    def script = loadScript(scriptName)
-    // when running with an available provider different from the default requested one
-    // without ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
-    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = null
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then it notices the use of the requested artifact caching provider
-    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
-    // then there is a call to configFile containing the requested artifact caching proxy provider id
-    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithArtifactCachingProxyEmptyProvidersEnvVar() throws Exception {
-    def script = loadScript(scriptName)
-    // when running with an available provider different from the default requested one
-    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = ''
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then it notices the use of the requested artifact caching provider
-    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
-    // then there is a call to configFile containing the requested artifact caching proxy provider id
-    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithArtifactCachingProxyInvalidProvidersEnvVar() throws Exception {
-    def script = loadScript(scriptName)
-    // when running with an available provider different from the default requested one
-    // with an invalid provider configured with ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
-    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = invalidArtifactCachingProxyProvider
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
-    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
-    // then there is no call to configFile containing the requested artifact caching proxy provider id
-    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithArtifactCachingProxyEmptyRequestedProvider() throws Exception {
-    def script = loadScript(scriptName)
-    // when running with an empty artifact caching proxy provider requested
-    env.ARTIFACT_CACHING_PROXY_PROVIDER = ''
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then an healthcheck is performed on the provider
-    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
-    // then it notices the use of the default artifact caching provider
-    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithArtifactCachingProxyInvalidRequestedProvider() throws Exception {
-    def script = loadScript(scriptName)
-    // when running with an invalid artifact caching proxy provider requested
-    env.ARTIFACT_CACHING_PROXY_PROVIDER = invalidArtifactCachingProxyProvider
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
-    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${invalidArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
-    // then there is no call to configFile containing the requested artifact caching proxy provider id
-    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${invalidArtifactCachingProxyProvider}"))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-  @Test
-  void testWithArtifactCachingProxyUnavailableRequestedProvider() throws Exception {
-    def script = loadScript(scriptName)
-    // when running with an unavailable requested provider
-    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = artifactCachingProxyProvidersWithoutAnotherProvider
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
-    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
-    // then there is no call to configFile containing the requested artifact caching proxy provider id
-    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithArtifactCachingProxyWithoutSkipArtifactCachingProxyOnPullRequest() throws Exception {
-    def script = loadScript(scriptName)
-
-    // when running on a pull request without a "skip-artifact-caching-proxy" label
-    env.BRANCH_IS_PRIMARY = false
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then a check is performed on the pull request labels
-    assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
-    // then it doesn't notice the skipping of artifact-caching-proxy
-    assertFalse(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
-    // then there is a call to configFile containing the default artifact caching proxy provider id
-    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithArtifactCachingProxySkipArtifactCachingProxyOnPullRequest() throws Exception {
-    def script = loadScript(scriptName)
-
-    // when running on a pull request with a "skip-artifact-caching-proxy" label
-    env.BRANCH_IS_PRIMARY = false
-    // Mock a "skip-artifact-caching-proxy" label
-    helper.addShMock(prLabelsContainSkipACPScriptSh, '', 0)
-    helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 0)
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then a check is performed on the pull request labels
-    assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
-    // then it notices the skipping of artifact-caching-proxy
-    assertTrue(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
-    // then there is no call to configFile containing the default artifact caching proxy provider id
-    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithArtifactCachingProxyReachableRequestedProvider() throws Exception {
-    def script = loadScript(scriptName)
-    // when running with a reachable requested provider
-    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then an healthcheck is performed on the provider
-    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
-    // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
-    assertFalse(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
-    // then there is no call to configFile containing the requested artifact caching proxy provider id
-    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithArtifactCachingProxyUnreachableRequestedProvider() throws Exception {
-    def script = loadScript(scriptName)
-    // Mock an healthcheck fail
-    helper.addShMock(healthCheckScriptSh, '', 1)
-    helper.addBatMock(healthCheckScriptBat, '', 1)
-
-    // when running with an unreachable requested provider
-    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-    def isOK = false
-    script.withArtifactCachingProxy() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    // then an healthcheck is performed on the provider
-    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
-    // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
-    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
-    // then there is no call to configFile containing the requested artifact caching proxy provider id
-    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
     // then it succeeds
     assertJobStatusSuccess()
   }

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -29,385 +29,384 @@ class InfraStepTests extends BaseTest {
     helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 1)
   }
 
-  // @Test
-  // void testIsRunningOnJenkinsInfra() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
-  //   assertTrue(script.isRunningOnJenkinsInfra())
-  // }
+  @Test
+  void testIsRunningOnJenkinsInfra() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://ci.jenkins.io/'
+    assertTrue(script.isRunningOnJenkinsInfra())
+  }
 
-  // @Test
-  // void testIsTrusted() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   env.JENKINS_URL = 'https://trusted.ci.jenkins.io:1443/'
-  //   binding.setVariable('env', env)
-  //   assertTrue(script.isTrusted())
-  // }
+  @Test
+  void testIsTrusted() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://trusted.ci.jenkins.io:1443/'
+    binding.setVariable('env', env)
+    assertTrue(script.isTrusted())
+  }
 
-  // @Test
-  // void testWithDockerCredentials() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
-  //   def isOK = false
-  //   script.withDockerCredentials() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithDockerCredentials() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://ci.jenkins.io/'
+    def isOK = false
+    script.withDockerCredentials() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithDockerCredentialsOutsideInfra() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   env.JENKINS_URL = 'https://foo/'
-  //   def isOK = false
-  //   script.withDockerCredentials() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertFalse(isOK)
-  //   assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environment'))
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithDockerCredentialsOutsideInfra() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://foo/'
+    def isOK = false
+    script.withDockerCredentials() {
+      isOK = true
+    }
+    printCallStack()
+    assertFalse(isOK)
+    assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environment'))
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithDockerPushCredentials() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
-  //   def isOK = false
-  //   script.withDockerPushCredentials() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithDockerPushCredentials() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://ci.jenkins.io/'
+    def isOK = false
+    script.withDockerPushCredentials() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithDockerPushCredentialsOutsideInfra() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   env.JENKINS_URL = 'https://foo/'
-  //   def isOK = false
-  //   script.withDockerPushCredentials() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertFalse(isOK)
-  //   assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environments'))
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithDockerPushCredentialsOutsideInfra() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://foo/'
+    def isOK = false
+    script.withDockerPushCredentials() {
+      isOK = true
+    }
+    printCallStack()
+    assertFalse(isOK)
+    assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environments'))
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithDockerPullCredentials() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
-  //   def isOK = false
-  //   script.withDockerPullCredentials() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   assertJobStatusSuccess()
-  //   assertTrue(assertMethodCallContainsPattern('sh', 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'))
-  // }
+  @Test
+  void testWithDockerPullCredentials() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://ci.jenkins.io/'
+    def isOK = false
+    script.withDockerPullCredentials() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertJobStatusSuccess()
+    assertTrue(assertMethodCallContainsPattern('sh', 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'))
+  }
 
-  // @Test
-  // void testWithDockerPullCredentialsWindows() throws Exception {
-  //   helper.registerAllowedMethod('isUnix', [], { false })
-  //   def script = loadScript(scriptName)
-  //   env.JENKINS_URL = 'https://ci.jenkins.io/'
-  //   def isOK = false
-  //   script.withDockerPullCredentials() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   assertJobStatusSuccess()
-  //   assertTrue(assertMethodCallContainsPattern('powershell', 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW}"'))
-  // }
+  @Test
+  void testWithDockerPullCredentialsWindows() throws Exception {
+    helper.registerAllowedMethod('isUnix', [], { false })
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://ci.jenkins.io/'
+    def isOK = false
+    script.withDockerPullCredentials() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertJobStatusSuccess()
+    assertTrue(assertMethodCallContainsPattern('powershell', 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW}"'))
+  }
 
-  // @Test
-  // void testWithDockerPullCredentialsOutsideInfra() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   env.JENKINS_URL = 'https://foo/'
-  //   def isOK = false
-  //   script.withDockerPullCredentials() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertFalse(isOK)
-  //   assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environments'))
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithDockerPullCredentialsOutsideInfra() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://foo/'
+    def isOK = false
+    script.withDockerPullCredentials() {
+      isOK = true
+    }
+    printCallStack()
+    assertFalse(isOK)
+    assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environments'))
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testCheckoutWithEnvVariable() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   env.BRANCH_NAME = 'BRANCH'
-  //   script.checkoutSCM()
-  //   printCallStack()
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testCheckoutWithEnvVariable() throws Exception {
+    def script = loadScript(scriptName)
+    env.BRANCH_NAME = 'BRANCH'
+    script.checkoutSCM()
+    printCallStack()
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testCheckoutWithArgument() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   script.checkoutSCM('foo.git')
-  //   printCallStack()
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testCheckoutWithArgument() throws Exception {
+    def script = loadScript(scriptName)
+    script.checkoutSCM('foo.git')
+    printCallStack()
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testCheckoutWithoutArgument() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   try {
-  //     script.checkoutSCM()
-  //   } catch(e) {
-  //     //NOOP
-  //   }
-  //   printCallStack()
-  //   assertTrue(assertMethodCallContainsPattern('error', 'buildPlugin must be used as part of a Multibranch Pipeline *or* a `repo` argument must be provided'))
-  //   assertJobStatusFailure()
-  // }
+  @Test
+  void testCheckoutWithoutArgument() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.checkoutSCM()
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'buildPlugin must be used as part of a Multibranch Pipeline *or* a `repo` argument must be provided'))
+    assertJobStatusFailure()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxy() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then it notices the use of the default artifact caching provider
-  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
-  //   // then configFile contains the default artifact caching proxy provider id
-  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
-  //   // then configFileProvider is correctly set
-  //   assertTrue(assertMethodCallContainsPattern('configFileProvider', '[OK]'))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithArtifactCachingProxy() throws Exception {
+    def script = loadScript(scriptName)
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then it notices the use of the default artifact caching provider
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
+    // then configFile contains the default artifact caching proxy provider id
+    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
+    // then configFileProvider is correctly set
+    assertTrue(assertMethodCallContainsPattern('configFileProvider', '[OK]'))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxyNoProvidersEnvVar() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   // when running with an available provider different from the default requested one
-  //   // without ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
-  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-  //   env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = null
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then it notices the use of the requested artifact caching provider
-  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
-  //   // then there is a call to configFile containing the requested artifact caching proxy provider id
-  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithArtifactCachingProxyNoProvidersEnvVar() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with an available provider different from the default requested one
+    // without ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = null
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then it notices the use of the requested artifact caching provider
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
+    // then there is a call to configFile containing the requested artifact caching proxy provider id
+    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxyEmptyProvidersEnvVar() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   // when running with an available provider different from the default requested one
-  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-  //   env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = ''
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then it notices the use of the requested artifact caching provider
-  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
-  //   // then there is a call to configFile containing the requested artifact caching proxy provider id
-  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithArtifactCachingProxyEmptyProvidersEnvVar() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with an available provider different from the default requested one
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = ''
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then it notices the use of the requested artifact caching provider
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider."))
+    // then there is a call to configFile containing the requested artifact caching proxy provider id
+    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxyInvalidProvidersEnvVar() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   // when running with an available provider different from the default requested one
-  //   // with an invalid provider configured with ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
-  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-  //   env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = invalidArtifactCachingProxyProvider
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
-  //   assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
-  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
-  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithArtifactCachingProxyInvalidProvidersEnvVar() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with an available provider different from the default requested one
+    // with an invalid provider configured with ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS env var declared
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = invalidArtifactCachingProxyProvider
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
+    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
+    // then there is no call to configFile containing the requested artifact caching proxy provider id
+    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxyEmptyRequestedProvider() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   // when running with an empty artifact caching proxy provider requested
-  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = ''
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then an healthcheck is performed on the provider
-  //   assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
-  //   // then it notices the use of the default artifact caching provider
-  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithArtifactCachingProxyEmptyRequestedProvider() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with an empty artifact caching proxy provider requested
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = ''
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then an healthcheck is performed on the provider
+    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
+    // then it notices the use of the default artifact caching provider
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxyInvalidRequestedProvider() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   // when running with an invalid artifact caching proxy provider requested
-  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = invalidArtifactCachingProxyProvider
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
-  //   assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${invalidArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
-  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
-  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${invalidArtifactCachingProxyProvider}"))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
-  // @Test
-  // void testWithArtifactCachingProxyUnavailableRequestedProvider() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   // when running with an unavailable requested provider
-  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-  //   env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = artifactCachingProxyProvidersWithoutAnotherProvider
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
-  //   assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
-  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
-  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithArtifactCachingProxyInvalidRequestedProvider() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with an invalid artifact caching proxy provider requested
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = invalidArtifactCachingProxyProvider
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
+    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${invalidArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
+    // then there is no call to configFile containing the requested artifact caching proxy provider id
+    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${invalidArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
+  @Test
+  void testWithArtifactCachingProxyUnavailableRequestedProvider() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with an unavailable requested provider
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+    env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS = artifactCachingProxyProvidersWithoutAnotherProvider
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then it notices invalid or unavailable artifact caching provider has been requested and that it will fallback to repo.jenkins-ci.org
+    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: invalid or unavailable artifact caching proxy provider '${anotherArtifactCachingProxyProvider}' requested by the agent, will use repo.jenkins-ci.org"))
+    // then there is no call to configFile containing the requested artifact caching proxy provider id
+    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxyWithoutSkipArtifactCachingProxyOnPullRequest() throws Exception {
-  //   def script = loadScript(scriptName)
+  @Test
+  void testWithArtifactCachingProxyWithoutSkipArtifactCachingProxyOnPullRequest() throws Exception {
+    def script = loadScript(scriptName)
 
-  //   // when running on a pull request without a "skip-artifact-caching-proxy" label
-  //   env.BRANCH_IS_PRIMARY = false
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then a check is performed on the pull request labels
-  //   assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
-  //   // then it doesn't notice the skipping of artifact-caching-proxy
-  //   assertFalse(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
-  //   // then there is a call to configFile containing the default artifact caching proxy provider id
-  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+    // when running on a pull request without a "skip-artifact-caching-proxy" label
+    env.BRANCH_IS_PRIMARY = false
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then a check is performed on the pull request labels
+    assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
+    // then it doesn't notice the skipping of artifact-caching-proxy
+    assertFalse(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
+    // then there is a call to configFile containing the default artifact caching proxy provider id
+    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxySkipArtifactCachingProxyOnPullRequest() throws Exception {
-  //   def script = loadScript(scriptName)
+  @Test
+  void testWithArtifactCachingProxySkipArtifactCachingProxyOnPullRequest() throws Exception {
+    def script = loadScript(scriptName)
 
-  //   // when running on a pull request with a "skip-artifact-caching-proxy" label
-  //   env.BRANCH_IS_PRIMARY = false
-  //   // Mock a "skip-artifact-caching-proxy" label
-  //   helper.addShMock(prLabelsContainSkipACPScriptSh, '', 0)
-  //   helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 0)
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then a check is performed on the pull request labels
-  //   assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
-  //   // then it notices the skipping of artifact-caching-proxy
-  //   assertTrue(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
-  //   // then there is no call to configFile containing the default artifact caching proxy provider id
-  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+    // when running on a pull request with a "skip-artifact-caching-proxy" label
+    env.BRANCH_IS_PRIMARY = false
+    // Mock a "skip-artifact-caching-proxy" label
+    helper.addShMock(prLabelsContainSkipACPScriptSh, '', 0)
+    helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 0)
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then a check is performed on the pull request labels
+    assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
+    // then it notices the skipping of artifact-caching-proxy
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
+    // then there is no call to configFile containing the default artifact caching proxy provider id
+    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxyReachableRequestedProvider() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   // when running with a reachable requested provider
-  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then an healthcheck is performed on the provider
-  //   assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
-  //   // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
-  //   assertFalse(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
-  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
-  //   assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+  @Test
+  void testWithArtifactCachingProxyReachableRequestedProvider() throws Exception {
+    def script = loadScript(scriptName)
+    // when running with a reachable requested provider
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then an healthcheck is performed on the provider
+    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
+    // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
+    assertFalse(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
+    // then there is no call to configFile containing the requested artifact caching proxy provider id
+    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
-  // @Test
-  // void testWithArtifactCachingProxyUnreachableRequestedProvider() throws Exception {
-  //   def script = loadScript(scriptName)
-  //   // Mock an healthcheck fail
-  //   helper.addShMock(healthCheckScriptSh, '', 1)
-  //   helper.addBatMock(healthCheckScriptBat, '', 1)
+  @Test
+  void testWithArtifactCachingProxyUnreachableRequestedProvider() throws Exception {
+    def script = loadScript(scriptName)
+    // Mock an healthcheck fail
+    helper.addShMock(healthCheckScriptSh, '', 1)
+    helper.addBatMock(healthCheckScriptBat, '', 1)
 
-  //   // when running with an unreachable requested provider
-  //   env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
-  //   def isOK = false
-  //   script.withArtifactCachingProxy() {
-  //     isOK = true
-  //   }
-  //   printCallStack()
-  //   assertTrue(isOK)
-  //   // then an healthcheck is performed on the provider
-  //   assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
-  //   // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
-  //   assertTrue(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
-  //   // then there is no call to configFile containing the requested artifact caching proxy provider id
-  //   assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
-  //   // then it succeeds
-  //   assertJobStatusSuccess()
-  // }
+    // when running with an unreachable requested provider
+    env.ARTIFACT_CACHING_PROXY_PROVIDER = anotherArtifactCachingProxyProvider
+    def isOK = false
+    script.withArtifactCachingProxy() {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    // then an healthcheck is performed on the provider
+    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
+    // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
+    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
+    // then there is no call to configFile containing the requested artifact caching proxy provider id
+    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
 
   @Test
   void testRunMaven() throws Exception {
     def script = loadScript(scriptName)
     script.runMaven(['clean'])
     printCallStack()
-    assertTrue(isOK)
     // then it notices the use of the default artifact caching provider
     assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
     // then configFile contains the default artifact caching proxy provider id

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -373,11 +373,11 @@ class InfraStepTests extends BaseTest {
     }
     printCallStack()
     assertTrue(isOK)
-    // then a check is performed on the pull request labels
+    // then a check is not performed on the labels
     assertFalse(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
-    // then it notices the skipping of artifact-caching-proxy
+    // then it doesn't notice the skipping of artifact-caching-proxy
     assertFalse(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
-    // then there is no call to configFile containing the default artifact caching proxy provider id
+    // then there is a call to configFile containing the default artifact caching proxy provider id
     assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
     // then it succeeds
     assertJobStatusSuccess()

--- a/test/groovy/mock/Infra.groovy
+++ b/test/groovy/mock/Infra.groovy
@@ -19,7 +19,7 @@ class Infra implements Serializable {
     }
   }
 
-  public Object runMaven(List<String> options, String jdk = null, List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = null) {
+  public Object runMaven(List<String> options, String jdk = null, List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = null, Boolean useArtifactCachingProxy = true) {
     def command = "mvn ${options.join(' ')}"
     return runWithMaven(command, jdk, extraEnv, addToolEnv)
   }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -137,13 +137,7 @@ def call(Map params = [:]) {
                   }
                   mavenOptions += 'clean install'
                   try {
-                    if (useArtifactCachingProxy) {
-                      infra.withArtifactCachingProxy {
-                        infra.runMaven(mavenOptions, jdk, null, env.MAVEN_SETTINGS, addToolEnv)
-                      }
-                    } else {
-                      infra.runMaven(mavenOptions, jdk, null, null, addToolEnv)
-                    }
+                    infra.runMaven(mavenOptions, jdk, null, null, addToolEnv, useArtifactCachingProxy)
                   } finally {
                     if (!skipTests) {
                       junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml')

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -116,7 +116,7 @@ Object withArtifactCachingProxy(Closure body) {
   }
 
   // If the build concerns a pull request, check if there is "skip-artifact-caching-proxy" label applied in case the user doesn't want ACP
-  if ((useArtifactCachingProxy) && (!env.BRANCH_IS_PRIMARY)) {
+  if ((useArtifactCachingProxy) && (!env.BRANCH_IS_PRIMARY) && (env.CHANGE_URL)) {
     withCredentials([
       // Would not be needed if there was a way to retrieve pull request labels natively.
       usernamePassword(credentialsId: getBuildCredentialsId(), usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -49,22 +49,22 @@
     See the method Javadoc in the repository for more information.
 </p>
 
-<strong>infra.runMaven(List&lt;String&gt; options, String jdk = '8', List&lt;String&gt; extraEnv = null, String settingsFile = null, Boolean addToolEnv = true)</strong>
+<strong>infra.runMaven(List&lt;String&gt; options, String jdk = '8', List&lt;String&gt; extraEnv = null, String settingsFile = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true)</strong>
 
 <p>
     Run Maven with the specified options in the current workspace.
-    If <code>settingsFile</code> is <code>null</code>, Maven settings will be added using <code>infra.retrieveMavenSettingsFile()</code>.
+    If <code>settingsFile</code> is <code>null</code> or <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code>.
 </p>
 
 <p>
     See the method Javadoc in the repository for more information.
 </p>
 
-<strong>runMaven(List&lt;String&gt; options, Integer jdk, List&lt;String&gt; extraEnv = null, String settingsFile = null, Boolean addToolEnv = true)</strong>
+<strong>infra.runMaven(List&lt;String&gt; options, Integer jdk, List&lt;String&gt; extraEnv = null, String settingsFile = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true)</strong>
 
 <p>
     Run Maven with the specified options in the current workspace.
-    If <code>settingsFile</code> is <code>null</code>, Maven settings will be added using <code>infra.retrieveMavenSettingsFile()</code>.
+    If <code>settingsFile</code> is <code>null</code> or <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code>.
 </p>
 
 <p>


### PR DESCRIPTION
PR to use Artifact Caching Proxy (almost) everywhere by including it in `infra.runMaven`

Note: the `settingsFile` parameter isn't used anymore anywhere in @jenkinsci and @jenkins-infra repositories, and same for the `extraEnv` parameter.
I'll open another PR to remove them.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752
