### PR TITLE
cleanup(`infra.withArtifactCachingProxy`): remove useless test on `env.BRANCH_IS_PRIMARY`

### DIFF
--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -23,10 +23,6 @@ class InfraStepTests extends BaseTest {
   void setUp() throws Exception {
     super.setUp()
     helper.registerAllowedMethod('getBuildCredentialsId', [], { 'aCredentialsId' })
-    env.CHANGE_URL = changeUrl
-    // Mock the absence of "skip-artifact-caching-proxy" label
-    helper.addShMock(prLabelsContainSkipACPScriptSh, '', 1)
-    helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 1)
   }
 
   @Test
@@ -314,6 +310,10 @@ class InfraStepTests extends BaseTest {
     def script = loadScript(scriptName)
 
     // when running on a pull request without a "skip-artifact-caching-proxy" label
+    env.CHANGE_URL = changeUrl
+    // Mock the absence of "skip-artifact-caching-proxy" label
+    helper.addShMock(prLabelsContainSkipACPScriptSh, '', 1)
+    helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 1)
     def isOK = false
     script.withArtifactCachingProxy() {
       isOK = true
@@ -335,6 +335,7 @@ class InfraStepTests extends BaseTest {
     def script = loadScript(scriptName)
 
     // when running on a pull request with a "skip-artifact-caching-proxy" label
+    env.CHANGE_URL = changeUrl
     // Mock a "skip-artifact-caching-proxy" label
     helper.addShMock(prLabelsContainSkipACPScriptSh, '', 0)
     helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 0)
@@ -355,7 +356,7 @@ class InfraStepTests extends BaseTest {
   }
 
   @Test
-  void testWithArtifactCachingProxySkipArtifactCachingProxyOnAnotherBranch() throws Exception {
+  void testWithArtifactCachingProxySkipArtifactCachingProxyOnBranchWithoutPullRequest() throws Exception {
     def script = loadScript(scriptName)
 
     // when running on a branch which doesn't have a pull request associated

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -314,7 +314,6 @@ class InfraStepTests extends BaseTest {
     def script = loadScript(scriptName)
 
     // when running on a pull request without a "skip-artifact-caching-proxy" label
-    env.BRANCH_IS_PRIMARY = false
     def isOK = false
     script.withArtifactCachingProxy() {
       isOK = true
@@ -336,7 +335,6 @@ class InfraStepTests extends BaseTest {
     def script = loadScript(scriptName)
 
     // when running on a pull request with a "skip-artifact-caching-proxy" label
-    env.BRANCH_IS_PRIMARY = false
     // Mock a "skip-artifact-caching-proxy" label
     helper.addShMock(prLabelsContainSkipACPScriptSh, '', 0)
     helper.addBatMock(prLabelsContainSkipACPScriptBat, '', 0)
@@ -360,9 +358,7 @@ class InfraStepTests extends BaseTest {
   void testWithArtifactCachingProxySkipArtifactCachingProxyOnAnotherBranch() throws Exception {
     def script = loadScript(scriptName)
 
-    // when running on another branch than the primary one
-    env.BRANCH_IS_PRIMARY = false
-    // but not on a pull request
+    // when running on a branch which doesn't have a pull request associated
     env.CHANGE_URL = null
     // Mock a "skip-artifact-caching-proxy" label
     helper.addShMock(prLabelsContainSkipACPScriptSh, '', 0)

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -116,7 +116,7 @@ Object withArtifactCachingProxy(Closure body) {
   }
 
   // If the build concerns a pull request, check if there is "skip-artifact-caching-proxy" label applied in case the user doesn't want ACP
-  if ((useArtifactCachingProxy) && (!env.BRANCH_IS_PRIMARY) && (env.CHANGE_URL)) {
+  if ((useArtifactCachingProxy) && (env.CHANGE_URL)) {
     withCredentials([
       // Would not be needed if there was a way to retrieve pull request labels natively.
       usernamePassword(credentialsId: getBuildCredentialsId(), usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')


### PR DESCRIPTION
The check for a pull request is done on `env.CHANGE_URL` not `env.BRANCH_IS_PRIMARY` as noted by @dduportal in https://github.com/jenkins-infra/pipeline-library/pull/592#discussion_r1106940837