### PR TITLE
Revert "feat(artifact-caching-proxy): ensure ARTIFACT_CACHING_PROXY_PROVIDER is always set"

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -101,11 +101,8 @@ Object withArtifactCachingProxy(Closure body) {
   boolean useArtifactCachingProxy = true
 
   // As the env var ARTIFACT_CACHING_PROXY_PROVIDER can't be set on Azure VM agents,
-  // we're specifying a default provider if none is specified, and we ensure the env var is always set
-  if (!env.ARTIFACT_CACHING_PROXY_PROVIDER) {
-    env.ARTIFACT_CACHING_PROXY_PROVIDER = 'azure'
-  }
-  final String requestedProxyProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER
+  // we're specifying a default provider if none is specified.
+  final String requestedProxyProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure'
   final String[] validProxyProviders = ['aws', 'azure', 'do']
   // Useful when a provider is in maintenance (or similar cases), add a global env var in Jenkins controller settings to restrict them.
   // To completely disable the artifact caching proxies, this value can be set to a value absent of validProxyProviders like "none" for example.


### PR DESCRIPTION
Reverts jenkins-infra/pipeline-library#596

This env is not set on the agent as I want.