### PR TITLE
fix(artifact-caching-proxy): correct `infra.runMaven` tests

### DIFF
--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -432,12 +432,8 @@ class InfraStepTests extends BaseTest {
     // when running with useArtifactCachingProxy set to true
     script.runMaven(['clean verify'], 11, null, null, null, true)
     printCallStack()
-    // then it notices the use of the default artifact caching provider
-    assertTrue(assertMethodCallContainsPattern('echo', "INFO: using artifact caching proxy from '${defaultArtifactCachingProxyProvider}' provider."))
-    // then configFile contains the default artifact caching proxy provider id
-    assertTrue(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
-    // then configFileProvider is correctly set
-    assertTrue(assertMethodCallContainsPattern('configFileProvider', '[OK]'))
+    // then it does notice a sh call with "-s null" (note: didn't manage to retrieve the MAVEN_SETTINGS env var value in tests outputs)
+    assertTrue(assertMethodCallContainsPattern('sh', ' -s null '))
     // then it succeeds
     assertJobStatusSuccess()
   }
@@ -453,12 +449,8 @@ class InfraStepTests extends BaseTest {
     // when running with useArtifactCachingProxy set to true
     script.runMaven(['clean verify'], 11, null, null, null, true)
     printCallStack()
-    // then a check is performed on the pull request labels
-    assertTrue(assertMethodCallContainsPattern('sh', prLabelsContainSkipACPScriptSh) || assertMethodCallContainsPattern('bat', prLabelsContainSkipACPScriptBat))
-    // then it notices the skipping of artifact-caching-proxy
-    assertTrue(assertMethodCallContainsPattern('echo', "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"))
-    // then there is no call to configFile containing the default artifact caching proxy provider id
-    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${defaultArtifactCachingProxyProvider}"))
+    // then it does not notice a sh call with "-s null"
+    assertFalse(assertMethodCallContainsPattern('sh', ' -s null '))
     // then it succeeds
     assertJobStatusSuccess()
   }
@@ -475,12 +467,8 @@ class InfraStepTests extends BaseTest {
     // when running with useArtifactCachingProxy set to true
     script.runMaven(['clean verify'], 11, null, null, null, true)
     printCallStack()
-    // then an healthcheck is performed on the provider
-    assertTrue(assertMethodCallContainsPattern('sh', healthCheckScriptSh) || assertMethodCallContainsPattern('bat', healthCheckScriptBat))
-    // then it notices the provider isn't reachable and that it will fallback to repo.jenkins-ci.org
-    assertTrue(assertMethodCallContainsPattern('echo', "WARNING: the artifact caching proxy from '${anotherArtifactCachingProxyProvider}' provider isn't reachable, will use repo.jenkins-ci.org"))
-    // then there is no call to configFile containing the requested artifact caching proxy provider id
-    assertFalse(assertMethodCallContainsPattern('configFile', "artifact-caching-proxy-${anotherArtifactCachingProxyProvider}"))
+    // then it does not notice a sh call with "-s null"
+    assertFalse(assertMethodCallContainsPattern('sh', ' -s null '))
     // then it succeeds
     assertJobStatusSuccess()
   }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -158,10 +158,10 @@ Object withArtifactCachingProxy(Closure body) {
     echo "INFO: using artifact caching proxy from '${requestedProxyProvider}' provider."
     configFileProvider(
         [configFile(fileId: "artifact-caching-proxy-${requestedProxyProvider}", variable: 'MAVEN_SETTINGS')]) {
-          body()
+          body(artifactCachingProxyConfigured = true)
         }
   } else {
-    body()
+    body(artifactCachingProxyConfigured = false)
   }
 }
 
@@ -180,8 +180,9 @@ Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = 
   if (useArtifactCachingProxy) {
     withArtifactCachingProxy {
       // If an artifact caching proxy provider has been correctly configured,
-      // add the corresponding settings.xml to Maven options
-      if (env.MAVEN_SETTINGS) {
+      // add the corresponding settings.xml path stored in MAVEN_SETTINGS env var by the config file provider
+      // to Maven options
+      if (artifactCachingProxyConfigured) {
         mvnOptions += "-s $env.MAVEN_SETTINGS"
       }
       mvnOptions.addAll(options)

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -158,10 +158,10 @@ Object withArtifactCachingProxy(Closure body) {
     echo "INFO: using artifact caching proxy from '${requestedProxyProvider}' provider."
     configFileProvider(
         [configFile(fileId: "artifact-caching-proxy-${requestedProxyProvider}", variable: 'MAVEN_SETTINGS')]) {
-          body(artifactCachingProxyConfigured = true)
+          body()
         }
   } else {
-    body(artifactCachingProxyConfigured = false)
+    body()
   }
 }
 
@@ -182,7 +182,7 @@ Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = 
       // If an artifact caching proxy provider has been correctly configured,
       // add the corresponding settings.xml path stored in MAVEN_SETTINGS env var
       // by the config file provider to Maven options
-      if (artifactCachingProxyConfigured) {
+      if (env.MAVEN_SETTINGS) {
         mvnOptions += "-s $env.MAVEN_SETTINGS"
       }
       mvnOptions.addAll(options)

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -180,8 +180,8 @@ Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = 
   if (useArtifactCachingProxy) {
     withArtifactCachingProxy {
       // If an artifact caching proxy provider has been correctly configured,
-      // add the corresponding settings.xml path stored in MAVEN_SETTINGS env var by the config file provider
-      // to Maven options
+      // add the corresponding settings.xml path stored in MAVEN_SETTINGS env var
+      // by the config file provider to Maven options
       if (artifactCachingProxyConfigured) {
         mvnOptions += "-s $env.MAVEN_SETTINGS"
       }


### PR DESCRIPTION
Follow-up of #611

Tests actually testing the fix from #611, the previous ones didn't do anything to catch the `-s null` error and passed even without the `infra.runMaven` groovy patch, as noticed by @jglick in https://github.com/jenkins-infra/pipeline-library/pull/611#discussion_r1126400780

<details>
<summary>Initial PR body</summary>

Better way of passing the fact that an artifact caching proxy has been configured or not in `infra.withArtifactCachingProxy` to `infra.runMaven` with `artifactCachingProxyConfigured` (cf @dduportal comment https://github.com/jenkins-infra/pipeline-library/pull/611#discussion_r1126494592)

Tests actually testing the fix from #611, the previous ones didn't do anything to catch the `-s null` error and passed even without the `infra.runMaven` groovy patch, as noticed by @jglick in https://github.com/jenkins-infra/pipeline-library/pull/611#discussion_r1126400780

Note: I didn't manage to retrieve in the tests the value of the `MAVEN_SETTINGS` variable defined by the config file provider here: https://github.com/jenkins-infra/pipeline-library/blob/f943c7ba139787abdcfafef8aa6d1acfd6f84233/vars/infra.groovy#L160

Any idea how/if it can be retrieved?

Ideally I'd like to pass this value in the closure instead of `artifactCachingProxyConfigured`

</details>