### PR TITLE
breaking(`infra.runMaven`): remove unused `settingsFile` parameter

### DIFF
--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -432,7 +432,7 @@ class InfraStepTests extends BaseTest {
     // mock a correctly configured artifact caching proxy provider
     env.MAVEN_SETTINGS = "/tmp_path/settings.xml"
     // when running with useArtifactCachingProxy set to true
-    script.runMaven(['clean verify'], 11, null, null, null, true)
+    script.runMaven(['clean verify'], 11, null, null, true)
     printCallStack()
     // then it does notice a sh call with the settings.xml path
     assertTrue(assertMethodCallContainsPattern('sh', '-s /tmp_path/settings.xml'))
@@ -446,7 +446,21 @@ class InfraStepTests extends BaseTest {
     // mock an artifact caching proxy provider unavailable, skipped or unreachable
     env.MAVEN_SETTINGS = null
     // when running with useArtifactCachingProxy set to true
-    script.runMaven(['clean verify'], 11, null, null, null, true)
+    script.runMaven(['clean verify'], 11, null, null, true)
+    printCallStack()
+    // then it does not notice a sh call with "-s null"
+    assertFalse(assertMethodCallContainsPattern('sh', '-s null'))
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testRunMavenWithArtifactCachingProxyDisabled() throws Exception {
+    def script = loadScript(scriptName)
+    // mock an artifact caching proxy disabled
+    env.MAVEN_SETTINGS = null
+    // when running with useArtifactCachingProxy set to false
+    script.runMaven(['clean verify'], 11, null, null, false)
     printCallStack()
     // then it does not notice a sh call with "-s null"
     assertFalse(assertMethodCallContainsPattern('sh', '-s null'))

--- a/test/groovy/mock/Infra.groovy
+++ b/test/groovy/mock/Infra.groovy
@@ -19,7 +19,7 @@ class Infra implements Serializable {
     }
   }
 
-  public Object runMaven(List<String> options, String jdk = null, List<String> extraEnv = null, String settingsFile = null, Boolean addToolEnv = null, Boolean useArtifactCachingProxy = true) {
+  public Object runMaven(List<String> options, String jdk = null, List<String> extraEnv = null, Boolean addToolEnv = null, Boolean useArtifactCachingProxy = true) {
     def command = "mvn ${options.join(' ')}"
     return runWithMaven(command, jdk, extraEnv, addToolEnv)
   }

--- a/test/groovy/mock/Infra.groovy
+++ b/test/groovy/mock/Infra.groovy
@@ -11,7 +11,7 @@ class Infra implements Serializable {
 
   public void checkoutSCM(String repo = null) { }
 
-  public Object withArtifactCachingProxy(Closure body) {
+  public Object withArtifactCachingProxy(Boolean useArtifactCachingProxy, Closure body) {
     if (buildError) {
       throw new RuntimeException('build error')
     } else {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -137,7 +137,7 @@ def call(Map params = [:]) {
                   }
                   mavenOptions += 'clean install'
                   try {
-                    infra.runMaven(mavenOptions, jdk, null, null, addToolEnv, useArtifactCachingProxy)
+                    infra.runMaven(mavenOptions, jdk, null, addToolEnv, useArtifactCachingProxy)
                   } finally {
                     if (!skipTests) {
                       junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml')

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -96,7 +96,7 @@ String getBuildCredentialsId() {
  * The available providers can be restricted by setting a global ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS
  * variable on the Jenkins controller, with providers separated by a comma. Ex: 'aws,do' if the Azure provider is unavailable.
  * A 'skip-artifact-caching-proxy' label can be added to pull request in order to punctually disable it.
- * @param useArtifactCachingProxy (default: true) use or not an artifact caching proxy in front of repo.jenkins-ci.org to decrease JFrog Artifactory bandwidth usage and to increase reliability
+ * @param useArtifactCachingProxy (default: true) if possible, use an artifact caching proxy in front of repo.jenkins-ci.org to decrease JFrog Artifactory bandwidth usage and to increase reliability
  */
 Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure body) {
   // As the env var ARTIFACT_CACHING_PROXY_PROVIDER can't be set on Azure VM agents,
@@ -170,7 +170,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
  * @param jdk JDK to be used
  * @param options Options to be passed to the Maven command
  * @param extraEnv Extra environment variables to be passed when invoking the command
- * @param useArtifactCachingProxy (default: true) use an artifact caching proxy in front of repo.jenkins-ci.org to decrease JFrog Artifactory bandwidth usage and to increase reliability
+ * @param useArtifactCachingProxy (default: true) if possible, use an artifact caching proxy in front of repo.jenkins-ci.org to decrease JFrog Artifactory bandwidth usage and to increase reliability
  * @see withArtifactCachingProxy
  */
 Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true) {
@@ -196,7 +196,7 @@ Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = 
  * @param options Options to be passed to the Maven command
  * @param extraEnv Extra environment variables to be passed when invoking the command
  * @param settingsFile specific Maven settings.xml filepath, not taken in account if useArtifactCachingProxy is true
- * @param useArtifactCachingProxy (default: true) use an artifact caching proxy in front of repo.jenkins-ci.org to decrease JFrog Artifactory bandwidth usage and to increase reliability
+ * @param useArtifactCachingProxy (default: true) if possible, use an artifact caching proxy in front of repo.jenkins-ci.org to decrease JFrog Artifactory bandwidth usage and to increase reliability
  * @see withArtifactCachingProxy
  */
 Object runMaven(List<String> options, Integer jdk, List<String> extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true) {

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -31,7 +31,7 @@
     Either this must be used as part of a Multibranch Pipeline or a repository argument must be provided.
 </p>
 
-<strong>infra.withArtifactCachingProxy(Closure body)</strong>
+<strong>infra.withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure body)</strong>
 
 <p>
     Execute the body passed as closure with a Maven settings file using the
@@ -49,22 +49,22 @@
     See the method Javadoc in the repository for more information.
 </p>
 
-<strong>infra.runMaven(List&lt;String&gt; options, String jdk = '8', List&lt;String&gt; extraEnv = null, String settingsFile = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true)</strong>
+<strong>infra.runMaven(List&lt;String&gt; options, String jdk = '8', List&lt;String&gt; extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true)</strong>
 
 <p>
     Run Maven with the specified options in the current workspace.
-    If <code>settingsFile</code> is <code>null</code> or <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code>.
+    If <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code> if the provider is available, reachable and not skipped.
 </p>
 
 <p>
     See the method Javadoc in the repository for more information.
 </p>
 
-<strong>infra.runMaven(List&lt;String&gt; options, Integer jdk, List&lt;String&gt; extraEnv = null, String settingsFile = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true)</strong>
+<strong>infra.runMaven(List&lt;String&gt; options, Integer jdk, List&lt;String&gt; extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true)</strong>
 
 <p>
     Run Maven with the specified options in the current workspace.
-    If <code>settingsFile</code> is <code>null</code> or <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code>.
+    If <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code> if the provider is available, reachable and not skipped.
 </p>
 
 <p>

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -53,7 +53,7 @@
 
 <p>
     Run Maven with the specified options in the current workspace.
-    If <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code> if the provider is available, reachable and not skipped.
+    If <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code> if possible (i.e. the provider is available, reachable and not skipped).
 </p>
 
 <p>
@@ -64,7 +64,7 @@
 
 <p>
     Run Maven with the specified options in the current workspace.
-    If <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code> if the provider is available, reachable and not skipped.
+    If <code>useArtifactCachingProxy</code> is <code>true</code>, Maven settings will be added using <code>infra.withArtifactCachingProxy()</code> if possible (i.e. the provider is available, reachable and not skipped).
 </p>
 
 <p>


### PR DESCRIPTION
As the `settingsFile` parameter isn't used anymore in any @jenkinsci or @jenkins-infra repository and as only `buildPlugin` uses the 2 last `infra.runMaven` parameters, this PR removes the `settingsFile` parameter.

It also simplifies `infra.runMaven` logic by passing `useArtifactCachingProxy` boolean directly as parameter of `infra.withArtifactCachingProxy`.

Tested in https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/66: ✅ 