### PR TITLE
feat: add `infra.isRelease` function (#616)Co-authored-by: Damien Duportal <damien.duportal@gmail.com>

### DIFF
--- a/src/io/jenkins/infra/InfraConfig.groovy
+++ b/src/io/jenkins/infra/InfraConfig.groovy
@@ -39,7 +39,7 @@ class InfraConfig implements Serializable {
 
   // Returns the Docker registry hostname which this instance has credentials for
   String getDockerRegistryNamespace() {
-    if (isTrusted() || isRelease() || isInfra()) {
+    if (isTrusted() || isInfra()) {
       return 'jenkinsciinfra'
     } else {
       return 'jenkins4eval'

--- a/src/io/jenkins/infra/InfraConfig.groovy
+++ b/src/io/jenkins/infra/InfraConfig.groovy
@@ -25,17 +25,21 @@ class InfraConfig implements Serializable {
     return isJenkinsURLcontains('trusted.ci')
   }
 
+  Boolean isRelease() {
+    return isJenkinsURLcontains('release.ci')
+  }
+
   Boolean isInfra() {
     return isJenkinsURLcontains('infra.ci')
   }
 
   Boolean isRunningOnJenkinsInfra() {
-    return isCI() || isTrusted() || isInfra()
+    return isCI() || isTrusted() || isRelease() || isInfra()
   }
 
   // Returns the Docker registry hostname which this instance has credentials for
   String getDockerRegistryNamespace() {
-    if (isTrusted() || isInfra()) {
+    if (isTrusted() || isRelease() || isInfra()) {
       return 'jenkinsciinfra'
     } else {
       return 'jenkins4eval'

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -41,6 +41,22 @@ class InfraStepTests extends BaseTest {
   }
 
   @Test
+  void testIsRelease() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://release.ci.jenkins.io/'
+    binding.setVariable('env', env)
+    assertTrue(script.isRelease())
+  }
+
+  @Test
+  void testIsInfra() throws Exception {
+    def script = loadScript(scriptName)
+    env.JENKINS_URL = 'https://infra.ci.jenkins.io/'
+    binding.setVariable('env', env)
+    assertTrue(script.isInfra())
+  }
+
+  @Test
   void testWithDockerCredentials() throws Exception {
     def script = loadScript(scriptName)
     env.JENKINS_URL = 'https://ci.jenkins.io/'

--- a/test/groovy/io/jenkins/infra/InfraConfigTest.groovy
+++ b/test/groovy/io/jenkins/infra/InfraConfigTest.groovy
@@ -15,6 +15,7 @@ class InfraConfigTest {
     def infraConfig = new InfraConfig([JENKINS_URL: 'https://ci.jenkins.io/'])
 
     assertFalse(infraConfig.isTrusted())
+    assertFalse(infraConfig.isRelease())
     assertFalse(infraConfig.isInfra())
     assertTrue(infraConfig.isCI())
     assertTrue(infraConfig.isRunningOnJenkinsInfra())
@@ -30,6 +31,7 @@ class InfraConfigTest {
     def infraConfig = new InfraConfig([JENKINS_URL: 'https://trusted.ci.jenkins.io/'])
 
     assertTrue(infraConfig.isTrusted())
+    assertFalse(infraConfig.isRelease())
     assertFalse(infraConfig.isInfra())
     assertFalse(infraConfig.isCI())
     assertTrue(infraConfig.isRunningOnJenkinsInfra())
@@ -41,10 +43,26 @@ class InfraConfigTest {
   }
 
   @Test
+  void canHandleReleaseConfiguration() throws Exception {
+    def infraConfig = new InfraConfig([JENKINS_URL: 'https://release.ci.jenkins.io/'])
+
+    assertFalse(infraConfig.isTrusted())
+    assertTrue(infraConfig.isRelease())
+    assertFalse(infraConfig.isInfra())
+    assertFalse(infraConfig.isCI())
+    assertTrue(infraConfig.isRunningOnJenkinsInfra())
+    assertEquals('jenkinsciinfra', infraConfig.getDockerRegistryNamespace())
+    assertEquals('releasecijenkinsio', infraConfig.getDockerPullOrgAndCredentialsId().organisation)
+    assertEquals('releasecijenkinsio-dockerhub-pull', infraConfig.getDockerPullOrgAndCredentialsId().credentialId)
+    assertTrue(infraConfig.getDockerPushOrgAndCredentialsId().error)
+  }
+
+  @Test
   void canHandleInfraConfiguration() throws Exception {
     def infraConfig = new InfraConfig([JENKINS_URL: 'https://infra.ci.jenkins.io/'])
 
     assertFalse(infraConfig.isTrusted())
+    assertFalse(infraConfig.isRelease())
     assertTrue(infraConfig.isInfra())
     assertFalse(infraConfig.isCI())
     assertTrue(infraConfig.isRunningOnJenkinsInfra())
@@ -60,6 +78,7 @@ class InfraConfigTest {
     def infraConfig = new InfraConfig([JENKINS_URL: 'https://ci.quidditch.io'])
 
     assertFalse(infraConfig.isTrusted())
+    assertFalse(infraConfig.isRelease())
     assertFalse(infraConfig.isInfra())
     assertFalse(infraConfig.isCI())
     assertFalse(infraConfig.isRunningOnJenkinsInfra())
@@ -73,6 +92,7 @@ class InfraConfigTest {
     def infraConfig = new InfraConfig()
 
     assertFalse(infraConfig.isTrusted())
+    assertFalse(infraConfig.isRelease())
     assertFalse(infraConfig.isInfra())
     assertFalse(infraConfig.isCI())
     assertFalse(infraConfig.isRunningOnJenkinsInfra())
@@ -86,6 +106,7 @@ class InfraConfigTest {
     def infraConfig = new InfraConfig([:])
 
     assertFalse(infraConfig.isTrusted())
+    assertFalse(infraConfig.isRelease())
     assertFalse(infraConfig.isInfra())
     assertFalse(infraConfig.isCI())
     assertFalse(infraConfig.isRunningOnJenkinsInfra())

--- a/test/groovy/io/jenkins/infra/InfraConfigTest.groovy
+++ b/test/groovy/io/jenkins/infra/InfraConfigTest.groovy
@@ -51,7 +51,7 @@ class InfraConfigTest {
     assertFalse(infraConfig.isInfra())
     assertFalse(infraConfig.isCI())
     assertTrue(infraConfig.isRunningOnJenkinsInfra())
-    assertEquals('jenkinsciinfra', infraConfig.getDockerRegistryNamespace())
+    assertEquals('jenkins4eval', infraConfig.getDockerRegistryNamespace())
     assertEquals('releasecijenkinsio', infraConfig.getDockerPullOrgAndCredentialsId().organisation)
     assertEquals('releasecijenkinsio-dockerhub-pull', infraConfig.getDockerPullOrgAndCredentialsId().credentialId)
     assertTrue(infraConfig.getDockerPushOrgAndCredentialsId().error)

--- a/test/groovy/mock/Infra.groovy
+++ b/test/groovy/mock/Infra.groovy
@@ -6,6 +6,7 @@ package mock
 class Infra implements Serializable {
 
   private boolean trusted
+  private boolean release
   private boolean infra
   private boolean buildError
 
@@ -38,6 +39,10 @@ class Infra implements Serializable {
 
   public boolean isTrusted() {
     return trusted
+  }
+
+  public boolean isRelease() {
+    return release
   }
 
   public boolean isInfra() {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -15,6 +15,11 @@ Boolean isTrusted() {
 }
 
 // Method kept for backward compatibility (as the method is available on the InfraConfig stateful object)
+Boolean isRelease() {
+  return new InfraConfig(env).isRelease()
+}
+
+// Method kept for backward compatibility (as the method is available on the InfraConfig stateful object)
 Boolean isInfra() {
   return new InfraConfig(env).isInfra()
 }

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -14,7 +14,7 @@
 <strong>infra.isRelease()</strong>
 
 <p>
-    Return true if this Pipeline is executing on a release CI environment.
+    Return true if this Pipeline is executing on the Jenkins release CI environment.
 </p>
 
 <strong>infra.isInfra()</strong>

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -11,6 +11,12 @@
     Return true if this Pipeline is executing on a trusted CI environment.
 </p>
 
+<strong>infra.isRelease()</strong>
+
+<p>
+    Return true if this Pipeline is executing on a release CI environment.
+</p>
+
 <strong>infra.isInfra()</strong>
 
 <p>


### PR DESCRIPTION
This PR will allow restricting certain steps/stages/commands in pipelines depending on their execution location, similar to `infra.isTrusted()` and `infra.isInfra()`.

I intend to use it to prevent the use of artifact caching proxies on release.ci and trusted.ci