### PR TITLE
More clearly communicate to Gradle users that they are not on a fully supported path

### DIFF
--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -44,8 +44,9 @@ def call(Map params = [:]) {
             }
             //TODO(oleg-nenashev): Once supported by Gradle JPI Plugin, pass jenkinsVersion
             if (jenkinsVersion) {
-              echo "WARNING: 'jenkinsVersion' parameter is not supported in buildPluginWithGradle(). It will be ignored"
+              infra.publishDeprecationCheck('Remove jenkinsVersion', 'The "jenkinsVersion" parameter is not supported in buildPluginWithGradle(). It will be ignored.')
             }
+            infra.publishDeprecationCheck('Migrate from Gradle to Maven', 'The Jenkins project offers only partial support for building plugins with Gradle and "gradle-jpi-plugin". The Jenkins project offers full support only for building plugins with Maven and "maven-hpi-plugin".')
             List<String> gradleOptions = ['--no-daemon', 'cleanTest', 'build']
             if (skipTests) {
               gradleOptions += '--exclude-task test'


### PR DESCRIPTION
In https://groups.google.com/g/jenkinsci-dev/c/lHQAiEepBiw/m/1efu_EUBBQAJ @lemeurherve notes that

> for those using `buildPluginWithGradle()` from the shared pipeline library, we could add a note about it in the logs

which makes sense to me. Here I am adding such a deprecation check. While I was here, I also cleaned up the preceding warning to use the GitHub Checks API rather than an `echo` step. To test this change I successfully ran `mvn clean verify` locally.