### PR TITLE
Add `launchable` step

### DIFF
--- a/test/groovy/LaunchableStepTests.groovy
+++ b/test/groovy/LaunchableStepTests.groovy
@@ -1,0 +1,52 @@
+import static org.junit.Assert.assertTrue
+
+import org.junit.Before
+import org.junit.Test
+
+class LaunchableStepTests extends BaseTest {
+  static final String scriptName = 'vars/launchable.groovy'
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+  }
+
+  @Test
+  void test_launchable_install() throws Exception {
+    def script = loadScript(scriptName)
+    script.install()
+    printCallStack()
+    // then it installs Launchable
+    assertTrue(assertMethodCallContainsPattern('sh', '''
+        python3 -m venv launchable
+        launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
+        launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
+        '''.stripIndent()))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_launchable_verify() throws Exception {
+    def script = loadScript(scriptName)
+    script.call("verify")
+    printCallStack()
+    // then it uses the appropriate credentials
+    assertMethodCallContainsPattern('withCredentials', 'LAUNCHABLE_TOKEN')
+    // then it runs "launchable verify"
+    assertTrue(assertMethodCallContainsPattern('sh', 'launchable verify'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_launchable_escaping() throws Exception {
+    def script = loadScript(scriptName)
+    script.call("record tests --no-build maven './**/target/surefire-reports'")
+    printCallStack()
+    // then it uses the appropriate credentials
+    assertMethodCallContainsPattern('withCredentials', 'LAUNCHABLE_TOKEN')
+    // then it passes the arguments without escaping to the Launchable CLI
+    assertTrue(assertMethodCallContainsPattern('sh', "record tests --no-build maven './**/target/surefire-reports'"))
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -1,0 +1,21 @@
+def install() {
+  if (isUnix()) {
+    sh '''
+        python3 -m venv launchable
+        launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
+        launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
+       '''.stripIndent()
+  } else {
+    error 'Launchable installation is not yet implemented for Windows'
+  }
+}
+
+def call(String args) {
+  withCredentials([string(credentialsId: 'launchable-prototype', variable: 'LAUNCHABLE_TOKEN')]) {
+    if (isUnix()) {
+      sh 'launchable/bin/launchable ' + args
+    } else {
+      error 'The Launchable CLI is not yet implemented for Windows'
+    }
+  }
+}

--- a/vars/launchable.txt
+++ b/vars/launchable.txt
@@ -1,0 +1,34 @@
+<p>
+  Install and run the
+  <a href="https://github.com/launchableinc/cli">Launchable CLI</a>.
+</p>
+
+<p>
+  <b>Usage:</b>
+</p>
+
+<dl>
+  <dt><code>args</code></dt>
+  <dd>
+    The arguments to pass to the Launchable CLI. See
+    <a href="https://www.launchableinc.com/docs/resources/cli-reference/">
+      the CLI reference
+    </a>
+    for more information. The arguments will be passed through to the shell
+    without escaping; use the shell's escaping functionality to allow the
+    Launchable CLI to do its own globbing.
+  </dd>
+</dl>
+
+<p>
+  <b>Example:</b>
+</p>
+
+<pre>
+  launchable.install()
+  launchable("record tests --no-build maven './**/target/surefire-reports'")
+</pre>
+
+<!--
+  vim: ft=html
+-->


### PR DESCRIPTION
It was requested that I do a prototype of Launchable. This provides me with functionality to install and run the Launchable CLI from within our CI system. I tested this on my local machine and on `ci.jenkins.io` by replaying `text-finder` plugin builds with both container-based and VM Linux agents. I did not implement the functionality for Windows agents because I determined that both our container-based and VM Windows agents do not have Python installed.