### PR TITLE
Record Launchable commits for successful builds

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -1,5 +1,6 @@
 import mock.CurrentBuild
 import mock.Infra
+import mock.Launchable
 import org.junit.Before
 import org.junit.Test
 import static org.junit.Assert.assertEquals
@@ -301,10 +302,12 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_configurations_and_incrementals() throws Exception {
     def script = loadScript(scriptName)
+    binding.setProperty('launchable', new Launchable())
     // when running with incrementals
     helper.registerAllowedMethod('fileExists', [String.class], { s ->
       return s.equals('.mvn/extensions.xml') || s.equals('pom.xml')
     })
+    helper.registerAllowedMethod('launchable', [String.class], null)
     helper.addReadFileMock('.mvn/extensions.xml', 'git-changelist-maven-extension')
     // and no jenkins version
     script.call(configurations: [['platform': 'linux', 'jdk': 8, 'jenkins': null]])

--- a/test/groovy/mock/Launchable.groovy
+++ b/test/groovy/mock/Launchable.groovy
@@ -1,0 +1,8 @@
+package mock
+
+/**
+ * Mock Launchable step
+ */
+class Launchable implements Serializable {
+  def install() {}
+}

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -255,6 +255,19 @@ def call(Map params = [:]) {
                   if (failFast && currentBuild.result == 'UNSTABLE') {
                     error 'Static analysis quality gates not passed; halting early'
                   }
+                  /*
+                   * If the current build was successful, we send the commits to Launchable so that
+                   * the result can be consumed by a Launchable build in the future. We do not
+                   * attempt to record commits for non-incrementalified plugins because such
+                   * plugins' PR builds could not be consumed by anything else anyway, and all
+                   * plugins currently in the BOM are incrementalified. We do not attempt to record
+                   * commits on Windows because our Windows agents do not have Python installed.
+                   */
+                  if (incrementals && platform != 'windows' && currentBuild.currentResult == 'SUCCESS') {
+                    launchable.install()
+                    launchable('verify')
+                    launchable('record commit')
+                  }
                 } else {
                   echo "Skipping static analysis results for ${stageIdentifier}"
                 }


### PR DESCRIPTION
Depends on #630 (and the PR build will fail until it is rebased on top of #630).

The second baby step in the Launchable prototype: getting commit information flowing to Launchable.

Tested in https://ci.jenkins.io/job/Plugins/job/text-finder-plugin/job/PR-163/3/ and by running `mvn clean verify`.