### PR TITLE
Make Launchable errors non-fatal

### DIFF
--- a/test/groovy/LaunchableStepTests.groovy
+++ b/test/groovy/LaunchableStepTests.groovy
@@ -23,6 +23,10 @@ class LaunchableStepTests extends BaseTest {
         launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
         launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
         '''.stripIndent()))
+    // without using any credentials
+    assertTrue(assertMethodCallOccurrences('withCredentials', 0))
+    // swallowing any errors that might occur
+    assertTrue(assertMethodCall('catchError'))
     assertJobStatusSuccess()
   }
 
@@ -33,6 +37,8 @@ class LaunchableStepTests extends BaseTest {
     printCallStack()
     // then it uses the appropriate credentials
     assertMethodCallContainsPattern('withCredentials', 'LAUNCHABLE_TOKEN')
+    // swallowing any errors that might occur
+    assertTrue(assertMethodCall('catchError'))
     // then it runs "launchable verify"
     assertTrue(assertMethodCallContainsPattern('sh', 'launchable verify'))
     assertJobStatusSuccess()
@@ -45,6 +51,8 @@ class LaunchableStepTests extends BaseTest {
     printCallStack()
     // then it uses the appropriate credentials
     assertMethodCallContainsPattern('withCredentials', 'LAUNCHABLE_TOKEN')
+    // swallowing any errors that might occur
+    assertTrue(assertMethodCall('catchError'))
     // then it passes the arguments without escaping to the Launchable CLI
     assertTrue(assertMethodCallContainsPattern('sh', "record tests --no-build maven './**/target/surefire-reports'"))
     assertJobStatusSuccess()

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -1,10 +1,12 @@
 def install() {
   if (isUnix()) {
-    sh '''
-        python3 -m venv launchable
-        launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
-        launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
-       '''.stripIndent()
+    catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to install Launchable; continuing build.') {
+      sh '''
+          python3 -m venv launchable
+          launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
+          launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
+         '''.stripIndent()
+    }
   } else {
     error 'Launchable installation is not yet implemented for Windows'
   }
@@ -13,7 +15,9 @@ def install() {
 def call(String args) {
   withCredentials([string(credentialsId: 'launchable-prototype', variable: 'LAUNCHABLE_TOKEN')]) {
     if (isUnix()) {
-      sh 'launchable/bin/launchable ' + args
+      catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to run Launchable; continuing build.') {
+        sh 'launchable/bin/launchable ' + args
+      }
     } else {
       error 'The Launchable CLI is not yet implemented for Windows'
     }


### PR DESCRIPTION
Launchable will shortly be in the critical path for BOM bills, and I am planning to add it to the critical path for Jenkins core and all plugin builds to collect commits. This introduces risk that a failure to install Launchable from PyPI will cause a Jenkins build failure (undesirable!) or that a failure to submit data to Launchable (for example, because Launchable is down) will cause a Jenkins build failure (also undesirable!). Since this is a prototype project that is not intended to be production-ready, I think it is prudent to proactively make Launchable errors non-fatal. This PR does so by turning them into warnings with the `catchError` step. We explicitly decline to catch interruptions so that builds can still be cancelled even if they are submitting data to Launchable. We also decline the default value of `buildResult` in favor of `SUCCESS` to ensure that Launchable failures don't block incrementals from being deployed. To test this change I ran the corresponding code in an artificial Pipeline job with an artificial Launchable failure (a syntax error) and verified that the `catchError` step behaved as expected, in addition to running the (updated) unit tests with `mvn clean verify`.