### PR TITLE
chore(`infra.withArtifactCachingProxy`): use `pipeline-github-plugin` to retrieve PR labels

### DIFF
--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -19,7 +19,7 @@ class InfraStepTests extends BaseTest {
   static final String changeUrl = 'https://github.com/jenkins-infra/pipeline-library/pull/123'
   static final String prLabelsContainSkipACPScriptSh = 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | grep --ignore-case "skip-artifact-caching-proxy"'
   static final String prLabelsContainSkipACPScriptBat = 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" https://api.github.com/repos/jenkins-infra/pipeline-library/issues/123/labels | findstr /i "skip-artifact-caching-proxy"'
-  
+
   @Override
   @Before
   void setUp() throws Exception {

--- a/test/groovy/TerraformStepTests.groovy
+++ b/test/groovy/TerraformStepTests.groovy
@@ -1,7 +1,6 @@
 import org.junit.Before
 import org.junit.Test
 import mock.CurrentBuild
-import mock.PullRequest
 
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
@@ -32,8 +31,6 @@ class TerraformStepTests extends BaseTest {
     binding.setProperty('scm', ['GIT_URL': 'https://github.com/lesfurets/jenkins-unit-test.git'])
     helper.registerAllowedMethod('ansiColor', [String.class, Closure.class], { s, body ->body() })
     helper.registerAllowedMethod('checkout', [Map.class], { m -> m })
-
-    binding.setVariable('pullRequest', new PullRequest())
 
     // Used by the publish checks
     addEnvVar('BUILD_URL', dummyBuildUrl)

--- a/test/groovy/TerraformStepTests.groovy
+++ b/test/groovy/TerraformStepTests.groovy
@@ -1,14 +1,10 @@
 import org.junit.Before
 import org.junit.Test
 import mock.CurrentBuild
+import mock.PullRequest
 
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
-
-class PullRequestMock {
-  def comment(String message) {
-  }
-}
 
 class TerraformStepTests extends BaseTest {
   static final String scriptName = 'vars/terraform.groovy'
@@ -37,7 +33,7 @@ class TerraformStepTests extends BaseTest {
     helper.registerAllowedMethod('ansiColor', [String.class, Closure.class], { s, body ->body() })
     helper.registerAllowedMethod('checkout', [Map.class], { m -> m })
 
-    binding.setVariable('pullRequest', new PullRequestMock())
+    binding.setVariable('pullRequest', new PullRequest())
 
     // Used by the publish checks
     addEnvVar('BUILD_URL', dummyBuildUrl)

--- a/test/groovy/mock/PullRequest.groovy
+++ b/test/groovy/mock/PullRequest.groovy
@@ -1,0 +1,21 @@
+package mock
+
+/**
+ * Mock PullRequest
+ */
+class PullRequest implements Serializable {
+  String comment
+  def labels
+
+  public PullRequest(def labels = []) {
+    this.labels = labels
+  }
+
+  public comment(String comment) {
+    this.comment = comment
+  }
+
+  public def labels() {
+    return this.labels
+  }
+}

--- a/test/groovy/mock/PullRequest.groovy
+++ b/test/groovy/mock/PullRequest.groovy
@@ -4,15 +4,10 @@ package mock
  * Mock PullRequest
  */
 class PullRequest implements Serializable {
-  String comment
   def labels
 
   public PullRequest(def labels = []) {
     this.labels = labels
-  }
-
-  public comment(String comment) {
-    this.comment = comment
   }
 
   public def labels() {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -116,7 +116,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
     final String skipACPLabel = 'skip-artifact-caching-proxy'
     // Note: the pullRequest object is provided by https://github.com/jenkinsci/pipeline-github-plugin
     if (pullRequest.labels.contains(skipACPLabel)) {
-      echo "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"
+      echo "INFO: the label '$skipACPLabel' has been applied to the pull request, will use repo.jenkins-ci.org"
       useArtifactCachingProxy = false
     }
   }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -112,8 +112,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
   }
 
   // If the build concerns a pull request, check if there is "skip-artifact-caching-proxy" label applied in case the user doesn't want ACP
-  if ((useArtifactCachingProxy) && (env.CHANGE_URL)) {
-    boolean prLabelsContainSkipACP = false
+  if (useArtifactCachingProxy && env.CHANGE_URL && pullRequest != null) {
     final String skipACPLabel = 'skip-artifact-caching-proxy'
     // Note: the pullRequest object is provided by https://github.com/jenkinsci/pipeline-github-plugin
     if (pullRequest.labels.contains(skipACPLabel)) {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -84,14 +84,6 @@ Object checkoutSCM(String repo = null) {
 }
 
 /**
- * Retrieve the current credentialsId used by the build
- */
-@NonCPS
-String getBuildCredentialsId() {
-  return SCMSource.SourceByItem.findSource(currentBuild.rawBuild.parent).credentialsId
-}
-
-/**
  * Execute the body passed as closure with a Maven settings file using the
  * Artifact Caching Proxy provider corresponding to the requested one defined
  * via the agent's env.ARTIFACT_CACHING_PROXY variable, or 'azure' if not defined.
@@ -121,23 +113,12 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
 
   // If the build concerns a pull request, check if there is "skip-artifact-caching-proxy" label applied in case the user doesn't want ACP
   if ((useArtifactCachingProxy) && (env.CHANGE_URL)) {
-    withCredentials([
-      // Would not be needed if there was a way to retrieve pull request labels natively.
-      usernamePassword(credentialsId: getBuildCredentialsId(), usernameVariable: 'GITHUB_APP', passwordVariable: 'GH_TOKEN')
-    ]) {
-      boolean prLabelsContainSkipACP = false
-      final String skipACPLabel = 'skip-artifact-caching-proxy'
-      // Creating the correct API URL to retrieve pull request labels from the $CHANGE_URL
-      final String pullrequestLabelsApiURL = (env.CHANGE_URL).replace('/pull/', '/issues/').replace('/github.com/', '/api.github.com/repos/') + '/labels'
-      if (isUnix()) {
-        prLabelsContainSkipACP = sh(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" ' + pullrequestLabelsApiURL + ' | grep --ignore-case "skip-artifact-caching-proxy"', returnStatus: true) == 0
-      } else {
-        prLabelsContainSkipACP = bat(script: 'curl --silent -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %GH_TOKEN%" ' + pullrequestLabelsApiURL + ' | findstr /i "skip-artifact-caching-proxy"', returnStatus: true) == 0
-      }
-      if (prLabelsContainSkipACP) {
-        echo "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"
-        useArtifactCachingProxy = false
-      }
+    boolean prLabelsContainSkipACP = false
+    final String skipACPLabel = 'skip-artifact-caching-proxy'
+    // Note: the pullRequest object is provided by https://github.com/jenkinsci/pipeline-github-plugin
+    if (pullRequest.labels.contains(skipACPLabel)) {
+      echo "INFO: the label 'skip-artifact-caching-proxy' has been applied to the pull request, will use repo.jenkins-ci.org"
+      useArtifactCachingProxy = false
     }
   }
 


### PR DESCRIPTION
As suggested by @basil in https://github.com/jenkins-infra/pipeline-library/pull/552#discussion_r1152685801, this PR replaces the GitHub API `curl` call with a credentials by the use of the `pullRequest` object provided by https://github.com/jenkinsci/pipeline-github-plugin.

> > What would be the benefit(s) of switching to this method?
> 
> The current code uses a `@NonCPS` method to call `SCMSource.SourceByItem.findSource` against `currentBuild.rawBuild.parent`, and using `currentBuild.rawBuild` goes against Pipeline best practices (I can't remember the reference now, but I could look it up if this helps). Also, starting a new (CPS-based) `sh`/`bat` durable task step to invoke `curl` is more expensive than the simple Groovy code I showed above (which could be optimized even further with `@NonCPS`). So the alternative is cleaner and more efficient.

Tested in https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/66 with and without the `skip-artifact-caching-proxy` label.