### PR TITLE
Use `withCredentials` for Launchable in `buildPlugin`

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -265,8 +265,10 @@ def call(Map params = [:]) {
                    */
                   if (incrementals && platform != 'windows' && currentBuild.currentResult == 'SUCCESS') {
                     launchable.install()
-                    launchable('verify')
-                    launchable('record commit')
+                    withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
+                      launchable('verify')
+                      launchable('record commit')
+                    }
                   }
                 } else {
                   echo "Skipping static analysis results for ${stageIdentifier}"


### PR DESCRIPTION
Having created my second workspace in Launchable, I now realize that it was a mistake to include a `withCredentials` step as an implementation detail of the `launchable` step, since it precludes using multiple workspaces. To fix that, I would like to remove `withCredentials` from the implementation of `launchable`, pushing the responsibility to consumers. But before I can do that, I have to modify existing consumers to fulfill this new obligation. Once existing consumers are modified I will delete the `withCredentials` call from inside the `launchable` step, and then I can start using multiple workspaces. To test this I re-ran a `text-finder` plugin build with these changes successfully.