### PR TITLE
Require `launchable` step consumers to pass in credentials

### DIFF
--- a/test/groovy/LaunchableStepTests.groovy
+++ b/test/groovy/LaunchableStepTests.groovy
@@ -23,8 +23,6 @@ class LaunchableStepTests extends BaseTest {
         launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
         launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
         '''.stripIndent()))
-    // without using any credentials
-    assertTrue(assertMethodCallOccurrences('withCredentials', 0))
     // swallowing any errors that might occur
     assertTrue(assertMethodCall('catchError'))
     assertJobStatusSuccess()
@@ -35,8 +33,6 @@ class LaunchableStepTests extends BaseTest {
     def script = loadScript(scriptName)
     script.call("verify")
     printCallStack()
-    // then it uses the appropriate credentials
-    assertMethodCallContainsPattern('withCredentials', 'LAUNCHABLE_TOKEN')
     // swallowing any errors that might occur
     assertTrue(assertMethodCall('catchError'))
     // then it runs "launchable verify"
@@ -49,8 +45,6 @@ class LaunchableStepTests extends BaseTest {
     def script = loadScript(scriptName)
     script.call("record tests --no-build maven './**/target/surefire-reports'")
     printCallStack()
-    // then it uses the appropriate credentials
-    assertMethodCallContainsPattern('withCredentials', 'LAUNCHABLE_TOKEN')
     // swallowing any errors that might occur
     assertTrue(assertMethodCall('catchError'))
     // then it passes the arguments without escaping to the Launchable CLI

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -13,13 +13,11 @@ def install() {
 }
 
 def call(String args) {
-  withCredentials([string(credentialsId: 'launchable-prototype', variable: 'LAUNCHABLE_TOKEN')]) {
-    if (isUnix()) {
-      catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to run Launchable; continuing build.') {
-        sh 'launchable/bin/launchable ' + args
-      }
-    } else {
-      error 'The Launchable CLI is not yet implemented for Windows'
+  if (isUnix()) {
+    catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to run Launchable; continuing build.') {
+      sh 'launchable/bin/launchable ' + args
     }
+  } else {
+    error 'The Launchable CLI is not yet implemented for Windows'
   }
 }

--- a/vars/launchable.txt
+++ b/vars/launchable.txt
@@ -26,7 +26,9 @@
 
 <pre>
   launchable.install()
-  launchable("record tests --no-build maven './**/target/surefire-reports'")
+  withCredentials([string(credentialsId: 'my-id', variable: 'LAUNCHABLE_TOKEN')]) {
+    launchable("record tests --no-build maven './**/target/surefire-reports'")
+  }
 </pre>
 
 <!--


### PR DESCRIPTION
I have now created two Launchable workspaces and am planning to create a third soon. Since each one requires its own credentials, it does not make sense for this step to run its own `withCredentials` block internally. Instead I am delegating this to consumers as in #638, which this PR depends on.