### PR TITLE
update default JDK version

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -349,7 +349,7 @@ List<Map<String, String>> getConfigurations(Map params) {
   }
 
   def platforms = params.containsKey('platforms') ? params.platforms : ['linux', 'windows']
-  def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : ['8']
+  def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : ['11']
   def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]
 
   def ret = []


### PR DESCRIPTION
JDK 11 have been required as the default for newer plugins at what time is it good thing to switch this here in the buildPlugin?

It's been 4 almost 5 months since blog post about JDK 11

https://www.jenkins.io/blog/2022/12/14/require-java-11/