### PR TITLE
feat(artifact-caching-proxy): set `MAVEN_ARGS` env var

### DIFF
--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -322,6 +322,7 @@ class InfraStepTests extends BaseTest {
     // then it succeeds
     assertJobStatusSuccess()
   }
+
   @Test
   void testWithArtifactCachingProxyUnavailableRequestedProvider() throws Exception {
     def script = loadScript(scriptName)
@@ -457,27 +458,11 @@ class InfraStepTests extends BaseTest {
   @Test
   void testRunMavenWithArtifactCachingProxy() throws Exception {
     def script = loadScript(scriptName)
-    // mock a correctly configured artifact caching proxy provider
-    env.MAVEN_SETTINGS = "/tmp_path/settings.xml"
     // when running with useArtifactCachingProxy set to true
     script.runMaven(['clean verify'], 11, null, null, true)
     printCallStack()
-    // then it does notice a sh call with the settings.xml path
-    assertTrue(assertMethodCallContainsPattern('sh', '-s /tmp_path/settings.xml'))
-    // then it succeeds
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testRunMavenWithArtifactCachingProxyUnavailableSkippedOrNotReachable() throws Exception {
-    def script = loadScript(scriptName)
-    // mock an artifact caching proxy provider unavailable, skipped or unreachable
-    env.MAVEN_SETTINGS = null
-    // when running with useArtifactCachingProxy set to true
-    script.runMaven(['clean verify'], 11, null, null, true)
-    printCallStack()
-    // then it does not notice a sh call with "-s null"
-    assertFalse(assertMethodCallContainsPattern('sh', '-s null'))
+    // then it does notice a withEnv call with the MAVEN_ARGS env var containing settings.xml path
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'MAVEN_ARGS=-s /tmp/settings.xml'))
     // then it succeeds
     assertJobStatusSuccess()
   }
@@ -485,13 +470,11 @@ class InfraStepTests extends BaseTest {
   @Test
   void testRunMavenWithArtifactCachingProxyDisabled() throws Exception {
     def script = loadScript(scriptName)
-    // mock an artifact caching proxy disabled
-    env.MAVEN_SETTINGS = null
     // when running with useArtifactCachingProxy set to false
     script.runMaven(['clean verify'], 11, null, null, false)
     printCallStack()
-    // then it does not notice a sh call with "-s null"
-    assertFalse(assertMethodCallContainsPattern('sh', '-s null'))
+    // then it does not notice a withEnv call with the MAVEN_ARGS env var containing settings.xml path
+    assertFalse(assertMethodCallContainsPattern('withEnv', 'MAVEN_ARGS=-s /tmp/settings.xml'))
     // then it succeeds
     assertJobStatusSuccess()
   }

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -458,6 +458,8 @@ class InfraStepTests extends BaseTest {
   @Test
   void testRunMavenWithArtifactCachingProxy() throws Exception {
     def script = loadScript(scriptName)
+    // Mock an available artifact caching proxy
+    env.MAVEN_SETTINGS = '/tmp/settings.xml'
     // when running with useArtifactCachingProxy set to true
     script.runMaven(['clean verify'], 11, null, null, true)
     printCallStack()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -141,10 +141,9 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
   if (useArtifactCachingProxy) {
     echo "INFO: using artifact caching proxy from '${requestedProxyProvider}' provider."
     configFileProvider(
-        [configFile(fileId: "artifact-caching-proxy-${requestedProxyProvider}", targetLocation: '/tmp/settings.xml')]) {
+        [configFile(fileId: "artifact-caching-proxy-${requestedProxyProvider}", variable: 'MAVEN_SETTINGS')]) {
           withEnv([
-            'MAVEN_SETTINGS=/tmp/settings.xml',
-            'MAVEN_ARGS=-s /tmp/settings.xml',
+            "MAVEN_ARGS=-s $env.MAVEN_SETTINGS",
             "ARTIFACT_CACHING_PROXY_ORIGIN=https://repo.${requestedProxyProvider}.jenkins.io"
           ]) {
             body()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -165,7 +165,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
  * @see withArtifactCachingProxy
  */
 Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true) {
-  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors']
+  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors', '--no-transfer-progress']
   withArtifactCachingProxy(useArtifactCachingProxy) {
     mvnOptions.addAll(options)
     mvnOptions.unique()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -142,10 +142,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
     echo "INFO: using artifact caching proxy from '${requestedProxyProvider}' provider."
     configFileProvider(
         [configFile(fileId: "artifact-caching-proxy-${requestedProxyProvider}", variable: 'MAVEN_SETTINGS')]) {
-          withEnv([
-            "MAVEN_ARGS=-s $env.MAVEN_SETTINGS",
-            "ARTIFACT_CACHING_PROXY_ORIGIN=https://repo.${requestedProxyProvider}.jenkins.io"
-          ]) {
+          withEnv(["MAVEN_ARGS=-s $env.MAVEN_SETTINGS"]) {
             body()
           }
         }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -164,7 +164,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
  * @see withArtifactCachingProxy
  */
 Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true) {
-  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors']
+  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors', '--no-transfer-progress']
   withArtifactCachingProxy(useArtifactCachingProxy) {
     mvnOptions.addAll(options)
     mvnOptions.unique()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -164,7 +164,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
  * @see withArtifactCachingProxy
  */
 Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true) {
-  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors', '--no-transfer-progress']
+  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors']
   withArtifactCachingProxy(useArtifactCachingProxy) {
     mvnOptions.addAll(options)
     mvnOptions.unique()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -165,7 +165,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
  * @see withArtifactCachingProxy
  */
 Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true) {
-  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors', '--no-transfer-progress']
+  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors']
   withArtifactCachingProxy(useArtifactCachingProxy) {
     mvnOptions.addAll(options)
     mvnOptions.unique()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -141,8 +141,14 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
   if (useArtifactCachingProxy) {
     echo "INFO: using artifact caching proxy from '${requestedProxyProvider}' provider."
     configFileProvider(
-        [configFile(fileId: "artifact-caching-proxy-${requestedProxyProvider}", variable: 'MAVEN_SETTINGS')]) {
-          body()
+        [configFile(fileId: "artifact-caching-proxy-${requestedProxyProvider}", targetLocation: '/tmp/settings.xml')]) {
+          withEnv([
+            'MAVEN_SETTINGS=/tmp/settings.xml',
+            'MAVEN_ARGS=-s /tmp/settings.xml',
+            "ARTIFACT_CACHING_PROXY_ORIGIN=https://repo.${requestedProxyProvider}.jenkins.io"
+          ]) {
+            body()
+          }
         }
   } else {
     body()
@@ -161,12 +167,6 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
 Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true) {
   List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors', '--no-transfer-progress']
   withArtifactCachingProxy(useArtifactCachingProxy) {
-    // If an artifact caching proxy provider has been correctly configured,
-    // add the corresponding settings.xml path stored in MAVEN_SETTINGS env var
-    // by the config file provider to Maven options
-    if (env.MAVEN_SETTINGS) {
-      mvnOptions += "-s $env.MAVEN_SETTINGS"
-    }
     mvnOptions.addAll(options)
     mvnOptions.unique()
     String command = "mvn ${mvnOptions.join(' ')}"

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -49,6 +49,7 @@
     The available providers can be restricted by setting a global ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS
     variable on the Jenkins controller, with providers separated by a comma. Ex: 'aws,do' if the Azure provider is unavailable.
     A 'skip-artifact-caching-proxy' label can be added to pull request in order to punctually disable it.
+    When calling this function with its boolean parameter to false, it does nothing.
 </p>
 
 <p>


### PR DESCRIPTION
As suggested by @jglick in https://github.com/jenkinsci/bom/pull/1955#discussion_r1163088843 and as this env var isn't used in any @jenkinsci or @jenkins-infra repositories and is [supported since Maven 3.9.0](https://maven.apache.org/configure.html#maven_args-environment-variable), we can set it to make the settings file be used automatically.

