### PR TITLE
fix(buildDockerAndPublish) `Makefile`: use modern Docker commands + apply shell best practises

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -8,17 +8,17 @@ else
 endif
 
 IMAGE_NAME ?= helloworld
-IMAGE_DEPLOY_NAME ?= $(IMAGE_NAME)
+IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
 IMAGE_PLATFORM ?= linux/amd64
 # Paths
-IMAGE_DOCKERFILE ?= $(IMAGE_DIR)/Dockerfile
-HADOLINT_REPORT ?= $(IMAGE_DIR)/hadolint.json
-TEST_HARNESS ?= $(IMAGE_DIR)/cst.yml
+IMAGE_DOCKERFILE ?= "$(IMAGE_DIR)"/Dockerfile
+HADOLINT_REPORT ?= "$(IMAGE_DIR)"/hadolint.json
+TEST_HARNESS ?= "$(IMAGE_DIR)"/cst.yml
 
 ## Image metadatas
 GIT_COMMIT_REV ?= $(shell git log -n 1 --pretty=format:'%h')
 GIT_SCM_URL ?= $(shell git config --get remote.origin.url)
-SCM_URI ?= $(subst git@github.com:,https://github.com/,$(GIT_SCM_URL))
+SCM_URI ?= $(subst git@github.com:,https://github.com/,"$(GIT_SCM_URL)")
 BUILD_DATE ?= $(shell date --utc '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || gdate --utc '+%Y-%m-%dT%H:%M:%S')
 
 help: ## Show this Makefile's help
@@ -35,7 +35,7 @@ lint: ## Lint the $(IMAGE_DOCKERFILE) content
 build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 	@echo "== Building $(IMAGE_NAME) from $(call FixPath,$(IMAGE_DOCKERFILE)) with docker:"
 	docker build \
-		--tag $(IMAGE_NAME) \
+		--tag "$(IMAGE_NAME)" \
 		--build-arg "GIT_COMMIT_REV=$(GIT_COMMIT_REV)" \
 		--build-arg "GIT_SCM_URL=$(GIT_SCM_URL)" \
 		--build-arg "BUILD_DATE=$(BUILD_DATE)" \
@@ -47,7 +47,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 		--label "org.label-schema.vcs-ref=$(GIT_COMMIT_REV)" \
 		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
 		--label "org.label-schema.build-date=$(BUILD_DATE)" \
-		--platform $(IMAGE_PLATFORM) \
+		--platform "$(IMAGE_PLATFORM)" \
 		--file "$(call FixPath,$(IMAGE_DOCKERFILE))" \
 		"$(IMAGE_DIR)"
 	@echo "== Build succeeded"
@@ -65,8 +65,8 @@ test: ## Execute the test harness on the Docker Image
 ## This steps expects that you are logged to the Docker registry to push image into
 deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 	@echo "== Deploying $(IMAGE_NAME) to $(IMAGE_DEPLOY_NAME) with docker:"
-	docker tag $(IMAGE_NAME) $(IMAGE_DEPLOY_NAME)
-	docker push $(IMAGE_DEPLOY_NAME)
+	docker tag "$(IMAGE_NAME)" "$(IMAGE_DEPLOY_NAME)"
+	docker push "$(IMAGE_DEPLOY_NAME)"
 	@echo "== Deploy succeeded"
 
 .PHONY: all clean lint build test deploy

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -34,7 +34,7 @@ lint: ## Lint the $(IMAGE_DOCKERFILE) content
 
 build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 	@echo "== Building $(IMAGE_NAME) from $(call FixPath,$(IMAGE_DOCKERFILE)) with docker:"
-	docker build \
+	docker image build \
 		--tag "$(IMAGE_NAME)" \
 		--build-arg "GIT_COMMIT_REV=$(GIT_COMMIT_REV)" \
 		--build-arg "GIT_SCM_URL=$(GIT_SCM_URL)" \
@@ -65,8 +65,8 @@ test: ## Execute the test harness on the Docker Image
 ## This steps expects that you are logged to the Docker registry to push image into
 deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 	@echo "== Deploying $(IMAGE_NAME) to $(IMAGE_DEPLOY_NAME) with docker:"
-	docker tag "$(IMAGE_NAME)" "$(IMAGE_DEPLOY_NAME)"
-	docker push "$(IMAGE_DEPLOY_NAME)"
+	docker image tag "$(IMAGE_NAME)" "$(IMAGE_DEPLOY_NAME)"
+	docker image push "$(IMAGE_DEPLOY_NAME)"
 	@echo "== Deploy succeeded"
 
 .PHONY: all clean lint build test deploy


### PR DESCRIPTION
This PR applies 2the following changes to the `Makefile` used to build/test/deploy Docker images on the infrastructure:

- shell best practise "use double quote on variables that could have special characters" which should fix https://github.com/jenkins-infra/jenkins-infra/pull/2752#issuecomment-1504801011
- Use `docker image` modern commands to avoid any kind of depreciation in Windows environment (premature change)

Since the version [`1.0.0`](https://github.com/jenkins-infra/packer-images/releases/tag/1.1.0) introducing an explicit installation of Docker CE 23.x on Windows, some `PATH` changes were introduced.

It results in GNU `make` being used with an Unix context (is it MinGit, Cygwin, cholocatey? not sure to be transparent).
=> When `make` spawns a command, the command must be unix shell compliant.
