### PR TITLE
feat: activate `launchable` in `buildPlugin` on Windows, remove `launchable.install` from `buildPlugin` and add corresponding deprecation notice

### DIFF
--- a/test/groovy/LaunchableStepTests.groovy
+++ b/test/groovy/LaunchableStepTests.groovy
@@ -1,10 +1,13 @@
 import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
 
 import org.junit.Before
 import org.junit.Test
 
 class LaunchableStepTests extends BaseTest {
   static final String scriptName = 'vars/launchable.groovy'
+  static final String checkAlreadyInstalledScriptSh = 'command -v launchable'
+  static final String checkAlreadyInstalledScriptBat = 'launchable --version 2>NUL || echo "NOT_INSTALLED"'
 
   @Override
   @Before
@@ -13,8 +16,42 @@ class LaunchableStepTests extends BaseTest {
   }
 
   @Test
-  void test_launchable_install() throws Exception {
+  void test_launchable_install_already_installed() throws Exception {
     def script = loadScript(scriptName)
+    // when Launchable is already installed
+    helper.addShMock(checkAlreadyInstalledScriptSh, '', 0)
+    helper.addBatMock(checkAlreadyInstalledScriptBat, { aScript -> return [stdout: 'a_version', exitValue: 0] })
+
+    script.install()
+    printCallStack()
+    // then it does not install Launchable
+    assertFalse(assertMethodCallContainsPattern('sh', '''
+        python3 -m venv launchable
+        launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
+        launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
+        ln -s launchable/bin/launchable /urs/local/bin/launchable
+        '''.stripIndent())
+        ||
+        assertMethodCallContainsPattern('bat', '''
+        python.exe -m pip --no-cache-dir install --upgrade setuptools wheel pip
+        python.exe -m pip --no-cache-dir install launchable
+        '''.stripIndent())
+    )
+
+    // swallowing any errors that might occur
+    assertTrue(assertMethodCall('catchError'))
+    // then it notices that Launchable is already installed
+    assertTrue(assertMethodCallContainsPattern('echo', 'NOTICE: Launchable is already installed.'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_launchable_install_not_already_installed() throws Exception {
+    def script = loadScript(scriptName)
+    // when Launchable is not already installed
+    helper.addShMock(checkAlreadyInstalledScriptSh, '', 1)
+    helper.addBatMock(checkAlreadyInstalledScriptBat, { aScript -> return [stdout: 'NOT_INSTALLED', exitValue: 0] })
+
     script.install()
     printCallStack()
     // then it installs Launchable
@@ -22,9 +59,19 @@ class LaunchableStepTests extends BaseTest {
         python3 -m venv launchable
         launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
         launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
-        '''.stripIndent()))
+        ln -s launchable/bin/launchable /urs/local/bin/launchable
+        '''.stripIndent())
+        ||
+        assertMethodCallContainsPattern('bat', '''
+        python.exe -m pip --no-cache-dir install --upgrade setuptools wheel pip
+        python.exe -m pip --no-cache-dir install launchable
+        '''.stripIndent())
+    )
+
     // swallowing any errors that might occur
     assertTrue(assertMethodCall('catchError'))
+    // then it does not notice that Launchable is already installed
+    assertFalse(assertMethodCallContainsPattern('echo', 'NOTICE: Launchable is already installed.'))
     assertJobStatusSuccess()
   }
 

--- a/test/groovy/LaunchableStepTests.groovy
+++ b/test/groovy/LaunchableStepTests.groovy
@@ -41,7 +41,7 @@ class LaunchableStepTests extends BaseTest {
     // swallowing any errors that might occur
     assertTrue(assertMethodCall('catchError'))
     // then it notices that Launchable is already installed
-    assertTrue(assertMethodCallContainsPattern('echo', 'NOTICE: Launchable is already installed.'))
+    assertTrue(assertMethodCallContainsPattern('echo', 'DEPRECATION NOTICE: Launchable is already installed, no need to run "launchable.install"'))
     assertJobStatusSuccess()
   }
 
@@ -71,7 +71,7 @@ class LaunchableStepTests extends BaseTest {
     // swallowing any errors that might occur
     assertTrue(assertMethodCall('catchError'))
     // then it does not notice that Launchable is already installed
-    assertFalse(assertMethodCallContainsPattern('echo', 'NOTICE: Launchable is already installed.'))
+    assertFalse(assertMethodCallContainsPattern('echo', 'DEPRECATION NOTICE: Launchable is already installed, no need to run "launchable.install"'))
     assertJobStatusSuccess()
   }
 

--- a/test/groovy/LaunchableStepTests.groovy
+++ b/test/groovy/LaunchableStepTests.groovy
@@ -36,7 +36,7 @@ class LaunchableStepTests extends BaseTest {
         python.exe -m pip --no-cache-dir install --upgrade setuptools wheel pip
         python.exe -m pip --no-cache-dir install launchable
         '''.stripIndent())
-    )
+        )
 
     // swallowing any errors that might occur
     assertTrue(assertMethodCall('catchError'))
@@ -66,7 +66,7 @@ class LaunchableStepTests extends BaseTest {
         python.exe -m pip --no-cache-dir install --upgrade setuptools wheel pip
         python.exe -m pip --no-cache-dir install launchable
         '''.stripIndent())
-    )
+        )
 
     // swallowing any errors that might occur
     assertTrue(assertMethodCall('catchError'))

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -277,10 +277,9 @@ def call(Map params = [:]) {
                    * the result can be consumed by a Launchable build in the future. We do not
                    * attempt to record commits for non-incrementalified plugins because such
                    * plugins' PR builds could not be consumed by anything else anyway, and all
-                   * plugins currently in the BOM are incrementalified. We do not attempt to record
-                   * commits on Windows because our Windows agents do not have Python installed.
+                   * plugins currently in the BOM are incrementalified.
                    */
-                  if (incrementals && platform != 'windows' && currentBuild.currentResult == 'SUCCESS') {
+                  if (incrementals && currentBuild.currentResult == 'SUCCESS') {
                     launchable.install()
                     withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
                       launchable('verify')

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -280,7 +280,6 @@ def call(Map params = [:]) {
                    * plugins currently in the BOM are incrementalified.
                    */
                   if (incrementals && currentBuild.currentResult == 'SUCCESS') {
-                    launchable.install()
                     withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
                       launchable('verify')
                       launchable('record commit')

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -44,7 +44,7 @@ def call(String args) {
       currentBuild.result = 'SUCCESS'
       echo 'Failed to run Launchable; continuing build.'
     } finally {
-      def errorsCount = bat(script: 'type ' + launchableStderrFile + ' | find /c /v ""', returnStdout: true)
+      def errorsCount = pwsh(script: "(Get-Content $launchableStderrFile).Length", returnStdout: true)
       echo "laucnhable errors count: $errorsCount"
       if (errorsCount > 2) {
         echo 'Launchable errors log (please ignore the two first lines); continuing build.'

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -44,11 +44,11 @@ def call(String args) {
       currentBuild.result = 'SUCCESS'
       echo 'Failed to run Launchable; continuing build.'
     } finally {
-      def errorsCount = Integer.parseInt(pwsh(script: "(Get-Content $launchableStderrFile | Select-Object -Skip 2) | Set-Content $launchableStderrFile; (Get-Content $launchableStderrFile).Length", returnStdout: true))
+      def errorsCount = Integer.parseInt(pwsh(script: "(Get-Content $launchableStderrFile).Length", returnStdout: true).trim())
       echo "launchable errors count: $errorsCount"
       if (errorsCount > 2) {
-        echo 'Launchable errors log (please ignore the two first lines); continuing build.'
-        bat 'type ' + launchableStderrFile
+        echo 'Launchable errors log below; continuing build.'
+        pwsh(script: "(Get-Content launchable.stderr | Select-Object -Skip 2)", returnStdout: false)
       }
     }
   }

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -44,8 +44,8 @@ def call(String args) {
       currentBuild.result = 'SUCCESS'
       echo 'Failed to run Launchable; continuing build.'
     } finally {
-      def errorsCount = pwsh(script: "(Get-Content $launchableStderrFile).Length", returnStdout: true)
-      echo "laucnhable errors count: $errorsCount"
+      def errorsCount = Integer.parseInt(pwsh(script: "(Get-Content $launchableStderrFile | Select-Object -Skip 2) | Set-Content $launchableStderrFile; (Get-Content $launchableStderrFile).Length", returnStdout: true))
+      echo "launchable errors count: $errorsCount"
       if (errorsCount > 2) {
         echo 'Launchable errors log (please ignore the two first lines); continuing build.'
         bat 'type ' + launchableStderrFile

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -45,10 +45,9 @@ def call(String args) {
       echo 'Failed to run Launchable; continuing build.'
     } finally {
       def errorsCount = Integer.parseInt(pwsh(script: "(Get-Content $launchableStderrFile).Length", returnStdout: true).trim())
-      echo "launchable errors count: $errorsCount"
       if (errorsCount > 2) {
         echo 'Launchable errors log below; continuing build.'
-        pwsh(script: "(Get-Content launchable.stderr | Select-Object -Skip 2)", returnStdout: false)
+        pwsh "(Get-Content launchable.stderr | Select-Object -Skip 2)"
       }
     }
   }

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -45,6 +45,9 @@ def call(String args) {
       echo 'Failed to run Launchable; continuing build.'
     } finally {
       def errorsCount = Integer.parseInt(pwsh(script: "(Get-Content $launchableStderrFile).Length", returnStdout: true).trim())
+      // Log only if there are more than the two errors "pythoncom error: CoInitializeEx failed (0x80004001)" & "pythoncom error: OLE initialization failed! (0x80004005)"
+      // due to Nano Server used in docker-inbound-agent
+      // TODO rework when switching to Windows Server images instead of Nano Server images
       if (errorsCount > 2) {
         echo 'Launchable errors log below; continuing build.'
         pwsh "(Get-Content launchable.stderr | Select-Object -Skip 2)"

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -14,7 +14,7 @@ def install() {
     }
   } else {
     catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to install Launchable; continuing build.') {
-      if (bat(script: 'launchable --version 2>NUL || echo "NOT_INSTALLED"', returnStdout: true) == 'NOT_INSTALLED') {
+      if (bat(script: 'python -m launchable -version 2>NUL || echo "NOT_INSTALLED"', returnStdout: true) == 'NOT_INSTALLED') {
         bat '''
             python.exe -m pip --no-cache-dir install --upgrade setuptools wheel pip
             python.exe -m pip --no-cache-dir install launchable
@@ -24,7 +24,7 @@ def install() {
     }
   }
   if (alreadyInstalled) {
-    echo 'NOTICE: Launchable is already installed.'
+    echo 'DEPRECATION NOTICE: Launchable is already installed, no need to run "launchable.install"'
   }
 }
 
@@ -35,7 +35,9 @@ def call(String args) {
     }
   } else {
     catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to run Launchable; continuing build.') {
-      bat 'launchable ' + args
+      // Avoid logging the errors due to Nano server used in docker-inbound-agent
+      // TODO remove ' 2>NUL' when switching to Windows Server images instead of Nano Server images
+      bat 'python -m launchable ' + args + ' 2>NUL'
     }
   }
 }

--- a/vars/launchable.groovy
+++ b/vars/launchable.groovy
@@ -1,23 +1,41 @@
 def install() {
+  boolean alreadyInstalled = true
   if (isUnix()) {
     catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to install Launchable; continuing build.') {
-      sh '''
-          python3 -m venv launchable
-          launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
-          launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
-         '''.stripIndent()
+      if (sh(script: 'command -v launchable', returnStatus: true) != 0) {
+        sh '''
+            python3 -m venv launchable
+            launchable/bin/pip --require-virtualenv --no-cache-dir install -U setuptools wheel
+            launchable/bin/pip --require-virtualenv --no-cache-dir install launchable
+            ln -s launchable/bin/launchable /urs/local/bin/launchable
+            '''.stripIndent()
+        alreadyInstalled = false
+      }
     }
   } else {
-    error 'Launchable installation is not yet implemented for Windows'
+    catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to install Launchable; continuing build.') {
+      if (bat(script: 'launchable --version 2>NUL || echo "NOT_INSTALLED"', returnStdout: true) == 'NOT_INSTALLED') {
+        bat '''
+            python.exe -m pip --no-cache-dir install --upgrade setuptools wheel pip
+            python.exe -m pip --no-cache-dir install launchable
+          '''.stripIndent()
+        alreadyInstalled = false
+      }
+    }
+  }
+  if (alreadyInstalled) {
+    echo 'NOTICE: Launchable is already installed.'
   }
 }
 
 def call(String args) {
   if (isUnix()) {
     catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to run Launchable; continuing build.') {
-      sh 'launchable/bin/launchable ' + args
+      sh 'launchable ' + args
     }
   } else {
-    error 'The Launchable CLI is not yet implemented for Windows'
+    catchError(buildResult: 'SUCCESS', catchInterruptions: false, message: 'Failed to run Launchable; continuing build.') {
+      bat 'launchable ' + args
+    }
   }
 }


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/packer-images/pull/605 & https://github.com/jenkins-infra/docker-inbound-agents/pull/71

As Launchable is now available on every agent, this PR:
- activate `launchable` on Windows builds
- removes `launchable.install` from `buildPlugin`
- add a deprecation notice when `launchable.install` is called

Tested in https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/82

Ref: https://github.com/jenkins-infra/helpdesk/issues/3484