### PR TITLE
fix(terraform): add toleration to use infracipool

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -147,6 +147,11 @@ def agentTemplate(containerImage, body) {
       kind: Pod
       spec:
         automountServiceAccountToken: false
+        tolerations:
+        - key: "jenkins"
+          operator: "Equal"
+          value: "infra.ci.jenkins.io"
+          effect: "NoSchedule"
       resources:
         limits:
           cpu: 2


### PR DESCRIPTION
To avoid cutting off the branch we're sitting on when modifying privatek8s node pools (ex: https://github.com/jenkins-infra/azure/pull/329 and its infra.ci.jenkins.io job which ran on the "linuxpool" node pool impacted by this change), this PR sets a toleration so terraform jobs will run on infracipool only.