### PR TITLE
Remove use of Launchable shared library functionality

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -1,6 +1,5 @@
 import mock.CurrentBuild
 import mock.Infra
-import mock.Launchable
 import org.junit.Before
 import org.junit.Test
 import static org.junit.Assert.assertEquals
@@ -369,12 +368,10 @@ class BuildPluginStepTests extends BaseTest {
   @Test
   void test_buildPlugin_with_configurations_and_incrementals() throws Exception {
     def script = loadScript(scriptName)
-    binding.setProperty('launchable', new Launchable())
     // when running with incrementals
     helper.registerAllowedMethod('fileExists', [String.class], { s ->
       return s.equals('.mvn/extensions.xml') || s.equals('pom.xml')
     })
-    helper.registerAllowedMethod('launchable', [String.class], null)
     helper.addReadFileMock('.mvn/extensions.xml', 'git-changelist-maven-extension')
     // and no jenkins version
     script.call(configurations: [['platform': 'linux', 'jdk': 8, 'jenkins': null]])

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -279,10 +279,14 @@ def call(Map params = [:]) {
                    * plugins' PR builds could not be consumed by anything else anyway, and all
                    * plugins currently in the BOM are incrementalified.
                    */
-                  if (incrementals && currentBuild.currentResult == 'SUCCESS') {
+                  if (incrementals && currentBuild.currentResult == 'SUCCESS' && useContainerAgent) {
                     withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
-                      launchable('verify')
-                      launchable('record commit')
+                      if (isUnix()) {
+                        sh 'launchable verify && launchable record commit'
+                      } else {
+                        // TODO launchable.exe still not working for some reason
+                        bat 'python -m launchable verify && python -m launchable record commit'
+                      }
                     }
                   }
                 } else {


### PR DESCRIPTION
Now that Launchable is installed on our container agents, there is no longer a need to use the Launchable shared library, which is slower and flakier.

Note that Jenkins core is still consuming the shared library. I plan to remove consumption from there. Once that consumption is removed (and backported!) I plan to delete `test/groovy/LaunchableStepTests.groovy`, `vars/launchable.groovy`, and `vars/launchable.txt` from this repository.

### Testing done

`buildPlugin`: https://ci.jenkins.io/job/Plugins/job/text-finder-plugin/job/PR-172/18/ (Linux) and https://ci.jenkins.io/job/Plugins/job/text-finder-plugin/job/PR-172/19/ (Windows)