### PR TITLE
Unify Launchable invocation between Linux and Windows

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -284,8 +284,7 @@ def call(Map params = [:]) {
                       if (isUnix()) {
                         sh 'launchable verify && launchable record commit'
                       } else {
-                        // TODO launchable.exe still not working for some reason
-                        bat 'python -m launchable verify && python -m launchable record commit'
+                        bat 'launchable verify && launchable record commit'
                       }
                     }
                   }


### PR DESCRIPTION
Adapting to https://github.com/jenkins-infra/helpdesk/issues/3484#issuecomment-1555119777. Tested in `text-finder-plugin` by running `launchable verify` successfully on a Windows container agent.