### PR TITLE
feat(updatecli): add `debug` parameter

### DIFF
--- a/test/groovy/UpdatecliStepTests.groovy
+++ b/test/groovy/UpdatecliStepTests.groovy
@@ -65,25 +65,6 @@ class UpdatecliStepTests extends BaseTest {
   }
 
   @Test
-  void itRunSuccessfullyWithCustomActionAndDebugOptionActivated() throws Exception {
-    def script = loadScript(scriptName)
-
-    // when calling the "updatecli" function with a custom action "eat"
-    script.call(action: 'eat', debug: true)
-    printCallStack()
-
-    // Then we expect a successful build
-    assertJobStatusSuccess()
-
-    // And the repository checkouted
-    assertTrue(assertMethodCallContainsPattern('checkout',''))
-
-    // And only the custom command called with default values
-    assertFalse(assertMethodCallContainsPattern('sh','updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.yaml --debug'))
-    assertTrue(assertMethodCallContainsPattern('sh','updatecli eat --config ./updatecli/updatecli.d --values ./updatecli/values.yaml --debug'))
-  }
-
-  @Test
   void itRunSuccessfullyWithCustomConfigAndEmptyValues() throws Exception {
     def script = loadScript(scriptName)
 
@@ -162,5 +143,23 @@ class UpdatecliStepTests extends BaseTest {
 
     // And the custom credentialsId is taken in account
     assertTrue(assertMethodCallContainsPattern('usernamePassword', "credentialsId=${anotherCredentialsId}"))
+  }
+
+  @Test
+  void itRunSuccessfullyWithDebugActivated() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling the "updatecli" function with "debug" set to true
+    script.call(debug: true)
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // And the repository checkouted
+    assertTrue(assertMethodCallContainsPattern('checkout',''))
+
+    // And only the custom command called with default values and the debug flag
+    assertTrue(assertMethodCallContainsPattern('sh','updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.yaml --debug'))
   }
 }

--- a/test/groovy/UpdatecliStepTests.groovy
+++ b/test/groovy/UpdatecliStepTests.groovy
@@ -65,6 +65,25 @@ class UpdatecliStepTests extends BaseTest {
   }
 
   @Test
+  void itRunSuccessfullyWithCustomActionAndDebugOptionActivated() throws Exception {
+    def script = loadScript(scriptName)
+
+    // when calling the "updatecli" function with a custom action "eat"
+    script.call(action: 'eat', debug: true)
+    printCallStack()
+
+    // Then we expect a successful build
+    assertJobStatusSuccess()
+
+    // And the repository checkouted
+    assertTrue(assertMethodCallContainsPattern('checkout',''))
+
+    // And only the custom command called with default values
+    assertFalse(assertMethodCallContainsPattern('sh','updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.yaml --debug'))
+    assertTrue(assertMethodCallContainsPattern('sh','updatecli eat --config ./updatecli/updatecli.d --values ./updatecli/values.yaml --debug'))
+  }
+
+  @Test
   void itRunSuccessfullyWithCustomConfigAndEmptyValues() throws Exception {
     def script = loadScript(scriptName)
 

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -7,6 +7,7 @@ def call(userConfig = [:]) {
     action: 'diff', // Updatecli subcommand to execute
     config: './updatecli/updatecli.d', // Config manifest used by updatecli (can be a file or a directory)
     values: './updatecli/values.yaml', // Values file used by updatecli
+    debug: false, // Debug output
     updatecliDockerImage: 'jenkinsciinfra/helmfile:2.5.94', // Container image to use for running updatecli
     containerMemory: '512Mi', // When using 'updatecliDockerImage', this is the memory limit+request of the container
     cronTriggerExpression: '', // When specified, it enables cron trigger for the calling pipeline
@@ -23,6 +24,8 @@ def call(userConfig = [:]) {
   updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ''
   // Do not add the flag "--values" if the provided value is "empty string"
   updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ''
+  // Do not add the flag "--debug" if the provided value is "empty string" or false
+  updatecliCommand += finalConfig.debug ? " --debug" : ''
 
   // Define a cron trigger only if requested by the user through attribute
   if (finalConfig.cronTriggerExpression) {

--- a/vars/updatecli.txt
+++ b/vars/updatecli.txt
@@ -8,6 +8,7 @@
       <li>String action: (Optional - Default: "diff") Updatecli action (e.g. subcommand) to execute.</li>
       <li>String config: (Optional - Default: "./updatecli/updatecli.d") path to the file or directory with the updatecli configuration (flag "--config").</li>
       <li>String values: (Optional - Default: "./updatecli/values.yaml") path to the file with the updatecli values (flag "--values").</li>
+      <li>String debug: (Optional - Default: false) set to true to activate debug output (flag "--debug").</li>
       <li>String updatecliDockerImage: (Optional - Default: "jenkinsciinfra/helmfile:2.5.94") Docker Image of updatecli to be used in the process.</li>
       <li>String cronTriggerExpression: (Optional - Default: "") Enable periodic execution by providing a cron-like expression.</li>
       <li>String containerMemory: (Optional - Default: "512Mi") specify the amount of memory dedicated to the updatecli container.</li>


### PR DESCRIPTION
This PR add the `debug` parameter (set to `false` by default) so we can activate the debug output (by adding `--debug` to the CLI call)

Tested in https://github.com/jenkins-infra/docker-inbound-agents/pull/87 (commit https://github.com/jenkins-infra/docker-inbound-agents/pull/87/commits/dd3eb0051715b70f2f0e726b8ccadcb5d113a0f4)