### PR TITLE
Remove deprecated 'recommendedConfigurations'

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -384,10 +384,3 @@ List<Map<String, String>> getConfigurations(Map params) {
   }
   return ret
 }
-
-/**
- * @deprecated no longer recommended
- */
-static List<Map<String, String>> recommendedConfigurations() {
-  null
-}


### PR DESCRIPTION
The config option has been deprecated since 2020. 3 years later, I'd propose to remove it, as I see this dated config option in hosting requests still frequently, likely copied from other plugins.

I have proposed PRs to all repositories using this configuration to move away from the deprecated syntax, building the entry point for a smooth transition.