### PR TITLE
Remove support for Gradle from `buildPlugin`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,8 +12,6 @@ Check link:https://github.com/jenkins-infra/documentation/blob/master/ci.adoc[th
 
 === buildPlugin
 
-WARNING: Gradle support in `buildPlugin()` is deprecated and will be eventually removed. Please use `buildPluginWithGradle()`
-
 Applies the appropriate defaults for building a Maven-based plugin project on
 Linux and Windows.
 

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -198,34 +198,6 @@ class BuildPluginStepTests extends BaseTest {
   }
 
   @Test
-  void test_buildPlugin_with_defaults_with_gradle() throws Exception {
-    def script = loadScript(scriptName)
-    // when running in a non maven project
-    helper.registerAllowedMethod('fileExists', [String.class], { s -> return !s.equals('pom.xml') })
-    script.call([:])
-    printCallStack()
-    // then it runs the junit step with the no maven test format
-    assertTrue(assertMethodCallContainsPattern('junit', '**/build/test-results/**/*.xml'))
-  }
-
-  @Test
-  void test_buildPlugin_with_build_error_with_gradle() throws Exception {
-    def script = loadScript(scriptName)
-    binding.setProperty('infra', new Infra(buildError: true))
-    // when running in a non maven project
-    helper.registerAllowedMethod('fileExists', [String.class], { s -> return !s.equals('pom.xml') })
-    try {
-      script.call([:])
-    } catch (ignored) {
-      // intentionally left empty
-    }
-    printCallStack()
-    // it runs the junit step
-    assertTrue(assertMethodCall('junit'))
-    assertJobStatusFailure()
-  }
-
-  @Test
   void test_buildPlugin_with_failfast_and_unstable() throws Exception {
     def script = loadScript(scriptName)
     // when running with fail fast and it's UNSTABLE

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -277,8 +277,7 @@ def call(Map params = [:]) {
                     publishingIncrementals = true
                   } else {
                     String artifacts
-                    artifacts = '**/target/*.hpi,**/target/*.jpi,**/target/*.jar'
-                    archiveArtifacts artifacts: artifacts, fingerprint: true
+                    archiveArtifacts artifacts: '**/target/*.hpi,**/target/*.jpi,**/target/*.jar', fingerprint: true
                   }
                 }
               }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -276,7 +276,6 @@ def call(Map params = [:]) {
                     }
                     publishingIncrementals = true
                   } else {
-                    String artifacts
                     archiveArtifacts artifacts: '**/target/*.hpi,**/target/*.jpi,**/target/*.jar', fingerprint: true
                   }
                 }


### PR DESCRIPTION
Support for Gradle in buildPlugin has been deprecated for more than 4 years. I'd propose to remove its support from buildPlugin, in favor of buildPluginWithGradle.

I've proposed PRs updating the existing repositories from buildPlugin to buildPluginWithGradle, builds are successful this time ;)