### PR TITLE
Remove deprecated 'useAci' parameter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,6 @@ buildPlugin(
 * `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
 * `useContainerAgent` (default: `false`) - uses a link:https://github.com/jenkins-infra/documentation/blob/main/ci.adoc#container-agents[Container agent] instead of a Virtual Machine: usually faster to start and generates less costs for the project
 ** Please note that the implementation of "containers" can be changed over time
-* `useAci` (DEPRECATED - see `useContainerAgent`)
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -15,10 +15,6 @@ def call(Map params = [:]) {
   def useArtifactCachingProxy = params.containsKey('useArtifactCachingProxy') ? params.useArtifactCachingProxy : true
 
   def useContainerAgent = params.containsKey('useContainerAgent') ? params.useContainerAgent : false
-  if (params.containsKey('useAci')) {
-    infra.publishDeprecationCheck('Replace useAci with useContainerAgent', 'The parameter "useAci" is deprecated. Please use "useContainerAgent" instead as per https://issues.jenkins.io/browse/INFRA-2918.')
-    useContainerAgent = params.containsKey('useAci')
-  }
   if (timeoutValue > 180) {
     echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
     timeoutValue = 180


### PR DESCRIPTION
2 years after deprecation, I propose to remove the parameter. I've filed merge-ready PRs, porting the leftover references.