### PR TITLE
Remove EOL `javaLevel` syntax

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -28,9 +28,6 @@ def call(Map params = [:]) {
     String platform = config.platform
     String jdk = config.jdk
     String jenkinsVersion = config.jenkins
-    if (config.containsKey('javaLevel')) {
-      infra.publishDeprecationCheck('Remove javaLevel', 'Ignoring deprecated "javaLevel" parameter. This parameter should be removed from your "Jenkinsfile".')
-    }
 
     String stageIdentifier = "${platform}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
     boolean first = tasks.size() == 1

--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -45,9 +45,6 @@ def call(Map params = [:]) {
 
           stage("Build (${stageIdentifier})") {
             m2repo = "${pwd tmp: true}/m2repo"
-            if (config.containsKey('javaLevel')) {
-              infra.publishDeprecationCheck('Remove javaLevel', 'Ignoring deprecated "javaLevel" parameter. This parameter should be removed from your "Jenkinsfile".')
-            }
             //TODO(oleg-nenashev): Once supported by Gradle JPI Plugin, pass jenkinsVersion
             if (jenkinsVersion) {
               infra.publishDeprecationCheck('Remove jenkinsVersion', 'The "jenkinsVersion" parameter is not supported in buildPluginWithGradle(). It will be ignored.')


### PR DESCRIPTION
I'd like to propose the EOL javaLevel syntax. It's flagged like that since 2021. I've submitted the necessary PRs in a merge-ready state, migrating away from this build logic.