### PR TITLE
Skip Incrementals deployment for branch build of CD-enabled repo

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -343,11 +343,13 @@ void prepareToPublishIncrementals() {
 void maybePublishIncrementals() {
   if (new InfraConfig(env).isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
     if (env.CHANGE_ID == null) {
+      def skip
       catchError(message: 'Could not check whether repo has enabled CD', buildResult: 'SUCCESS', stageResult: 'UNSTABLE', catchInterruptions: false) {
-        if (readTrusted('.mvn/maven.config').contains('changelist.format')) {
-          echo 'Skipping Incrementals deployment for branch build of CD-enabled repo (helpdesk#3687)'
-          return
-        }
+        skip = readTrusted('.mvn/maven.config').contains('changelist.format')
+      }
+      if (skip) {
+        echo 'Skipping Incrementals deployment for branch build of CD-enabled repo (helpdesk#3687)'
+        return
       }
     }
     stage('Deploy') {


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/helpdesk/issues/3687. Not sure whether it is feasible to test something like this in advance. @timja can the infra test plugin be set up to pick up this PR throughout a plugin PR test, merge, and release cycle? Would still not be verifying that there is no behavioral change for a non-CD repo like `jenkinsci/jenkins`.