### PR TITLE
Add forkCount argument to buildPlugin

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,6 +34,7 @@ buildPlugin(
 * `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
 * `useContainerAgent` (default: `false`) - uses a link:https://github.com/jenkins-infra/documentation/blob/main/ci.adoc#container-agents[Container agent] instead of a Virtual Machine: usually faster to start and generates less costs for the project
 ** Please note that the implementation of "containers" can be changed over time
+* `forkCount` (default: null) - Execute tests with `forkCount` Java virtual machines. Common values include `0.45C`, `1`, `2`, and `1C`.
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ buildPlugin(
 * `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
 * `useContainerAgent` (default: `false`) - uses a link:https://github.com/jenkins-infra/documentation/blob/main/ci.adoc#container-agents[Container agent] instead of a Virtual Machine: usually faster to start and generates less costs for the project
 ** Please note that the implementation of "containers" can be changed over time
-* `forkCount` (default: null) - Execute tests with `forkCount` Java virtual machines. If no value is specified, a single JVM is used.  Common values include `0.45C`, `1`, `2`, and `1C`. If you terminate the value with a 'C', that value will be multiplied by the number of available CPU cores. This controls the number of JVM's used for the test code, including unit tests, integration tests (like JenkinsRule tests), and additional JVM's launched by end to end tests (like agent JVM's and RealJenkinsRule tests).
+* `forkCount` (default: null) - Execute tests with `forkCount` Java virtual machines. If no value is specified, a single JVM is used.  Common values include `0.45C`, `1`, `2`, and `1C`. If you terminate the value with a 'C', that value will be multiplied by the number of available CPU cores. This controls the number of JVM's used for the test code.  Additional JVM's will be launched if the test code starts agents or uses `RealJenkinsRule`.
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ buildPlugin(
 * `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
 * `useContainerAgent` (default: `false`) - uses a link:https://github.com/jenkins-infra/documentation/blob/main/ci.adoc#container-agents[Container agent] instead of a Virtual Machine: usually faster to start and generates less costs for the project
 ** Please note that the implementation of "containers" can be changed over time
-* `forkCount` (default: null) - Execute tests with `forkCount` Java virtual machines. Common values include `0.45C`, `1`, `2`, and `1C`.
+* `forkCount` (default: null) - Execute tests with `forkCount` Java virtual machines. Common values include `0.45C`, `1`, `2`, and `1C` (if you terminate the value with a 'C', that value will be multiplied by the number of available CPU cores).
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ buildPlugin(
 * `repo` (default: `null`  inherit from Multibranch) - custom Git repository to check out
 * `useContainerAgent` (default: `false`) - uses a link:https://github.com/jenkins-infra/documentation/blob/main/ci.adoc#container-agents[Container agent] instead of a Virtual Machine: usually faster to start and generates less costs for the project
 ** Please note that the implementation of "containers" can be changed over time
-* `forkCount` (default: null) - Execute tests with `forkCount` Java virtual machines. Common values include `0.45C`, `1`, `2`, and `1C` (if you terminate the value with a 'C', that value will be multiplied by the number of available CPU cores).
+* `forkCount` (default: null) - Execute tests with `forkCount` Java virtual machines. If no value is specified, a single JVM is used.  Common values include `0.45C`, `1`, `2`, and `1C`. If you terminate the value with a 'C', that value will be multiplied by the number of available CPU cores. This controls the number of JVM's used for the test code, including unit tests, integration tests (like JenkinsRule tests), and additional JVM's launched by end to end tests (like agent JVM's and RealJenkinsRule tests).
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -149,6 +149,28 @@ class BuildPluginStepTests extends BaseTest {
   }
 
   @Test
+  void test_buildPlugin_with_forkCount() throws Exception {
+    def script = loadScript(scriptName)
+    // Run with forkCount=1C
+    script.call([forkCount: '1C'])
+    printCallStack()
+    // and confirm expected message is output
+    assertTrue(assertMethodCallContainsPattern('echo', 'Running parallel tests with forkCount'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_without_forkCount() throws Exception {
+    def script = loadScript(scriptName)
+    // Run without forkCount
+    script.call()
+    printCallStack()
+    // and confirm forkCount message is not output
+    assertFalse(assertMethodCallContainsPattern('echo', 'Running parallel tests with forkCount'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_buildPlugin_with_customplatforms() throws Exception {
     def script = loadScript(scriptName)
     // when running with useContainerAgent set to true

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -15,6 +15,10 @@ def call(Map params = [:]) {
   def useArtifactCachingProxy = params.containsKey('useArtifactCachingProxy') ? params.useArtifactCachingProxy : true
 
   def useContainerAgent = params.containsKey('useContainerAgent') ? params.useContainerAgent : false
+  def forkCount = params.containsKey('forkCount') ? params.forkCount : null
+  if (forkCount) {
+    echo "Running parallel tests with forkCount=${forkCount}"
+  }
   if (timeoutValue > 180) {
     echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
     timeoutValue = 180
@@ -127,6 +131,9 @@ def call(Map params = [:]) {
                 }
                 if (skipTests) {
                   mavenOptions += '-DskipTests'
+                }
+                if (forkCount) {
+                  mavenOptions += "-DforkCount=${forkCount}"
                 }
                 mavenOptions += 'clean install'
                 def pit = params?.pit as Map ?: [:]


### PR DESCRIPTION
## Add forkCount argument to buildPlugin

Allow CI jobs to declare parallel execution rather than using a configuration in the pom.xml file.

Fixes https://github.com/jenkins-infra/pipeline-library/issues/285 to allow users to tune the number of forks based on their knowledge of the tests in their plugin.
