### PR TITLE
breaking!(buildDockerAndPublishImage): support multi-platform with Docker Bake for building Linux container images

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -189,17 +189,44 @@ Supported parameters:
 `imageName`::
 Name of the docker image to build
 
-`configs`::
-(Optional) extra flags
+`config`::
+(Optional) map of extra flags
 
-registry: override the smart default of jenkinsciinfra/ or jenkins4eval/
-dockerfile: override the default dockerfile of Dockerfile
+* agentLabels: String expression for the labels the agent must match
+* automaticSemanticVersioning: Do not automagically increase semantic version by default
+* includeImageNameInTag: Set to true for multiple semversioned images built in parallel, will include the image name in tag to avoid conflict
+* dockerfile: override the default dockerfile of Dockerfile
+* targetplatforms: defined the platforms to build as TARGET
+* nextVersionCommand: Commmand line used to retrieve the next version (default 'jx-release-version')
+* gitCredentials: override Credential ID for tagging and creating release
+* imageDir: Relative path to the context directory for the Docker build
+* registryNamespace: empty = autodiscover based on the current controller, but can override the smart default of jenkinsciinfra/ or jenkins4eval/
+* unstash: Allow to unstash files if not empty
+* dockerBakeFile: Allow to build from a bake file instead
 
 ==== Example
 [source, groovy]
 ----
-buildDockerImage_k8s('plugins-site-api')
+buildDockerAndPublishImage('plugins-site-api')
+buildDockerAndPublishImage('inbound-agent-maven:jdk8-nanoserver', [
+      dockerfile: 'maven/jdk8/Dockerfile.nanoserver',
+      agentLabels: 'docker-windows-2019 && amd64',
+      targetplatforms: 'windows/amd64',
+      imageDir: 'maven/jdk8',
+    ])
 ----
+
+is also called from `parallelDockerUpdatecli` with `config` within `buildDockerConfig` like this :
+[source, groovy]
+----
+parallelDockerUpdatecli([
+  imageName: 'wiki',
+  rebuildImageOnPeriodicJob: false,
+  updatecliConfig: [containerMemory: '1G'],
+  buildDockerConfig : [targetplatforms: 'linux/amd64,linux/arm64,linux/s390x']
+])
+----
+
 
 == Contribute
 
@@ -213,4 +240,3 @@ buildDockerImage_k8s('plugins-site-api')
 By adding `@Library('pipeline-library@pull/<your-pr-number>/head') _` at the top of a Jenkinsfile from a repository built on one of the *.ci.jenkins.io instances, you can test your pipeline library pull request on ci.jenkins.io.
 
 A repository is dedicated for these kind of tests: https://github.com/jenkinsci/jenkins-infra-test-plugin/
-

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -55,10 +55,9 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 
 buildbake: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
-	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	docker buildx create --use
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set '*.platform=linux/"$(dpkg --print-architecture)"'  --load
+	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(dpkg --print-architecture)"  --load
 
 clean: ## Delete any file generated during the build steps
 	@echo "== Cleaning working directory $(IMAGE_DIR) from generated artefacts:"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -57,6 +57,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 
 buildbake: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
+	env
 	docker buildx create --use
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -10,12 +10,11 @@ endif
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
 IMAGE_PLATFORM ?= linux/amd64
-DOCKER_BAKE_FILE ?= "docker-bake.hcl"
-
 # Paths
 IMAGE_DOCKERFILE ?= "$(IMAGE_DIR)"/Dockerfile
 HADOLINT_REPORT ?= "$(IMAGE_DIR)"/hadolint.json
 TEST_HARNESS ?= "$(IMAGE_DIR)"/cst.yml
+DOCKER_BAKE_FILE ?= "$(IMAGE_DIR)"/docker-bake.hcl
 
 ## Image metadatas
 GIT_COMMIT_REV ?= $(shell git log -n 1 --pretty=format:'%h')

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -9,7 +9,7 @@ endif
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
-IMAGE_PLATFORMS ?= linux/amd64
+BUILD_TARGETPLATFORM ?= linux/amd64
 # Paths
 IMAGE_DOCKERFILE ?= "$(IMAGE_DIR)"/Dockerfile
 HADOLINT_REPORT ?= "$(IMAGE_DIR)"/hadolint.json
@@ -48,12 +48,12 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 		--label "org.label-schema.vcs-ref=$(GIT_COMMIT_REV)" \
 		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
 		--label "org.label-schema.build-date=$(BUILD_DATE)" \
-		--platform "$(IMAGE_PLATFORMS)" \
+		--platform "$(BUILD_TARGETPLATFORM)" \
 		--file "$(call FixPath,$(IMAGE_DOCKERFILE))" \
 		"$(IMAGE_DIR)"
 	@echo "== Build succeeded"
 
-buildbake: ## Build the Docker Image(s) with dockerbake file
+bake-build: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
 	docker buildx create --use
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
@@ -77,7 +77,7 @@ deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 	docker image push "$(IMAGE_DEPLOY_NAME)"
 	@echo "== Deploy succeeded"
 
-deploybake:  ## Tag and push the built image as specified by docker bake file
+bake-deploy:  ## Tag and push the built image as specified by docker bake file
 	@echo "== Deploying with docker bake file"
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --push

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -57,6 +57,9 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 
 buildbake: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
+	## debug env variable
+	env
+	## end debug
 	docker buildx create --use
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -56,6 +56,10 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 buildbake: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
 	docker buildx create --use
+	@echo debug path
+	pwd
+	ls -lta
+	@echo fin debug
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --load
 
 clean: ## Delete any file generated during the build steps

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -22,6 +22,8 @@ GIT_SCM_URL ?= $(shell git config --get remote.origin.url)
 SCM_URI ?= $(subst git@github.com:,https://github.com/,"$(GIT_SCM_URL)")
 BUILD_DATE ?= $(shell date --utc '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || gdate --utc '+%Y-%m-%dT%H:%M:%S')
 
+RUN_PLAFORM ?= $(shell dpkg --print-architecture)
+
 help: ## Show this Makefile's help
 	@echo "Help:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -57,7 +59,7 @@ buildbake: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
 	docker buildx create --use
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(dpkg --print-architecture)"  --load
+	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(RUN_PLAFORM)"  --load
 
 clean: ## Delete any file generated during the build steps
 	@echo "== Cleaning working directory $(IMAGE_DIR) from generated artefacts:"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -80,6 +80,6 @@ deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 
 deploybake:  ## Tag and push the built image as specified by docker bake file
 	@echo "== Deploying with docker bake file"
-	TAG = ${env.TAG_NAME}" docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"  --push
+	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"  --push
 
 .PHONY: all clean lint build test deploy

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -80,6 +80,6 @@ deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 
 deploybake:  ## Tag and push the built image as specified by docker bake file
 	@echo "== Deploying with docker bake file"
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --push
+	TAG = ${env.TAG_NAME}" docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"  --push
 
 .PHONY: all clean lint build test deploy

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -22,8 +22,6 @@ GIT_SCM_URL ?= $(shell git config --get remote.origin.url)
 SCM_URI ?= $(subst git@github.com:,https://github.com/,"$(GIT_SCM_URL)")
 BUILD_DATE ?= $(shell date --utc '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || gdate --utc '+%Y-%m-%dT%H:%M:%S')
 
-RUN_PLAFORM ?= $(shell dpkg --print-architecture)
-
 help: ## Show this Makefile's help
 	@echo "Help:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -60,7 +58,7 @@ buildbake: ## Build the Docker Image(s) with dockerbake file
 	docker buildx create --use
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(RUN_PLAFORM)"  --load
+	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(shell dpkg --print-architecture)"  --load
 
 clean: ## Delete any file generated during the build steps
 	@echo "== Cleaning working directory $(IMAGE_DIR) from generated artefacts:"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -9,7 +9,7 @@ endif
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
-IMAGE_PLATFORM ?= linux/amd64
+IMAGE_PLATFORMS ?= linux/amd64
 # Paths
 IMAGE_DOCKERFILE ?= "$(IMAGE_DIR)"/Dockerfile
 HADOLINT_REPORT ?= "$(IMAGE_DIR)"/hadolint.json
@@ -50,7 +50,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 		--label "org.label-schema.vcs-ref=$(GIT_COMMIT_REV)" \
 		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
 		--label "org.label-schema.build-date=$(BUILD_DATE)" \
-		--platform "$(IMAGE_PLATFORM)" \
+		--platform "$(IMAGE_PLATFORMS)" \
 		--file "$(call FixPath,$(IMAGE_DOCKERFILE))" \
 		"$(IMAGE_DIR)"
 	@echo "== Build succeeded"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -55,9 +55,10 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 
 buildbake: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
-	docker buildx create --use
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --load
+	docker buildx create --use
+	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
+	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set '*.platform=linux/"$(dpkg --print-architecture)"'  --load
 
 clean: ## Delete any file generated during the build steps
 	@echo "== Cleaning working directory $(IMAGE_DIR) from generated artefacts:"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -58,6 +58,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 buildbake: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
 	docker buildx create --use
+	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(RUN_PLAFORM)"  --load
 
@@ -80,6 +81,7 @@ deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 
 deploybake:  ## Tag and push the built image as specified by docker bake file
 	@echo "== Deploying with docker bake file"
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"  --push
+	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
+	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --push
 
 .PHONY: all clean lint build test deploy

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -55,10 +55,8 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 
 bake-build: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
-	docker buildx create --use
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(shell dpkg --print-architecture)"  --load
+	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
+
 
 clean: ## Delete any file generated during the build steps
 	@echo "== Cleaning working directory $(IMAGE_DIR) from generated artefacts:"
@@ -66,6 +64,13 @@ clean: ## Delete any file generated during the build steps
 	@echo "== Cleanup succeeded"
 
 test: ## Execute the test harness on the Docker Image
+	@echo "== Test $(IMAGE_NAME) with $(call FixPath,$(TEST_HARNESS)) from $(IMAGE_NAME) with container-structure-test:"
+	container-structure-test test --driver=docker --image="$(IMAGE_NAME)" --config="$(call FixPath,$(TEST_HARNESS))"
+	@echo "== Test succeeded"
+
+bake-test: ## Execute the test harness on the Docker Image with load
+	@echo "== Load $(IMAGE_NAME) within docker engine from docker bake buildx engine"
+	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(shell dpkg --print-architecture)"  --load
 	@echo "== Test $(IMAGE_NAME) with $(call FixPath,$(TEST_HARNESS)) from $(IMAGE_NAME) with container-structure-test:"
 	container-structure-test test --driver=docker --image="$(IMAGE_NAME)" --config="$(call FixPath,$(TEST_HARNESS))"
 	@echo "== Test succeeded"
@@ -79,7 +84,6 @@ deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 
 bake-deploy:  ## Tag and push the built image as specified by docker bake file
 	@echo "== Deploying with docker bake file"
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
-	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --push
+	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --push
 
 .PHONY: all clean lint build test deploy

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -56,9 +56,10 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 	@echo "== Build succeeded"
 
 buildbake: ## Build the Docker Image(s) with dockerbake file
-	@echo "== Building from DockerBake file with $(TAG_NAME)"
+	@echo "== Building from DockerBake file with TAG $(TAG_NAME)"
 	env
 	docker buildx create --use
+	@echo "== TAG_NAME vaut $(TAG_NAME)"
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(RUN_PLAFORM)"  --load

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -56,10 +56,8 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 	@echo "== Build succeeded"
 
 buildbake: ## Build the Docker Image(s) with dockerbake file
-	@echo "== Building from DockerBake file with TAG $(TAG_NAME)"
-	env
+	@echo "== Building from DockerBake file"
 	docker buildx create --use
-	@echo "== TAG_NAME vaut $(TAG_NAME)"
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(RUN_PLAFORM)"  --load
@@ -82,7 +80,7 @@ deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 	@echo "== Deploy succeeded"
 
 deploybake:  ## Tag and push the built image as specified by docker bake file
-	@echo "== Deploying with docker bake file with $(TAG_NAME)"
+	@echo "== Deploying with docker bake file"
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --push
 

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -57,9 +57,6 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 
 buildbake: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
-	## debug env variable
-	env
-	## end debug
 	docker buildx create --use
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -56,7 +56,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 	@echo "== Build succeeded"
 
 buildbake: ## Build the Docker Image(s) with dockerbake file
-	@echo "== Building from DockerBake file"
+	@echo "== Building from DockerBake file with $(TAG_NAME)"
 	env
 	docker buildx create --use
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
@@ -81,7 +81,7 @@ deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 	@echo "== Deploy succeeded"
 
 deploybake:  ## Tag and push the built image as specified by docker bake file
-	@echo "== Deploying with docker bake file"
+	@echo "== Deploying with docker bake file with $(TAG_NAME)"
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --push
 

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -56,10 +56,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 buildbake: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file"
 	docker buildx create --use
-	@echo debug path
-	pwd
-	ls -lta
-	@echo fin debug
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --load
 
 clean: ## Delete any file generated during the build steps

--- a/resources/io/jenkins/infra/docker/docker-bake.override.hcl
+++ b/resources/io/jenkins/infra/docker/docker-bake.override.hcl
@@ -8,6 +8,10 @@ variable "TAG_NAME" {
   default = ""
 }
 
+variable "PLATFORMS" {
+  default = "linux/arm64"
+}
+
 # return the full image name
 function "full_image_name" {
   params = [tag]
@@ -21,7 +25,7 @@ target "default" {
     full_image_name("latest"),
     full_image_name(TAG_NAME)
   ]
-  platforms = ["$(PLATFORMS)"]
+  platforms = [PLATFORMS]
   args = {
     GIT_COMMIT_REV="$(GIT_COMMIT_REV)",
     GIT_SCM_URL="$(GIT_SCM_URL)",

--- a/resources/io/jenkins/infra/docker/docker-bake.override.hcl
+++ b/resources/io/jenkins/infra/docker/docker-bake.override.hcl
@@ -12,7 +12,7 @@ variable "PLATFORMS" {
   default = "linux/arm64"
 }
 
-variable "DOCKERFILE" {
+variable "IMAGE_DOCKERFILE" {
   default = "Dockerfile"
 }
 
@@ -27,7 +27,7 @@ function "full_image_name" {
 }
 
 target "default" {
-  dockerfile = "$(DOCKERFILE)"
+  dockerfile = "$(IMAGE_DOCKERFILE)"
   context = "$(IMAGE_DIR)"
   tags = [
     full_image_name("latest"),

--- a/resources/io/jenkins/infra/docker/docker-bake.override.hcl
+++ b/resources/io/jenkins/infra/docker/docker-bake.override.hcl
@@ -28,7 +28,7 @@ function "full_image_name" {
 
 target "default" {
   dockerfile = "$(IMAGE_DOCKERFILE)"
-  context = "$(IMAGE_DIR)"
+  context = IMAGE_DIR
   tags = [
     full_image_name("latest"),
     full_image_name(TAG_NAME)

--- a/resources/io/jenkins/infra/docker/docker-bake.override.hcl
+++ b/resources/io/jenkins/infra/docker/docker-bake.override.hcl
@@ -21,7 +21,7 @@ target "default" {
     full_image_name("latest"),
     full_image_name(TAG_NAME)
   ]
-  platforms = "$(PLATFORMS)"
+  platforms = ["$(PLATFORMS)"]
   args = {
     GIT_COMMIT_REV="$(GIT_COMMIT_REV)",
     GIT_SCM_URL="$(GIT_SCM_URL)",

--- a/resources/io/jenkins/infra/docker/docker-bake.override.hcl
+++ b/resources/io/jenkins/infra/docker/docker-bake.override.hcl
@@ -27,7 +27,7 @@ function "full_image_name" {
 }
 
 target "default" {
-  dockerfile = "$(IMAGE_DOCKERFILE)"
+  dockerfile = IMAGE_DOCKERFILE
   context = IMAGE_DIR
   tags = [
     full_image_name("latest"),

--- a/resources/io/jenkins/infra/docker/docker-bake.override.hcl
+++ b/resources/io/jenkins/infra/docker/docker-bake.override.hcl
@@ -12,6 +12,14 @@ variable "PLATFORMS" {
   default = "linux/arm64"
 }
 
+variable "DOCKERFILE" {
+  default = "Dockerfile"
+}
+
+variable "IMAGE_DIR" {
+  default = "."
+}
+
 # return the full image name
 function "full_image_name" {
   params = [tag]
@@ -19,8 +27,8 @@ function "full_image_name" {
 }
 
 target "default" {
-  dockerfile = "Dockerfile"
-  context = "."
+  dockerfile = "$(DOCKERFILE)"
+  context = "$(IMAGE_DIR)"
   tags = [
     full_image_name("latest"),
     full_image_name(TAG_NAME)

--- a/resources/io/jenkins/infra/docker/docker-bake.override.hcl
+++ b/resources/io/jenkins/infra/docker/docker-bake.override.hcl
@@ -1,0 +1,40 @@
+variable "IMAGE_NAME" {}
+
+variable "REGISTRY" {
+  default = "docker.io"
+}
+
+variable "TAG_NAME" {
+  default = ""
+}
+
+# return the full image name
+function "full_image_name" {
+  params = [tag]
+  result = notequal("", tag) ? "${REGISTRY}/${IMAGE_NAME}:${tag}" : "${REGISTRY}/${IMAGE_NAME}:latest"
+}
+
+target "default" {
+  dockerfile = "Dockerfile"
+  context = "."
+  tags = [
+    full_image_name("latest"),
+    full_image_name(TAG_NAME)
+  ]
+  platforms = "$(PLATFORMS)"
+  args = {
+    GIT_COMMIT_REV="$(GIT_COMMIT_REV)",
+    GIT_SCM_URL="$(GIT_SCM_URL)",
+    BUILD_DATE="$(BUILD_DATE)",
+  }
+  labels = {
+    "org.opencontainers.image.source"="$(GIT_SCM_URL)",
+    "org.label-schema.vcs-url"="$(GIT_SCM_URL)",
+    "org.opencontainers.image.url"="$(SCM_URI)",
+    "org.label-schema.url"="$(SCM_URI)",
+    "org.opencontainers.image.revision"="$(GIT_COMMIT_REV)",
+    "org.label-schema.vcs-ref"="$(GIT_COMMIT_REV)",
+    "org.opencontainers.image.created"="$(BUILD_DATE)",
+    "org.label-schema.build-date"="$(BUILD_DATE)",
+  }
+}

--- a/resources/io/jenkins/infra/docker/jenkinsinfrabakefile.hcl
+++ b/resources/io/jenkins/infra/docker/jenkinsinfrabakefile.hcl
@@ -1,4 +1,4 @@
-variable "IMAGE_NAME" {}
+variable "IMAGE_DEPLOY_NAME" {}
 
 variable "REGISTRY" {
   default = "docker.io"
@@ -8,7 +8,7 @@ variable "TAG_NAME" {
   default = ""
 }
 
-variable "PLATFORMS" {
+variable "BAKE_TARGETPLATFORMS" {
   default = "linux/arm64"
 }
 
@@ -23,7 +23,7 @@ variable "IMAGE_DIR" {
 # return the full image name
 function "full_image_name" {
   params = [tag]
-  result = notequal("", tag) ? "${REGISTRY}/${IMAGE_NAME}:${tag}" : "${REGISTRY}/${IMAGE_NAME}:latest"
+  result = notequal("", tag) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${tag}" : "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest"
 }
 
 target "default" {
@@ -33,7 +33,7 @@ target "default" {
     full_image_name("latest"),
     full_image_name(TAG_NAME)
   ]
-  platforms = [PLATFORMS]
+  platforms = [BAKE_TARGETPLATFORMS]
   args = {
     GIT_COMMIT_REV="$(GIT_COMMIT_REV)",
     GIT_SCM_URL="$(GIT_SCM_URL)",

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -113,14 +113,6 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     addEnvVar('TAG_NAME', gitTag)
   }
 
-  // Return if the set of methods expected for ALL pipeline run have been detected in the callstack
-  Boolean assertBaseWorkflow() {
-    return assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile') \
-      && (assertMethodCallContainsPattern('sh','make lint') || assertMethodCallContainsPattern('powershell','make lint')) \
-      && (assertMethodCallContainsPattern('sh','make build') || assertMethodCallContainsPattern('sh','make bake-build') || assertMethodCallContainsPattern('powershell','make build')) \
-      && assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}")
-  }
-
   // Return if the usual static checks had been recorded with the usual pattern
   Boolean assertRecordIssues(String imageName = fullTestImageName) {
     final String reportId = "${imageName}-hadolint-${mockedTimestamp}".replaceAll('/','-').replaceAll(':', '-')
@@ -161,7 +153,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertJobStatusSuccess()
 
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
 
     // And the expected environment variable defined to their defaults
@@ -199,7 +195,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Then we expect a successful build with the code cloned
     assertJobStatusSuccess()
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
     // And generated reports are recorded with named without ':' but '-' instead
     assertTrue(assertRecordIssues(fullCustomImageName.replaceAll(':','-')))
@@ -227,7 +227,10 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Then we expect a successful build with the code cloned
     assertJobStatusSuccess()
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
     // And generated reports are recorded
     assertTrue(assertRecordIssues())
@@ -258,7 +261,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Then we expect a successful build with the code cloned
     assertJobStatusSuccess()
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
     // And generated reports are recorded
     assertTrue(assertRecordIssues())
@@ -293,7 +300,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Then we expect a successful build with the code cloned
     assertJobStatusSuccess()
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
     // And the environement variables set with the custom configuration values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=docker/'))
@@ -322,7 +333,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Then we expect a successful build
     assertJobStatusSuccess()
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
     // But no deploy step called for latest
     assertFalse(assertMethodCallContainsPattern('sh','make bake-deploy'))
@@ -347,7 +362,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Then we expect a successful build
     assertJobStatusSuccess()
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
     // And the deploy step called for latest
     assertTrue(assertMethodCallContainsPattern('sh','make bake-deploy'))
@@ -383,7 +402,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Then we expect a successful build
     assertJobStatusSuccess()
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
     // And the deploy step called for latest
     assertTrue(assertMethodCallContainsPattern('sh','make bake-deploy'))
@@ -491,7 +514,12 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Then we expect a successful build with the code cloned
     assertJobStatusSuccess()
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('powershell','make lint'))
+    assertTrue(assertMethodCallContainsPattern('powershell','make build'))
+
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker-windows'))
     // And the expected environment variables set to their default values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=.'))
@@ -528,7 +556,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertJobStatusSuccess()
 
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
 
     // And the expected environment variable defined to their defaults
@@ -567,7 +599,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Then we expect a successful build with the code cloned
     assertJobStatusSuccess()
     // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
     // And the environement variables set with the custom configuration values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=.'))
@@ -600,7 +636,11 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertJobStatusSuccess()
 
     // // With the common workflow run as expected
-    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}"))
+    assertTrue(assertMethodCallContainsPattern('sh','make lint'))
+    assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
+
     assertTrue(assertMethodCallContainsPattern('sh', 'make bake-build'))
     assertFalse(assertMethodCallContainsPattern('sh', 'make build'))
     assertTrue(assertMethodCallContainsPattern('sh', 'make bake-deploy'))
@@ -691,5 +731,42 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
 
     // And the error message is shown
     assertTrue(assertMethodCallContainsPattern('echo', 'ERROR: dockerBakeFile is not supported on windows.'))
+  }
+
+  @Test
+  void itWarnIfWindowsAgentAndNotWindowsTarget() throws Exception {
+    def script = loadScript(scriptName)
+    mockPrincipalBranch()
+    withMocks{
+      script.call(testImageName, [
+        targetplatforms: 'linux/amd64',
+        agentLabels: 'docker-windows',
+      ])
+    }
+    printCallStack()
+
+    // Then we expect a failing build
+    assertJobStatusSuccess()
+
+    // And the error message is shown
+    assertTrue(assertMethodCallContainsPattern('echo', 'WARNING: A \'windows\' agent is requested, but the \'platform(s)\' is set to'))
+  }
+
+  @Test
+  void itWarnIfNotWindowsAgentButWindowsTarget() throws Exception {
+    def script = loadScript(scriptName)
+    mockPrincipalBranch()
+    withMocks{
+      script.call(testImageName, [
+        targetplatforms: 'windows/1804',
+      ])
+    }
+    printCallStack()
+
+    // Then we expect a failing build
+    assertJobStatusSuccess()
+
+    // And the error message is shown
+    assertTrue(assertMethodCallContainsPattern('echo', 'WARNING: The \'targetplatforms\' is set to \'windows/1804\', but there isn\'t any \'windows\' agent requested.'))
   }
 }

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -173,7 +173,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // And the expected environment variable defined to their defaults
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=.'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=Dockerfile'))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORM=linux/amd64'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORMS=linux/amd64'))
 
     // And generated reports are recorded
     assertTrue(assertRecordIssues())
@@ -297,7 +297,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // And the environement variables set with the custom configuration values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=docker/'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=build.Dockerfile'))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORM=linux/s390x'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORMS=linux/s390x'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_NAME=' + expectedImageName))
     // But no tag and no deploy called (branch or PR)
     assertTrue(assertMakeDeploy(expectedImageName))
@@ -481,7 +481,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // And the expected environment variables set to their default values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=.'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=Dockerfile'))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORM=linux/amd64'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORMS=linux/amd64'))
     // And generated reports recorded
     assertTrue(assertRecordIssues())
     // And the deploy step called
@@ -510,7 +510,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // And the expected environment variables set to their default values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=.'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=Dockerfile'))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORM=linux/amd64'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORMS=linux/amd64'))
     // And generated reports recorded
     assertTrue(assertRecordIssues())
     // But no deploy step called (not on principal branch)
@@ -545,7 +545,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // And the expected environment variable defined to their defaults
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=.'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=Dockerfile'))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORM=linux/amd64'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_PLATFORMS=linux/amd64'))
 
     // And generated reports are recorded
     assertTrue(assertRecordIssues())

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -562,4 +562,37 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // And all mocked/stubbed methods have to be called
     verifyMocks()
   }
+
+  @Test
+  void itBuildsAndDeploysImageWithCustomPlatformOnPrincipalBranch() throws Exception {
+    def script = loadScript(scriptName)
+    mockPrincipalBranch()
+    withMocks{
+      script.call(testImageName, [
+        dockerfile: 'build.Dockerfile',
+        imageDir: 'docker/',
+        platform: 'linux/amd64,linux/arm64,linux/s390x',
+        automaticSemanticVersioning: true,
+        gitCredentials: 'git-creds',
+        registryNamespace: 'jenkins',
+      ])
+    }
+    final String expectedImageName = 'jenkins/' + testImageName
+    printCallStack()
+    // Then we expect a successful build with the code cloned
+    assertJobStatusSuccess()
+    // With the common workflow run as expected
+    assertTrue(assertBaseWorkflow())
+    assertTrue(assertMethodCallContainsPattern('node', 'docker'))
+    // And the environement variables set with the custom configuration values
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=docker/'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=build.Dockerfile'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'PLATFORMS=linux/amd64,linux/arm64,linux/s390x'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_NAME=' + expectedImageName))
+    // But no tag and no deploy called (branch or PR)
+    assertTrue(assertMakeDeploy(expectedImageName))
+    assertTrue(assertTagPushed(defaultGitTag))
+    // And all mocked/stubbed methods have to be called
+    verifyMocks()
+  }
 }

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -117,7 +117,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   Boolean assertBaseWorkflow() {
     return assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile') \
       && (assertMethodCallContainsPattern('sh','make lint') || assertMethodCallContainsPattern('powershell','make lint')) \
-      && (assertMethodCallContainsPattern('sh','make $action') || assertMethodCallContainsPattern('sh','make bake-$action') || assertMethodCallContainsPattern('powershell','make $action')) \
+      && (assertMethodCallContainsPattern('sh','make build') || assertMethodCallContainsPattern('sh','make bake-build') || assertMethodCallContainsPattern('powershell','make build')) \
       && assertMethodCallContainsPattern('withEnv', "BUILD_DATE=${mockedSimpleDate}")
   }
 
@@ -132,7 +132,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
 
   // return if the "make deploy" was detected with the provided argument as image name
   Boolean assertMakeDeploy(String expectedImageName = fullTestImageName) {
-    return (assertMethodCallContainsPattern('sh','make $action') || assertMethodCallContainsPattern('sh','make bake-$action') || assertMethodCallContainsPattern('powershell','make $action')) \
+    return (assertMethodCallContainsPattern('sh','make deploy') || assertMethodCallContainsPattern('sh','make bake-deploy') || assertMethodCallContainsPattern('powershell','make deploy')) \
       && assertMethodCallContainsPattern('withEnv', "IMAGE_DEPLOY_NAME=${expectedImageName}")
   }
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -77,8 +77,6 @@ def call(String imageShortName, Map userConfig=[:]) {
           writeFile file: 'Makefile', text: makefileContent
 
           writeFile file: overrideDockerBakeFile, text: bakefileContent
-
-          sh 'ls -lta' //DEBUG
         } // stage
 
         // Automatic tagging on principal branch is not enabled by default, show potential next version in PR anyway
@@ -152,8 +150,7 @@ def call(String imageShortName, Map userConfig=[:]) {
             } else {
               if (cstConfigSuffix == "") {
                 //linux ==> generated docker bake
-                withEnv (["PLATFORMS=$finalConfig.platform", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
-                  sh 'ls -lta' //DEBUG
+                withEnv (["PLATFORMS=[$finalConfig.platform]", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
                   sh 'make buildbake'
                 }
               } else {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -103,8 +103,6 @@ def call(String imageShortName, Map userConfig=[:]) {
           // The makefile to use must come from the pipeline to avoid a nasty user trying to exfiltrate data from the build
           // Even though we have mitigation through the multibranch job config allowing to build PRs only from the repository contributors
           writeFile file: 'Makefile', text: makefileContent
-
-
         } // stage
 
         // Automatic tagging on principal branch is not enabled by default, show potential next version in PR anyway
@@ -282,7 +280,6 @@ def call(String imageShortName, Map userConfig=[:]) {
             } else {
               powershell 'make deploy'
             } // unix agent
-
           } //stage
         } // if
       } // withDockerPushCredentials

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -23,7 +23,7 @@ def call(String imageShortName, Map userConfig=[:]) {
 
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
-  final String bakefileContent = libraryResource 'io/jenkins/infra/docker/docker-bake.hcl'
+  final String bakefileContent = libraryResource 'io/jenkins/infra/docker/docker-bake.override.hcl'
   final boolean semVerEnabledOnPrimaryBranch = finalConfig.automaticSemanticVersioning && env.BRANCH_IS_PRIMARY
 
   // Only run 1 build at a time on primary branch to ensure builds won't use the same tag when semantic versionning is activated

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -76,7 +76,7 @@ def call(String imageShortName, Map userConfig=[:]) {
           // Even though we have mitigation through the multibranch job config allowing to build PRs only from the repository contributors
           writeFile file: 'Makefile', text: makefileContent
 
-          writeFile file: '$overrideDockerBakeFile', text: bakefileContent
+          writeFile file: overrideDockerBakeFile, text: bakefileContent
 
           sh 'ls -lta' //DEBUG
         } // stage

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -93,6 +93,7 @@ def call(String imageShortName, Map userConfig=[:]) {
 
   // Default Value if targetplatforms is not set, I set it to linux/amd64 by default
   if (finalConfig.targetplatforms == '') {
+    echo "WARNING: `platform` is deprecated, use `targetplatforms` instead."
     finalConfig.targetplatforms = 'linux/amd64'
   }
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -151,7 +151,7 @@ def call(String imageShortName, Map userConfig=[:]) {
               if (cstConfigSuffix == "") {
                 //linux ==> generated docker bake
                 withEnv (["PLATFORMS=$finalConfig.platform", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
-                  sh 'make buildbake'
+                  sh 'env && make buildbake'
                 }
               } else {
                 // still used for windows

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -21,9 +21,6 @@ def call(String imageShortName, Map userConfig=[:]) {
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
   final Map finalConfig = defaultConfig << userConfig
 
-  // DEBUG ONLY FOR PUSH
-  env.TAG_NAME = "0.0.2"
-
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
   final boolean semVerEnabledOnPrimaryBranch = finalConfig.automaticSemanticVersioning && env.BRANCH_IS_PRIMARY

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -260,7 +260,6 @@ def call(String imageShortName, Map userConfig=[:]) {
               } else {
                 powershell 'make deploy'
               } // unix agent
-
             } // withEnv
           } //stage
         } // if

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -60,6 +60,7 @@ def call(String imageShortName, Map userConfig=[:]) {
       "IMAGE_DIR=${finalConfig.imageDir}",
       "IMAGE_DOCKERFILE=${finalConfig.dockerfile}",
       "IMAGE_PLATFORM=${finalConfig.platform}",
+      "DOCKER_BAKE_FILE=${finalConfig.dockerBakeFile}",
     ]) {
       infra.withDockerPullCredentials{
         String nextVersion = ''

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -295,7 +295,7 @@ def call(String imageShortName, Map userConfig=[:]) {
       infra.withDockerPushCredentials{
         if (env.TAG_NAME || env.BRANCH_IS_PRIMARY) {
           stage("Deploy ${imageName}") {
-            makecall('deploy', imageDeployName, operatingSystem, finalConfig.dockerBakeFile)
+            makecall('deploy', imageName, operatingSystem, finalConfig.dockerBakeFile)
           }
         } // if
       } // withDockerPushCredentials

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -21,6 +21,9 @@ def call(String imageShortName, Map userConfig=[:]) {
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
   final Map finalConfig = defaultConfig << userConfig
 
+  // DEBUG ONLY FOR PUSH
+  TAG_NAME = "0.0.1-beta"
+
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
   final boolean semVerEnabledOnPrimaryBranch = finalConfig.automaticSemanticVersioning && env.BRANCH_IS_PRIMARY
@@ -142,7 +145,6 @@ def call(String imageShortName, Map userConfig=[:]) {
         stage("Build ${imageName}") {
           if (isUnix()) {
             if (finalConfig.dockerBakeFile != '') {
-              //sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
               sh 'make buildbake'
             } else {
               sh 'make build'
@@ -233,7 +235,6 @@ def call(String imageShortName, Map userConfig=[:]) {
               // Please note that "make deploy" uses the environment variable "IMAGE_DEPLOY_NAME"
               if (isUnix()) {
                 if (finalConfig.dockerBakeFile != '') {
-                  sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
                   sh 'make deploybake'
                 } else {
                   sh 'make deploy'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -247,15 +247,19 @@ def call(String imageShortName, Map userConfig=[:]) {
                 if (finalConfig.dockerBakeFile != '') {
                   sh 'make deploybake'
                 } else {
-                  sh 'make deploy'
+                  if (operatingSystem == "linux") {
+                    //linux ==> generated docker bake
+                    withEnv (["PLATFORMS=$finalConfig.platform", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
+                      sh 'make deploybake'
+                    }
+                  } else {
+                    // old process still used for windows
+                    sh 'make deploy'
+                  }
                 }
               } else {
-                if (finalConfig.dockerBakeFile != '') {
-                  powershell 'make deploybake'
-                } else {
-                  powershell 'make deploy'
-                }
-              }
+                powershell 'make deploy'
+              } // unix agent
 
             } // withEnv
           } //stage

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -23,6 +23,7 @@ def call(String imageShortName, Map userConfig=[:]) {
 
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
+  final String bakefileContent = libraryResource 'io/jenkins/infra/docker/docker-bake.hcl'
   final boolean semVerEnabledOnPrimaryBranch = finalConfig.automaticSemanticVersioning && env.BRANCH_IS_PRIMARY
 
   // Only run 1 build at a time on primary branch to ensure builds won't use the same tag when semantic versionning is activated
@@ -73,6 +74,8 @@ def call(String imageShortName, Map userConfig=[:]) {
           // The makefile to use must come from the pipeline to avoid a nasty user trying to exfiltrate data from the build
           // Even though we have mitigation through the multibranch job config allowing to build PRs only from the repository contributors
           writeFile file: 'Makefile', text: makefileContent
+
+          writeFile file: 'docker-bake.override.hcl', text: bakefileContent
         } // stage
 
         // Automatic tagging on principal branch is not enabled by default, show potential next version in PR anyway
@@ -144,7 +147,15 @@ def call(String imageShortName, Map userConfig=[:]) {
             if (finalConfig.dockerBakeFile != '') {
               sh 'make buildbake'
             } else {
-              sh 'make build'
+              if (cstConfigSuffix == "") {
+                //linux ==> generated docker bake
+                env.PLATFORMS=finalConfig.platform
+                env.DOCKER_BAKE_FILE='docker-bake.override.hcl'
+                sh 'env && make buildbake'
+              } else {
+                // still used for windows
+                sh 'make build'
+              }
             }
           } else {
             if (finalConfig.dockerBakeFile != '') {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -22,7 +22,7 @@ def call(String imageShortName, Map userConfig=[:]) {
   final Map finalConfig = defaultConfig << userConfig
 
   // DEBUG ONLY FOR PUSH
-  TAG_NAME = "0.0.1-beta"
+  env.TAG_NAME = "0.0.1-beta"
 
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -23,7 +23,6 @@ def makecall(String action, String imageDeployName, String targetOperationSystem
   }
 
   if (action == 'deploy') {
-    String imageDeployName = imageName
     if (env.TAG_NAME) {
       if (imageDeployName.contains(env.TAG_NAME)) {
         // The tag is already within the image name to deploy no need to add it again

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -22,7 +22,7 @@ def call(String imageShortName, Map userConfig=[:]) {
   final Map finalConfig = defaultConfig << userConfig
 
   // DEBUG ONLY FOR PUSH
-  env.TAG_NAME = "0.0.1"
+  env.TAG_NAME = "0.0.2"
 
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -24,7 +24,7 @@ def call(String imageShortName, Map userConfig=[:]) {
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
   final String overrideDockerBakeFile = 'docker-bake.override.hcl'
-  final String bakefileContent = libraryResource 'io/jenkins/infra/docker/' + $overrideDockerBakeFile
+  final String bakefileContent = libraryResource 'io/jenkins/infra/docker/' + overrideDockerBakeFile
   final boolean semVerEnabledOnPrimaryBranch = finalConfig.automaticSemanticVersioning && env.BRANCH_IS_PRIMARY
 
   // Only run 1 build at a time on primary branch to ensure builds won't use the same tag when semantic versionning is activated

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -142,7 +142,7 @@ def call(String imageShortName, Map userConfig=[:]) {
         stage("Build ${imageName}") {
           if (isUnix()) {
             if (finalConfig.dockerBakeFile != '') {
-              sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
+              //sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
               sh 'make buildbake'
             } else {
               sh 'make build'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -148,17 +148,18 @@ def call(String imageShortName, Map userConfig=[:]) {
             if (finalConfig.dockerBakeFile != '') {
               sh 'make buildbake'
             } else {
-              if (cstConfigSuffix == "") {
+              if (operatingSystem == "linux") {
                 //linux ==> generated docker bake
                 withEnv (["PLATFORMS=$finalConfig.platform", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
-                  sh 'env && make buildbake'
+                  sh 'make buildbake'
                 }
               } else {
-                // still used for windows
+                // old process still used for windows
                 sh 'make build'
               }
             }
           } else {
+            // the agent is a windows agent so we do not force bakefile
             if (finalConfig.dockerBakeFile != '') {
               powershell 'make buildbake'
             } else {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -23,7 +23,8 @@ def call(String imageShortName, Map userConfig=[:]) {
 
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
-  final String bakefileContent = libraryResource 'io/jenkins/infra/docker/docker-bake.override.hcl'
+  final String overrideDockerBakeFile = 'docker-bake.override.hcl'
+  final String bakefileContent = libraryResource 'io/jenkins/infra/docker/$overrideDockerBakeFile'
   final boolean semVerEnabledOnPrimaryBranch = finalConfig.automaticSemanticVersioning && env.BRANCH_IS_PRIMARY
 
   // Only run 1 build at a time on primary branch to ensure builds won't use the same tag when semantic versionning is activated
@@ -75,7 +76,7 @@ def call(String imageShortName, Map userConfig=[:]) {
           // Even though we have mitigation through the multibranch job config allowing to build PRs only from the repository contributors
           writeFile file: 'Makefile', text: makefileContent
 
-          writeFile file: 'docker-bake.override.hcl', text: bakefileContent
+          writeFile file: '$overrideDockerBakeFile', text: bakefileContent
         } // stage
 
         // Automatic tagging on principal branch is not enabled by default, show potential next version in PR anyway
@@ -149,9 +150,11 @@ def call(String imageShortName, Map userConfig=[:]) {
             } else {
               if (cstConfigSuffix == "") {
                 //linux ==> generated docker bake
-                env.PLATFORMS=finalConfig.platform
-                env.DOCKER_BAKE_FILE='docker-bake.override.hcl'
-                sh 'env && make buildbake'
+                env.
+                env.
+                withEnv (["PLATFORMS=$finalConfig.platform", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
+                  sh 'make buildbake'
+                }
               } else {
                 // still used for windows
                 sh 'make build'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -24,7 +24,7 @@ def call(String imageShortName, Map userConfig=[:]) {
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
   final String overrideDockerBakeFile = 'docker-bake.override.hcl'
-  final String bakefileContent = libraryResource 'io/jenkins/infra/docker/$overrideDockerBakeFile'
+  final String bakefileContent = libraryResource 'io/jenkins/infra/docker/' + $overrideDockerBakeFile
   final boolean semVerEnabledOnPrimaryBranch = finalConfig.automaticSemanticVersioning && env.BRANCH_IS_PRIMARY
 
   // Only run 1 build at a time on primary branch to ensure builds won't use the same tag when semantic versionning is activated

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -231,7 +231,7 @@ def call(String imageShortName, Map userConfig=[:]) {
               }
             }
 
-            withEnv(["IMAGE_DEPLOY_NAME=${imageDeployName}"]) {
+            withEnv(["IMAGE_DEPLOY_NAME=${imageDeployName}", "TAG_NAME=${env.TAG_NAME}"]) {
               // Please note that "make deploy" uses the environment variable "IMAGE_DEPLOY_NAME"
               if (isUnix()) {
                 if (finalConfig.dockerBakeFile != '') {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -15,7 +15,7 @@ def makecall(String action, String imageDeployName, String targetOperationSystem
         writeFile file: specificDockerBakeFile, text: bakefileContent
       }
       withEnv(["DOCKER_BAKE_FILE=${specificDockerBakeFile}"]) {
-        sh 'docker buildx create --use'
+        sh 'export BUILDX_BUILDER_NAME=buildx-builder; docker buildx use "${BUILDX_BUILDER_NAME}" 2>/dev/null || docker buildx create --use --name="${BUILDX_BUILDER_NAME}"'
         sh "make bake-$action"
       }
     } else {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -26,22 +26,22 @@ def makecall(String action, String imageDeployName, String targetOperationSystem
     if (isUnix()) {
       if (SpecificDockerBakeFile) {
         withEnv(["DOCKER_BAKE_FILE=${SpecificDockerBakeFile}"]) {
-          sh 'make bake-$action'
+          sh "make bake-$action"
         }
       } else {
         if (targetOperationSystem == "linux") {
           //linux ==> generated docker bake
           writeFile file: jenkinsInfraBakeFile, text: bakefileContent
           withEnv(["DOCKER_BAKE_FILE=${jenkinsInfraBakeFile}"]) {
-            sh 'make bake-$action'
+            sh "make bake-$action"
           }
         } else {
           // old process still used for windows
-          sh 'make $action'
+          sh "make $action"
         }
       }
     } else {
-      powershell 'make $action'
+      powershell "make $action"
     } // unix agent
   } // withEnv
 }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -145,7 +145,7 @@ def call(String imageShortName, Map userConfig=[:]) {
         stage("Build ${imageName}") {
           if (isUnix()) {
             if (finalConfig.dockerBakeFile != '') {
-              sh 'env && make buildbake'
+              sh 'make buildbake'
             } else {
               sh 'make build'
             }
@@ -235,7 +235,7 @@ def call(String imageShortName, Map userConfig=[:]) {
               // Please note that "make deploy" uses the environment variable "IMAGE_DEPLOY_NAME"
               if (isUnix()) {
                 if (finalConfig.dockerBakeFile != '') {
-                  sh 'env && make deploybake'
+                  sh 'make deploybake'
                 } else {
                   sh 'make deploy'
                 }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -77,6 +77,8 @@ def call(String imageShortName, Map userConfig=[:]) {
           writeFile file: 'Makefile', text: makefileContent
 
           writeFile file: '$overrideDockerBakeFile', text: bakefileContent
+
+          sh 'ls -lta' //DEBUG
         } // stage
 
         // Automatic tagging on principal branch is not enabled by default, show potential next version in PR anyway
@@ -151,6 +153,7 @@ def call(String imageShortName, Map userConfig=[:]) {
               if (cstConfigSuffix == "") {
                 //linux ==> generated docker bake
                 withEnv (["PLATFORMS=$finalConfig.platform", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
+                  sh 'ls -lta' //DEBUG
                   sh 'make buildbake'
                 }
               } else {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -39,10 +39,13 @@ def call(String imageShortName, Map userConfig=[:]) {
 
   // only one platform parameter is supported for now either platform or platforms
   if (finalConfig.platforms != '' && finalConfig.platform != '') {
+    // both platform and platforms cannot be set at the same time
     throw new Exception("Only one platform parameter is supported for now either platform or platforms, prefer platforms")
   } else if (finalConfig.platform != '') {
+    // if platform is set, I override platforms with it
     finalConfig.platforms = finalConfig.platform
-  } else {
+  } else if (finalConfig.platforms == '') {
+    // if platforms is not set, I set it to linux/amd64 by default
     finalConfig.platforms = 'linux/amd64'
   }
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -145,7 +145,7 @@ def call(String imageShortName, Map userConfig=[:]) {
         stage("Build ${imageName}") {
           if (isUnix()) {
             if (finalConfig.dockerBakeFile != '') {
-              sh 'make buildbake'
+              sh 'env && make buildbake'
             } else {
               sh 'make build'
             }
@@ -235,7 +235,7 @@ def call(String imageShortName, Map userConfig=[:]) {
               // Please note that "make deploy" uses the environment variable "IMAGE_DEPLOY_NAME"
               if (isUnix()) {
                 if (finalConfig.dockerBakeFile != '') {
-                  sh 'make deploybake'
+                  sh 'env && make deploybake'
                 } else {
                   sh 'make deploy'
                 }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -150,7 +150,7 @@ def call(String imageShortName, Map userConfig=[:]) {
             } else {
               if (cstConfigSuffix == "") {
                 //linux ==> generated docker bake
-                withEnv (["PLATFORMS=[$finalConfig.platform]", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
+                withEnv (["PLATFORMS=$finalConfig.platform", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
                   sh 'make buildbake'
                 }
               } else {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -22,7 +22,7 @@ def call(String imageShortName, Map userConfig=[:]) {
   final Map finalConfig = defaultConfig << userConfig
 
   // DEBUG ONLY FOR PUSH
-  env.TAG_NAME = "0.0.1-beta"
+  env.TAG_NAME = "0.0.1"
 
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -22,21 +22,6 @@ def makecall(String action, String imageDeployName, String targetOperationSystem
     return
   }
 
-  if (action == 'deploy') {
-    if (env.TAG_NAME) {
-      if (imageDeployName.contains(env.TAG_NAME)) {
-        // The tag is already within the image name to deploy no need to add it again
-      } else {
-        // User could specify a tag in the image name. In that case the git tag is appended. Otherwise the docker tag is set to the git tag.
-        if (imageDeployName.contains(':')) {
-          imageDeployName += "-${env.TAG_NAME}"
-        } else {
-          imageDeployName += ":${env.TAG_NAME}"
-        }
-      }
-    }
-  }
-
   // Please note that "make deploy" and the generated bake deploy file uses the environment variable "IMAGE_DEPLOY_NAME"
   withEnv(["IMAGE_DEPLOY_NAME=${imageDeployName}"]) {
     if (isUnix()) {
@@ -53,10 +38,38 @@ def makecall(String action, String imageDeployName, String targetOperationSystem
           }
         } else {
           // old process still used for windows
+          if (action == 'deploy') {
+            if (env.TAG_NAME) {
+              if (imageDeployName.contains(env.TAG_NAME)) {
+                // The tag is already within the image name to deploy no need to add it again
+              } else {
+                // User could specify a tag in the image name. In that case the git tag is appended. Otherwise the docker tag is set to the git tag.
+                if (imageDeployName.contains(':')) {
+                  imageDeployName += "-${env.TAG_NAME}"
+                } else {
+                  imageDeployName += ":${env.TAG_NAME}"
+                }
+              }
+            }
+          }
           sh "make $action"
         }
       }
     } else {
+      if (action == 'deploy') {
+        if (env.TAG_NAME) {
+          if (imageDeployName.contains(env.TAG_NAME)) {
+            // The tag is already within the image name to deploy no need to add it again
+          } else {
+            // User could specify a tag in the image name. In that case the git tag is appended. Otherwise the docker tag is set to the git tag.
+            if (imageDeployName.contains(':')) {
+              imageDeployName += "-${env.TAG_NAME}"
+            } else {
+              imageDeployName += ":${env.TAG_NAME}"
+            }
+          }
+        }
+      }
       powershell "make $action"
     } // unix agent
   } // withEnv

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -150,8 +150,6 @@ def call(String imageShortName, Map userConfig=[:]) {
             } else {
               if (cstConfigSuffix == "") {
                 //linux ==> generated docker bake
-                env.
-                env.
                 withEnv (["PLATFORMS=$finalConfig.platform", "DOCKER_BAKE_FILE=$overrideDockerBakeFile"]) {
                   sh 'make buildbake'
                 }

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -11,12 +11,13 @@ The following arguments are available for this function:
   * Boolean **includeImageNameInTag**: (Optional, defaults to "false") Set to true for multiple semversioned images built in parallel, will include the image name in tag to avoid conflict
   * String **dockerfile**: (Optional, defaults to "Dockerfile") Relative path to the Dockerfile to use within the repository (Example: "build.dockerfile", "docker/Dockerfile").
   * String ~~**platform**~~: DEPRECATED (Optional, defaults to "linux/amd64") Name of the docker platform to use when building this image..
-  * String **targetplatforms**: (Optional, defaults to "linux/amd64") Name of the docker platforms separated by comma, to use as target when building this image. For multiple platforms use a comma separated list (Example: "linux/amd64,linux/arm64").
+  * String **targetplatforms**: (Optional, defaults to "linux/amd64") Define the (comma separated) list of Docker supported platforms to build the image for. Defaults to `linux/amd64` when unspecified. Incompatible with the legacy `platform` attribute.
   * String **nextVersionCommand** (Optional, defaults to "jx-release-version") If "automaticSemanticVersioning" is set, this is the command to retrieve the next version (to use for tagging and releasing)
   * String **gitCredentials**: (Optional, defaults to "") If "automaticSemanticVersioning" is set, name of the credential to use when tagging the git repository. Support user/password or GitHub App credential types.
   * String **imageDir**: (Optional, defaults to ".", the parent directory of the Dockerfile) Path to a directory to use as build context (Example: "docker/", "python/2.7") ref: https://docs.docker.com/engine/reference/commandline/build/#description.
   * String **registry**: (Optional, defaults to "" which defines the registry based on the current controller setup) Container registry to deploy this image to (Example: "ghcr.io", "python/2.7").
   * String **unstash**: (Optional, default to "") Allow to restore files from a previously saved stash if not empty, should contain the name of the last stashed as per https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#unstash-restore-files-previously-stashed.
+  * String **dockerBakeFile**: (Optionan, default to "") Specify the path to a custom Docker Bake file to use instead of the default one
 
 The lint phase generates a report when it fails, recorded by the hadolint tool in your Jenkins instance.
 

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -10,7 +10,8 @@ The following arguments are available for this function:
   * Boolean **automaticSemanticVersioning**: (Optional, defaults to "false") Should a release be created for every merge to the mainBranch. This uses "jx-release-version" to determine the version number based on the commit history.
   * Boolean **includeImageNameInTag**: (Optional, defaults to "false") Set to true for multiple semversioned images built in parallel, will include the image name in tag to avoid conflict
   * String **dockerfile**: (Optional, defaults to "Dockerfile") Relative path to the Dockerfile to use within the repository (Example: "build.dockerfile", "docker/Dockerfile").
-  * String **platform**: (Optional, defaults to "linux/amd64") Name of the docker platform to use when building this image. For multiple platforms use a comma separated list (Example: "linux/amd64,linux/arm64").
+  * String ~~**platform**~~: DEPRECATED (Optional, defaults to "linux/amd64") Name of the docker platform to use when building this image..
+  * String **targetplatforms**: (Optional, defaults to "linux/amd64") Name of the docker platforms separated by comma, to use as target when building this image. For multiple platforms use a comma separated list (Example: "linux/amd64,linux/arm64").
   * String **nextVersionCommand** (Optional, defaults to "jx-release-version") If "automaticSemanticVersioning" is set, this is the command to retrieve the next version (to use for tagging and releasing)
   * String **gitCredentials**: (Optional, defaults to "") If "automaticSemanticVersioning" is set, name of the credential to use when tagging the git repository. Support user/password or GitHub App credential types.
   * String **imageDir**: (Optional, defaults to ".", the parent directory of the Dockerfile) Path to a directory to use as build context (Example: "docker/", "python/2.7") ref: https://docs.docker.com/engine/reference/commandline/build/#description.
@@ -56,11 +57,18 @@ parallel(
     buildDockerAndPublishImage('maven-jdk8-nanoserver', [
       imageDir: 'maven/jdk8',
       dockerfile: 'Dockerfile.nanoserver',
-      platform: 'windows/amd64',
+      targetplatforms: 'windows/amd64',
       agentLabels: 'windows',
       automaticSemanticVersioning: true,
       includeImageNameInTag: true,
     ])
   },
 )
+</code></pre>
+
+Build of three linux images in parallel (imply docker bake inside)
+<pre><code>
+buildDockerAndPublishImage('wiki',[
+  targetplatforms: 'linux/amd64,linux/arm64,linux/s390x'
+]),
 </code></pre>


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3619
provide the ability to build docker images for multi platforms as linux/arm64, linux/amd64 etc ...

this use the bake mode to directly build multiplatform. 
It also convert "normal" one platform build for linux as docker bake build in buildx engine.


BREAKING CHANGES : 

- ⚠️ the `makefile` parameter `IMAGE_PLATFORM` change for`BUILD_TARGETPLATFORM`
- the pipeline library parameter `platform` change for `targetplatforms` (the deprecated parameter is still consume for now)


