### PR TITLE
fix(buildDockerAndPublishImage.groovy): fix ath build

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -72,8 +72,6 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 
 bake-build: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file $(DOCKER_BAKE_FILE)"
-	@echo "== DEBUG : IMAGE_DIR $(IMAGE_DIR), IMAGE_DEPLOY_NAME $(IMAGE_DEPLOY_NAME), IMAGE_DOCKERFILE $(IMAGE_DOCKERFILE), BAKE_TARGETPLATFORMS $(BAKE_TARGETPLATFORMS)"
-	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" --print
 	@docker buildx bake -f "$(DOCKER_BAKE_FILE)"
 	@echo "== Build succeeded"
 

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -12,13 +12,17 @@ IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
 BUILD_TARGETPLATFORM ?= linux/amd64
 # Paths
-# need absolute path for docker bake
-ifeq ($(IMAGE_DOCKERFILE),)
-	IMAGE_DOCKERFILE := $(abspath $(PWD)/Dockerfile)
+# Detect Windows (only OS separating paths in $PATH with ";") to set specific absolute paths for linux (bake) only
+ifeq '$(findstring ;,$(PATH))' ';'
+	IMAGE_DOCKERFILE ?= "$(IMAGE_DIR)"/Dockerfile
 else
-	IMAGE_DOCKERFILE := $(abspath $(PWD)/$(IMAGE_DOCKERFILE))
+	# need absolute path for docker bake
+	ifeq ($(IMAGE_DOCKERFILE),)
+		IMAGE_DOCKERFILE := $(abspath $(PWD)/Dockerfile)
+	else
+		IMAGE_DOCKERFILE := $(abspath $(PWD)/$(IMAGE_DOCKERFILE))
+	endif
 endif
-
 HADOLINT_REPORT ?= "$(IMAGE_DIR)"/hadolint.json
 TEST_HARNESS ?= "$(IMAGE_DIR)"/cst.yml
 DOCKER_BAKE_FILE ?= "$(IMAGE_DIR)"/docker-bake.hcl

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -29,14 +29,14 @@ GIT_SCM_URL ?= $(shell git config --get remote.origin.url)
 SCM_URI ?= $(subst git@github.com:,https://github.com/,"$(GIT_SCM_URL)")
 BUILD_DATE ?= $(shell date --utc '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || gdate --utc '+%Y-%m-%dT%H:%M:%S')
 
-export 	IMAGE_DEPLOY_NAME 		\
-		TAG_NAME 				\
-		BAKE_TARGETPLATFORMS 	\
-		IMAGE_DOCKERFILE 		\
-		IMAGE_DIR 				\
-		GIT_COMMIT_REV 			\
-		GIT_SCM_URL 			\
-		BUILD_DATE 				\
+export 	IMAGE_DEPLOY_NAME \
+		TAG_NAME \
+		BAKE_TARGETPLATFORMS \
+		IMAGE_DOCKERFILE \
+		IMAGE_DIR \
+		GIT_COMMIT_REV \
+		GIT_SCM_URL \
+		BUILD_DATE \
 		SCM_URI
 
 help: ## Show this Makefile's help

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -1,17 +1,24 @@
 # Detect Windows (only OS separating paths in $PATH with ";") to set specific variable and function to get compatible paths
+IMAGE_DIR ?= .
 ifeq '$(findstring ;,$(PATH))' ';'
 	FixPath = $(subst /,\,$1)
-	IMAGE_DIR ?= .
 else
 	FixPath = $1
-	IMAGE_DIR ?= $(PWD)
+	# need absolute path for docker bake
+	IMAGE_DIR := $(abspath $(PWD)/$(IMAGE_DIR))
 endif
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
 BUILD_TARGETPLATFORM ?= linux/amd64
 # Paths
-IMAGE_DOCKERFILE ?= "$(IMAGE_DIR)"/Dockerfile
+# need absolute path for docker bake
+ifeq ($(IMAGE_DOCKERFILE),)
+	IMAGE_DOCKERFILE := $(abspath $(PWD)/Dockerfile)
+else
+	IMAGE_DOCKERFILE := $(abspath $(PWD)/$(IMAGE_DOCKERFILE))
+endif
+
 HADOLINT_REPORT ?= "$(IMAGE_DIR)"/hadolint.json
 TEST_HARNESS ?= "$(IMAGE_DIR)"/cst.yml
 DOCKER_BAKE_FILE ?= "$(IMAGE_DIR)"/docker-bake.hcl
@@ -21,6 +28,16 @@ GIT_COMMIT_REV ?= $(shell git log -n 1 --pretty=format:'%h')
 GIT_SCM_URL ?= $(shell git config --get remote.origin.url)
 SCM_URI ?= $(subst git@github.com:,https://github.com/,"$(GIT_SCM_URL)")
 BUILD_DATE ?= $(shell date --utc '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || gdate --utc '+%Y-%m-%dT%H:%M:%S')
+
+export 	IMAGE_DEPLOY_NAME 		\
+		TAG_NAME 				\
+		BAKE_TARGETPLATFORMS 	\
+		IMAGE_DOCKERFILE 		\
+		IMAGE_DIR 				\
+		GIT_COMMIT_REV 			\
+		GIT_SCM_URL 			\
+		BUILD_DATE 				\
+		SCM_URI
 
 help: ## Show this Makefile's help
 	@echo "Help:"
@@ -54,10 +71,10 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 	@echo "== Build succeeded"
 
 bake-build: ## Build the Docker Image(s) with dockerbake file
-	@echo "== Building from DockerBake file "
+	@echo "== Building from DockerBake file $(DOCKER_BAKE_FILE)"
 	@echo "== DEBUG : IMAGE_DIR $(IMAGE_DIR), IMAGE_DEPLOY_NAME $(IMAGE_DEPLOY_NAME), IMAGE_DOCKERFILE $(IMAGE_DOCKERFILE), BAKE_TARGETPLATFORMS $(BAKE_TARGETPLATFORMS)"
-	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
-	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
+	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" --print
+	@docker buildx bake -f "$(DOCKER_BAKE_FILE)"
 	@echo "== Build succeeded"
 
 

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -56,7 +56,9 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 bake-build: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file "
 	@echo "== DEBUG : IMAGE_DIR $(IMAGE_DIR), IMAGE_DEPLOY_NAME $(IMAGE_DEPLOY_NAME), IMAGE_DOCKERFILE $(IMAGE_DOCKERFILE), BAKE_TARGETPLATFORMS $(BAKE_TARGETPLATFORMS)"
+	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --print
 	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
+	@echo "== Build succeeded"
 
 
 clean: ## Delete any file generated during the build steps

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -54,7 +54,8 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 	@echo "== Build succeeded"
 
 bake-build: ## Build the Docker Image(s) with dockerbake file
-	@echo "== Building from DockerBake file"
+	@echo "== Building from DockerBake file "
+	@echo "== DEBUG : IMAGE_DIR $(IMAGE_DIR), IMAGE_DEPLOY_NAME $(IMAGE_DEPLOY_NAME), IMAGE_DOCKERFILE $(IMAGE_DOCKERFILE), BAKE_TARGETPLATFORMS $(BAKE_TARGETPLATFORMS)"
 	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))"
 
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -188,7 +188,7 @@ def call(String imageShortName, Map userConfig=[:]) {
                 sh 'make lint'
               } else {
                 powershell "$pwd"
-                powershell 'dir c:\maven\jdk11'
+                powershell 'dir c:\\maven\\jdk11'
                 powershell 'make lint'
               }
             } finally {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -187,8 +187,6 @@ def call(String imageShortName, Map userConfig=[:]) {
               if (isUnix()) {
                 sh 'make lint'
               } else {
-                powershell "$pwd"
-                powershell 'dir c:\\maven\\jdk11'
                 powershell 'make lint'
               }
             } finally {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -187,6 +187,8 @@ def call(String imageShortName, Map userConfig=[:]) {
               if (isUnix()) {
                 sh 'make lint'
               } else {
+                powershell "$pwd"
+                powershell 'dir c:\maven\jdk11'
                 powershell 'make lint'
               }
             } finally {


### PR DESCRIPTION
as per https://github.com/jenkinsci/acceptance-test-harness/pull/1356#issuecomment-1706939223
and following https://github.com/jenkins-infra/pipeline-library/pull/739

this should correct the bug in the Path due to the absolute vs relative definition

tested on wiki (default path): https://infra.ci.jenkins.io/job/docker-jobs/job/docker-confluence-data/job/main/131/pipeline-graph/
tested on ATH (manually defined path): https://infra.ci.jenkins.io/job/docker-jobs/job/acceptance-test-harness/job/master/289/pipeline-graph/
tested on docker-inbound-agent (windows/legacy build): https://infra.ci.jenkins.io/job/docker-jobs/job/docker-inbound-agents/job/main/178/pipeline-console/
