### PR TITLE
chore(infra.withDockerCredentials): fix `--password via the CLI is insecure` warning

### DIFF
--- a/test/groovy/BaseTest.groovy
+++ b/test/groovy/BaseTest.groovy
@@ -65,6 +65,7 @@ class BaseTest extends DeclarativePipelineTest {
 
     helper.registerAllowedMethod('sh', [String.class], { s -> s })
     helper.registerAllowedMethod('powershell', [String.class], { s -> s })
+    helper.registerAllowedMethod('pwsh', [String.class], { s -> s })
     helper.registerAllowedMethod('stage', [String.class], { s -> s })
     helper.registerAllowedMethod('timeout', [String.class], { s -> s })
     helper.registerAllowedMethod('timeout', [Integer.class, Closure.class], { list, body -> body() })

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -135,7 +135,7 @@ class InfraStepTests extends BaseTest {
     printCallStack()
     assertTrue(isOK)
     assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('powershell', 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW}"'))
+    assertTrue(assertMethodCallContainsPattern('powershell', 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW} 2>&1 > $tmpFolder/discarded_output.log"'))
   }
 
   @Test

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -135,7 +135,7 @@ class InfraStepTests extends BaseTest {
     printCallStack()
     assertTrue(isOK)
     assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('powershell', 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW} 2>&1 > $tmpFolder/discarded_output.log"'))
+    assertTrue(assertMethodCallContainsPattern('powershell', 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW}"'))
   }
 
   @Test

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -135,7 +135,7 @@ class InfraStepTests extends BaseTest {
     printCallStack()
     assertTrue(isOK)
     assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('powershell', 'Write-Output ${env:DOCKER_CONFIG_PSW} | & ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin'))
+    assertTrue(assertMethodCallContainsPattern('pwsh', 'Write-Output ${env:DOCKER_CONFIG_PSW} | & ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin'))
   }
 
   @Test

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -135,7 +135,7 @@ class InfraStepTests extends BaseTest {
     printCallStack()
     assertTrue(isOK)
     assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('powershell', 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW}"'))
+    assertTrue(assertMethodCallContainsPattern('powershell', 'Write-Output ${env:DOCKER_CONFIG_PSW} | & ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin'))
   }
 
   @Test

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -42,7 +42,7 @@ Object withDockerCredentials(Map orgAndCredentialsId, Closure body) {
         if (isUnix()) {
           sh 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'
         } else {
-          powershell 'Write-Output ${env:DOCKER_CONFIG_PSW} | & ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin'
+          pwsh 'Write-Output ${env:DOCKER_CONFIG_PSW} | & ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin'
         }
 
         body.call()
@@ -50,7 +50,7 @@ Object withDockerCredentials(Map orgAndCredentialsId, Closure body) {
         if (isUnix()) {
           sh '"${CONTAINER_BIN}" logout'
         } else {
-          powershell 'Invoke-Expression "${Env:CONTAINER_BIN} logout"'
+          pwsh 'Invoke-Expression "${Env:CONTAINER_BIN} logout"'
         }
         return
       } // withCredentials

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -42,7 +42,7 @@ Object withDockerCredentials(Map orgAndCredentialsId, Closure body) {
         if (isUnix()) {
           sh 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'
         } else {
-          powershell 'Invoke-Expression "Write-Output ${env:DOCKER_CONFIG_PSW} | ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin"'
+          powershell 'Write-Output ${env:DOCKER_CONFIG_PSW} | & ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin'
         }
 
         body.call()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -42,15 +42,7 @@ Object withDockerCredentials(Map orgAndCredentialsId, Closure body) {
         if (isUnix()) {
           sh 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'
         } else {
-          def tmpFolder = pwd(tmp:true)
-          powershell '''
-            Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW} 2>&1 > $tmpFolder/discarded_output.log"
-            if($lastExitCode -ne 0) {
-              exit $lastExitCode
-            } else {
-              Write-Host 'Docker login succeeded.'
-            }
-          '''
+          powershell 'Write-Output ${env:DOCKER_CONFIG_PSW} | & ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin'
         }
 
         body.call()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -42,7 +42,7 @@ Object withDockerCredentials(Map orgAndCredentialsId, Closure body) {
         if (isUnix()) {
           sh 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'
         } else {
-          powershell 'Invoke-Expression "${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password ${Env:DOCKER_CONFIG_PSW}"'
+          powershell 'Invoke-Expression "Write-Output ${env:DOCKER_CONFIG_PSW} | ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin"'
         }
 
         body.call()


### PR DESCRIPTION
This PR removes the first following warning from logs when calling `infra.withDockerCredentials` function on Windows agents:

```console
powershell.exe : WARNING! Using --password via the CLI is insecure. Use --password-stdin.
 At C:\Jenkins\agent\workspace\Packaging_docker_PR-1770@tmp\durable-ba669f40\powershellWrapper.ps1:3 char:1
 + & powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Comm ...
 + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : NotSpecified: (WARNING! Using ...password-stdin.:String) [], RemoteException
     + FullyQualifiedErrorId : NativeCommandError
  
 WARNING! Your password will be stored unencrypted in C:\Windows\system32\config\systemprofile\.docker\config.json.
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
 Login Succeeded
```

Note: the second warning should also be dealt with (not in this PR).

Tested in https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/107

https://ci.jenkins.io/job/Plugins/job/jenkins-infra-test-plugin/job/PR-107/2/console ✅ 

Closes https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/107
