### PR TITLE
feat(buildDockerAndPublishImage): add optional `disablePublication` parameter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -204,6 +204,7 @@ Name of the docker image to build
 * unstash: Allow to unstash files if not empty
 * dockerBakeFile: Allow to build from a bake file instead
 * dockerBakeTarget: Allow to specify a docker bake target other than 'default'
+* disablePublication: (Optional, default to false) Allow to disable tagging and publication of container image and GitHub release
 
 ==== Example
 [source, groovy]

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -266,17 +266,17 @@ def call(String imageShortName, Map userConfig=[:]) {
         } // if
       }// withDockerPullCredentials
 
-      if (!finalConfig.disablePublication) {
-        infra.withDockerPushCredentials{
-          if (env.TAG_NAME || env.BRANCH_IS_PRIMARY) {
-            stage("Deploy ${imageName}") {
+      if (env.TAG_NAME || env.BRANCH_IS_PRIMARY) {
+        stage("Deploy ${imageName}") {
+          if (!finalConfig.disablePublication) {
+            infra.withDockerPushCredentials{
               makecall('deploy', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget)
-            }
-          } // if
-        } // withDockerPushCredentials
-      } else {
-        echo 'INFO: publication disabled.'
-      } // else
+            } // withDockerPushCredentials
+          } else {
+            echo 'INFO: publication disabled.'
+          } // else
+        } // stage
+      } // if
 
       if (env.TAG_NAME && finalConfig.automaticSemanticVersioning) {
         stage('GitHub Release') {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -274,7 +274,9 @@ def call(String imageShortName, Map userConfig=[:]) {
             }
           } // if
         } // withDockerPushCredentials
-      } // if
+      } else {
+        echo 'INFO: publication disabled.'
+      } // else
 
       if (env.TAG_NAME && finalConfig.automaticSemanticVersioning) {
         stage('GitHub Release') {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -51,6 +51,7 @@ def call(String imageShortName, Map userConfig=[:]) {
     unstash: '', // Allow to unstash files if not empty
     dockerBakeFile: '', // Specify the path to a custom Docker Bake file to use instead of the default one
     dockerBakeTarget: 'default', // Specify the target of a custom Docker Bake file to work with
+    disablePublication: false, // Allow to disable tagging and publication of container image and GitHub release (true by default)
   ]
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
   final Map finalConfig = defaultConfig << userConfig
@@ -58,7 +59,7 @@ def call(String imageShortName, Map userConfig=[:]) {
   // Retrieve Library's Static File Resources
   final String makefileContent = libraryResource 'io/jenkins/infra/docker/Makefile'
 
-  final boolean semVerEnabledOnPrimaryBranch = finalConfig.automaticSemanticVersioning && env.BRANCH_IS_PRIMARY
+  final boolean semVerEnabledOnPrimaryBranch = finalConfig.automaticSemanticVersioning && !finalConfig.disablePublication && env.BRANCH_IS_PRIMARY
 
   // Only run 1 build at a time on primary branch to ensure builds won't use the same tag when semantic versionning is activated
   if (env.BRANCH_IS_PRIMARY) {
@@ -225,7 +226,7 @@ def call(String imageShortName, Map userConfig=[:]) {
           } // if else
         } // each
 
-        // Automatic tagging on principal branch is not enabled by default
+        // Automatic tagging on principal branch is not enabled by default, and disabled if disablePublication is set to true
         if (semVerEnabledOnPrimaryBranch) {
           stage("Semantic Release of ${imageName}") {
             echo "Configuring credential.helper"
@@ -264,14 +265,16 @@ def call(String imageShortName, Map userConfig=[:]) {
           } // stage
         } // if
       }// withDockerPullCredentials
-      infra.withDockerPushCredentials{
-        if (env.TAG_NAME || env.BRANCH_IS_PRIMARY) {
-          stage("Deploy ${imageName}") {
-            makecall('deploy', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget)
-          }
-        } // if
-      } // withDockerPushCredentials
 
+      if (!finalConfig.disablePublication) {
+        infra.withDockerPushCredentials{
+          if (env.TAG_NAME || env.BRANCH_IS_PRIMARY) {
+            stage("Deploy ${imageName}") {
+              makecall('deploy', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget)
+            }
+          } // if
+        } // withDockerPushCredentials
+      } // if
 
       if (env.TAG_NAME && finalConfig.automaticSemanticVersioning) {
         stage('GitHub Release') {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -271,7 +271,7 @@ def call(String imageShortName, Map userConfig=[:]) {
           if (!finalConfig.disablePublication) {
             infra.withDockerPushCredentials{
               makecall('deploy', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget)
-            } // withDockerPushCredentials
+            }
           } else {
             echo 'INFO: publication disabled.'
           } // else

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -19,6 +19,7 @@ The following arguments are available for this function:
   * String **unstash**: (Optional, default to "") Allow to restore files from a previously saved stash if not empty, should contain the name of the last stashed as per https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#unstash-restore-files-previously-stashed.
   * String **dockerBakeFile**: (Optionan, default to "") Specify the path to a custom Docker Bake file to use instead of the default one
   * String **dockerBakeTarget**: (Optional, default to "default") Specify the target of a custom Docker Bake file to work with
+  * Boolean **disablePublication**: (Optional, default to false) Allow to disable tagging and publication of container image and GitHub release
 
 The lint phase generates a report when it fails, recorded by the hadolint tool in your Jenkins instance.
 


### PR DESCRIPTION
This PR adds a parameter to disable tagging and publication of docker image(s) and github release.

Use case: running the same pipeline on both ci.jenkins.io and infra.ci.jenkins.io

Tested with https://github.com/jenkins-infra/account-app/pull/351

Confirmed working as expected: https://ci.jenkins.io/job/Infra/job/account-app/job/main/167/pipeline-console/log?nodeId=87

> [2024-02-10T13:15:21.549Z] INFO: publication disabled.

The main branch job passed on ci.jenkins.io.

Ref:
- https://github.com/jenkins-infra/plugin-site-api/pull/142
- https://github.com/jenkins-infra/account-app/pull/339#issuecomment-1872404386