### PR TITLE
chore: show `--print` output when using docker bake to publish an image

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -76,6 +76,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 
 bake-build: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building from DockerBake file $(DOCKER_BAKE_FILE)"
+	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" --print
 	@docker buildx bake -f "$(DOCKER_BAKE_FILE)"
 	@echo "== Build succeeded"
 


### PR DESCRIPTION
This PR adds the docker bake `--print` option output (https://docs.docker.com/engine/reference/commandline/buildx_bake/#print) when publishing an image with a docker bake file with `buildDockerAndPublishImage`.

Test:
- https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1462
- https://infra.ci.jenkins.io/job/docker-jobs/job/docker-jenkins-weekly/job/PR-1462/5/execution/node/48/log/?consoleFull
