### PR TITLE
feat(buildDockerAndPublishImage): allow to specify a target when using docker bake

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -203,6 +203,7 @@ Name of the docker image to build
 * registryNamespace: empty = autodiscover based on the current controller, but can override the smart default of jenkinsciinfra/ or jenkins4eval/
 * unstash: Allow to unstash files if not empty
 * dockerBakeFile: Allow to build from a bake file instead
+* dockerBakeTarget: Allow to specify a docker bake target other than 'default'
 
 ==== Example
 [source, groovy]

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -8,6 +8,9 @@ else
 	IMAGE_DIR := $(abspath $(PWD)/$(IMAGE_DIR))
 endif
 
+current_arch := $(shell uname -m)
+export ARCH ?= $(shell case $(current_arch) in (x86_64) echo "amd64" ;; (i386) echo "386";; (aarch64|arm64) echo "arm64" ;; (armv6*) echo "arm/v6";; (armv7*) echo "arm/v7";; (s390*|riscv*|ppc64le) echo $(current_arch);; (*) echo "UNKNOWN-CPU";; esac)
+
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
 BUILD_TARGETPLATFORM ?= linux/amd64
@@ -77,7 +80,7 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 
 bake-build: ## Build the Docker Image(s) with dockerbake file
 	@echo "== Building ${DOCKER_BAKE_TARGET} target from DockerBake file $(DOCKER_BAKE_FILE)"
-	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" "$(DOCKER_BAKE_TARGET)" --print
+	@make show
 	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" "$(DOCKER_BAKE_TARGET)"
 	@echo "== Build succeeded"
 
@@ -92,11 +95,22 @@ test: ## Execute the test harness on the Docker Image
 	container-structure-test test --driver=docker --image="$(IMAGE_NAME)" --config="$(call FixPath,$(TEST_HARNESS))"
 	@echo "== Test succeeded"
 
-bake-test: ## Execute the test harness on the Docker Image with load
+show:
+	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" "$(DOCKER_BAKE_TARGET)" --print
+
+list:
+	@set -x; make --silent show | jq -r '.target | path(.. | select(.platforms[] | contains("linux/$(ARCH)"))?) | add'
+
+bake-test: ## Execute the test harness on the Docker image(s) with load
 	@echo "== Load $(IMAGE_NAME) within docker engine from docker bake buildx engine"
-	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" "$(DOCKER_BAKE_TARGET)" --set "*.platform=linux/$(shell dpkg --print-architecture)"  --load
-	@echo "== Test $(IMAGE_NAME) with $(call FixPath,$(TEST_HARNESS)) from $(IMAGE_NAME) with container-structure-test:"
-	container-structure-test test --driver=docker --image="$(IMAGE_NAME)" --config="$(call FixPath,$(TEST_HARNESS))"
+	@make show
+	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" "$(DOCKER_BAKE_TARGET)" --set "*.platform=linux/$(ARCH)"  --load
+	@make --silent list | while read image; do make --silent "bake-test-$${image}"; done
+	@echo "== All tests succeeded"
+
+bake-test-%: ## Execute the test harness on the tag of an image
+	@echo "== Test $(IMAGE_NAME):latest-$* with $(call FixPath,$(TEST_HARNESS)) from $(IMAGE_NAME) with container-structure-test:"
+	container-structure-test test --driver=docker --image="$(IMAGE_NAME):latest-$*" --config="$(call FixPath,$(TEST_HARNESS))"
 	@echo "== Test succeeded"
 
 ## This steps expects that you are logged to the Docker registry to push image into

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -26,6 +26,7 @@ endif
 HADOLINT_REPORT ?= "$(IMAGE_DIR)"/hadolint.json
 TEST_HARNESS ?= "$(IMAGE_DIR)"/cst.yml
 DOCKER_BAKE_FILE ?= "$(IMAGE_DIR)"/docker-bake.hcl
+DOCKER_BAKE_TARGET ?= default
 
 ## Image metadatas
 GIT_COMMIT_REV ?= $(shell git log -n 1 --pretty=format:'%h')
@@ -75,9 +76,9 @@ build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)
 	@echo "== Build succeeded"
 
 bake-build: ## Build the Docker Image(s) with dockerbake file
-	@echo "== Building from DockerBake file $(DOCKER_BAKE_FILE)"
-	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" --print
-	@docker buildx bake -f "$(DOCKER_BAKE_FILE)"
+	@echo "== Building ${DOCKER_BAKE_TARGET} target from DockerBake file $(DOCKER_BAKE_FILE)"
+	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" "$(DOCKER_BAKE_TARGET)" --print
+	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" "$(DOCKER_BAKE_TARGET)"
 	@echo "== Build succeeded"
 
 
@@ -93,7 +94,7 @@ test: ## Execute the test harness on the Docker Image
 
 bake-test: ## Execute the test harness on the Docker Image with load
 	@echo "== Load $(IMAGE_NAME) within docker engine from docker bake buildx engine"
-	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --set "*.platform=linux/$(shell dpkg --print-architecture)"  --load
+	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" "$(DOCKER_BAKE_TARGET)" --set "*.platform=linux/$(shell dpkg --print-architecture)"  --load
 	@echo "== Test $(IMAGE_NAME) with $(call FixPath,$(TEST_HARNESS)) from $(IMAGE_NAME) with container-structure-test:"
 	container-structure-test test --driver=docker --image="$(IMAGE_NAME)" --config="$(call FixPath,$(TEST_HARNESS))"
 	@echo "== Test succeeded"
@@ -106,7 +107,7 @@ deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 	@echo "== Deploy succeeded"
 
 bake-deploy:  ## Tag and push the built image as specified by docker bake file
-	@echo "== Deploying with docker bake file"
-	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" --push
+	@echo "== Deploying $(DOCKER_BAKE_TARGET) target with docker bake file"
+	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" "$(DOCKER_BAKE_TARGET)" --push
 
 .PHONY: all clean lint build test deploy

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -95,11 +95,11 @@ test: ## Execute the test harness on the Docker Image
 	container-structure-test test --driver=docker --image="$(IMAGE_NAME)" --config="$(call FixPath,$(TEST_HARNESS))"
 	@echo "== Test succeeded"
 
-show:
+show: ## Show the output of docker buildx bake --print
 	@docker buildx bake -f "$(DOCKER_BAKE_FILE)" "$(DOCKER_BAKE_TARGET)" --print
 
-list:
-	@set -x; make --silent show | jq -r '.target | path(.. | select(.platforms[] | contains("linux/$(ARCH)"))?) | add'
+list: ## List the first tag of each target including the same platform than the current architecture, with "/" replaced by "#"
+	@set -x; make --silent show | jq -r '.target | to_entries[] | select(.value.platforms[] | contains("linux/$(ARCH)")) | .value.tags[0] | gsub("/"; "#")'
 
 bake-test: ## Execute the test harness on the Docker image(s) with load
 	@echo "== Load $(IMAGE_NAME) within docker engine from docker bake buildx engine"
@@ -109,8 +109,8 @@ bake-test: ## Execute the test harness on the Docker image(s) with load
 	@echo "== All tests succeeded"
 
 bake-test-%: ## Execute the test harness on the tag of an image
-	@echo "== Test $(IMAGE_NAME):latest-$* with $(call FixPath,$(TEST_HARNESS)) from $(IMAGE_NAME) with container-structure-test:"
-	container-structure-test test --driver=docker --image="$(IMAGE_NAME):latest-$*" --config="$(call FixPath,$(TEST_HARNESS))"
+	@echo "== Test $(subst #,/,$*) with $(call FixPath,$(TEST_HARNESS)) from $(IMAGE_NAME) with container-structure-test:"
+	container-structure-test test --driver=docker --image="$(subst #,/,$*)" --config="$(call FixPath,$(TEST_HARNESS))"
 	@echo "== Test succeeded"
 
 ## This steps expects that you are logged to the Docker registry to push image into

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -4,7 +4,7 @@ import java.util.Date
 import java.text.DateFormat
 
 // makecall is a function to concentrate all the call to 'make'
-def makecall(String action, String imageDeployName, String targetOperationSystem, String specificDockerBakeFile) {
+def makecall(String action, String imageDeployName, String targetOperationSystem, String specificDockerBakeFile, String dockerBakeTarget) {
   final String bakefileContent = libraryResource 'io/jenkins/infra/docker/jenkinsinfrabakefile.hcl'
   // Please note that "make deploy" and the generated bake deploy file uses the environment variable "IMAGE_DEPLOY_NAME"
   if (isUnix()) {
@@ -12,7 +12,11 @@ def makecall(String action, String imageDeployName, String targetOperationSystem
       specificDockerBakeFile = 'jenkinsinfrabakefile.hcl'
       writeFile file: specificDockerBakeFile, text: bakefileContent
     }
-    withEnv(["DOCKER_BAKE_FILE=${specificDockerBakeFile}", "IMAGE_DEPLOY_NAME=${imageDeployName}"]) {
+    withEnv([
+      "DOCKER_BAKE_FILE=${specificDockerBakeFile}",
+      "DOCKER_BAKE_TARGET=${dockerBakeTarget}",
+      "IMAGE_DEPLOY_NAME=${imageDeployName}"
+    ]) {
       sh 'export BUILDX_BUILDER_NAME=buildx-builder; docker buildx use "${BUILDX_BUILDER_NAME}" 2>/dev/null || docker buildx create --use --name="${BUILDX_BUILDER_NAME}"'
       sh "make bake-$action"
     }
@@ -46,6 +50,7 @@ def call(String imageShortName, Map userConfig=[:]) {
     registryNamespace: '', // Empty by default (means "autodiscover based on the current controller")
     unstash: '', // Allow to unstash files if not empty
     dockerBakeFile: '', // Specify the path to a custom Docker Bake file to use instead of the default one
+    dockerBakeTarget: 'default', // Specify the target of a custom Docker Bake file to work with
   ]
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
   final Map finalConfig = defaultConfig << userConfig
@@ -101,7 +106,7 @@ def call(String imageShortName, Map userConfig=[:]) {
   String operatingSystem = finalConfig.targetplatforms.split('/')[0]
 
   if (operatingSystem == 'windows' && finalConfig.dockerBakeFile != '') {
-    echo 'ERROR: dockerBakeFile is not supported on windows.'
+    echo 'ERROR: docker bake is not (yet) supported on windows.'
     currentBuild.result = 'FAILURE'
     return
   }
@@ -200,7 +205,7 @@ def call(String imageShortName, Map userConfig=[:]) {
         } // stage
 
         stage("Build ${imageName}") {
-          makecall('build', imageName, operatingSystem, finalConfig.dockerBakeFile)
+          makecall('build', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget)
         } //stage
 
         // There can be 2 kind of tests: per image and per repository
@@ -212,7 +217,7 @@ def call(String imageShortName, Map userConfig=[:]) {
           if (fileExists(testHarness)) {
             stage("Test ${testName} for ${imageName}") {
               withEnv(["TEST_HARNESS=${testHarness}"]) {
-                makecall('test', imageName, operatingSystem, finalConfig.dockerBakeFile)
+                makecall('test', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget)
               } // withEnv
             } //stage
           } else {
@@ -262,7 +267,7 @@ def call(String imageShortName, Map userConfig=[:]) {
       infra.withDockerPushCredentials{
         if (env.TAG_NAME || env.BRANCH_IS_PRIMARY) {
           stage("Deploy ${imageName}") {
-            makecall('deploy', imageName, operatingSystem, finalConfig.dockerBakeFile)
+            makecall('deploy', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget)
           }
         } // if
       } // withDockerPushCredentials

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -18,7 +18,7 @@ The following arguments are available for this function:
   * String **registry**: (Optional, defaults to "" which defines the registry based on the current controller setup) Container registry to deploy this image to (Example: "ghcr.io", "python/2.7").
   * String **unstash**: (Optional, default to "") Allow to restore files from a previously saved stash if not empty, should contain the name of the last stashed as per https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#unstash-restore-files-previously-stashed.
   * String **dockerBakeFile**: (Optionan, default to "") Specify the path to a custom Docker Bake file to use instead of the default one
-  * String **dockerBakeTarget**: (Optionan, default to "default") Specify the target of a custom Docker Bake file to work with
+  * String **dockerBakeTarget**: (Optional, default to "default") Specify the target of a custom Docker Bake file to work with
 
 The lint phase generates a report when it fails, recorded by the hadolint tool in your Jenkins instance.
 

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -18,6 +18,7 @@ The following arguments are available for this function:
   * String **registry**: (Optional, defaults to "" which defines the registry based on the current controller setup) Container registry to deploy this image to (Example: "ghcr.io", "python/2.7").
   * String **unstash**: (Optional, default to "") Allow to restore files from a previously saved stash if not empty, should contain the name of the last stashed as per https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#unstash-restore-files-previously-stashed.
   * String **dockerBakeFile**: (Optionan, default to "") Specify the path to a custom Docker Bake file to use instead of the default one
+  * String **dockerBakeTarget**: (Optionan, default to "default") Specify the target of a custom Docker Bake file to work with
 
 The lint phase generates a report when it fails, recorded by the hadolint tool in your Jenkins instance.
 


### PR DESCRIPTION
This PR adds a `dockerBakeTarget` parameter to the `buildDockerAndPublishImage` function to allow specifying a target when using docker bake.

This PR also fixes the fact that before this change when using docker bake, cst tests are executed only on the image with the `latest` tag instead of testing all<sup>*</sup> built targets.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3887

*: with a platform corresponding to the architecture of the machine executing the tests.