### PR TITLE
Revert "Bump `hashicorp-tools` docker image to 1.0.62"

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -9,7 +9,7 @@ def call(userConfig = [:]) {
     stagingCredentials: [], // No custom secrets for staging by default
     productionCredentials: [], // No custom secrets for production by default
     productionBranch: 'main', // Defaults to the principal branch
-    agentContainerImage: 'jenkinsciinfra/hashicorp-tools:1.0.62', // Version managed by updatecli
+    agentContainerImage: 'jenkinsciinfra/hashicorp-tools:1.0.60', // Version managed by updatecli
     runTests: false, // Executes the tests provided by the "calling" project, which should provide a tests/Makefile
     runCommonTests: true, // Executes the default test suite from the shared tools repository (terratest)
   ]


### PR DESCRIPTION
Reverts jenkins-infra/pipeline-library#824