### PR TITLE
chore(buildDockerAndPublishImage): annotate GitHub release with `make show` output

### DIFF
--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -303,7 +303,7 @@ def call(String imageShortName, Map userConfig=[:]) {
                     body="$(gh api "${releasesUrl}/${releaseId}" | jq -e -r '.body')"
                     body+='
 
-## :memo: Release settings
+## :memo: What's in this release
 
 <details>
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -304,7 +304,7 @@ def call(String imageShortName, Map userConfig=[:]) {
 
 ```yaml
 '
-                    body+="$(echo ${MAKE_SHOW_CONTENT} | yq --prettyPrint"
+                    body+="$(echo ${MAKE_SHOW_CONTENT} | yq --prettyPrint)"
                     body+='
 ```
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -297,14 +297,16 @@ def call(String imageShortName, Map userConfig=[:]) {
                   then
                     body="$(gh api "${releasesUrl}/${releaseId}" | jq -e -r '.body')"
                     body+='
-                    <hr><details><summary>Details:</summary>
+<details><summary>Settings used for this release:</summary>
 
-                    ```yaml'
+```yaml
+'
                     body+="${MAKE_SHOW_CONTENT}"
                     body+='
-                    ```
+```
 
-                    </details>'
+</details>
+'
                     echo "-------- body ---------"
                     echo "${body}"
                     echo "------ end body -------"

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -297,7 +297,10 @@ def call(String imageShortName, Map userConfig=[:]) {
                   then
                     body="$(gh api "${releasesUrl}/${releaseId}" | jq -e -r '.body')"
                     body+='
-<details><summary>Settings used for this release:</summary>
+
+## :memo: Release settings
+
+<details>
 
 ```yaml
 '
@@ -307,9 +310,6 @@ def call(String imageShortName, Map userConfig=[:]) {
 
 </details>
 '
-                    echo "-------- body ---------"
-                    echo "${body}"
-                    echo "------ end body -------"
                     gh api -X PATCH -F draft=false -F name="${TAG_NAME}" -F tag_name="${TAG_NAME}" -F body="${body}" "${releasesUrl}/${releaseId}" > /dev/null
                   fi
                   echo "${releaseId}"

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -289,7 +289,19 @@ def call(String imageShortName, Map userConfig=[:]) {
                 releaseId="$(gh api "${releasesUrl}" | jq -e -r '[ .[] | select(.draft == true and .name == "next").id] | max | select(. != null)')"
                 if test "${releaseId}" -gt 0
                 then
-                  gh api -X PATCH -F draft=false -F name="${TAG_NAME}" -F tag_name="${TAG_NAME}" "${releasesUrl}/${releaseId}" > /dev/null
+                  body="$(gh api "${releasesUrl}/${releaseId}" | jq -e -r '.body')"
+                  body+='<hr><details><summary>Details:</summary>
+
+                  ```yaml'
+                  body+="$(make show | jq -r '.target')"
+                  body+='
+                  ```
+
+                  </details>'
+                  echo "-------- body ---------"
+                  echo "${body}"
+                  echo "------ end body -------"
+                  gh api -X PATCH -F draft=false -F name="${TAG_NAME}" -F tag_name="${TAG_NAME}" -F body="${body}" "${releasesUrl}/${releaseId}" > /dev/null
                 fi
                 echo "${releaseId}"
               '''

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -302,7 +302,7 @@ def call(String imageShortName, Map userConfig=[:]) {
 
 <details>
 
-```yaml
+```json
 '
                     body+="${MAKE_SHOW_CONTENT}"
                     body+='

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -302,9 +302,9 @@ def call(String imageShortName, Map userConfig=[:]) {
 
 <details>
 
-```json
+```yaml
 '
-                    body+="${MAKE_SHOW_CONTENT}"
+                    body+="$(echo ${MAKE_SHOW_CONTENT} | yq --prettyPrint"
                     body+='
 ```
 


### PR DESCRIPTION
This PR annotates GitHub release with the output from `make show` allowing to know which target(s) and tag(s) have been published, and which settings have been used for the release.

Tested on https://github.com/jenkins-infra/docker-confluence-data/ with success: https://github.com/jenkins-infra/docker-confluence-data/releases/tag/0.1.39

<details><summary>Release body content output:</summary>

<img width="979" alt="image" src="https://github.com/jenkins-infra/pipeline-library/assets/91831478/30a50afa-5c2a-4a1d-8ead-94091bb490de">

</details>

Note: easier to review without whitespace changes, see https://github.com/jenkins-infra/pipeline-library/pull/834/files?diff=unified&w=1

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3887