### PR TITLE
chore(terraform): archive common tests logs file

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -58,8 +58,14 @@ def call(userConfig = [:]) {
                 sh makeCliCmd + ' validate'
               }
               if (finalConfig.runCommonTests) {
-                stage('✅ Commons Test Terraform Project') {
-                  sh makeCliCmd + ' common-tests'
+                final String commonTestsFileName = 'common-tests.log'
+                withEnv([
+                  "COMMON_TESTS_FILE_NAME=${commonTestsFileName}",
+                ]) {
+                  stage('✅ Commons Test Terraform Project') {
+                    sh makeCliCmd + ' common-tests'
+                    archiveArtifacts commonTestsFileName
+                  }
                 }
               }
               if (finalConfig.runTests) {

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -59,9 +59,7 @@ def call(userConfig = [:]) {
               }
               if (finalConfig.runCommonTests) {
                 final String commonTestsFileName = 'common-tests.log'
-                withEnv([
-                  "COMMON_TESTS_FILE_NAME=${commonTestsFileName}",
-                ]) {
+                withEnv(["COMMON_TESTS_FILE_NAME=${commonTestsFileName}",]) {
                   stage('✅ Commons Test Terraform Project') {
                     sh makeCliCmd + ' common-tests'
                     archiveArtifacts commonTestsFileName


### PR DESCRIPTION
This PR archives the terraform common tests logs file generated from https://github.com/jenkins-infra/shared-tools/pull/140.

In draft until https://github.com/jenkins-infra/shared-tools/pull/140 is accepted or not.