### PR TITLE
chore(terraform): show with a GitHub check that shipping change failed

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -129,7 +129,12 @@ def call(userConfig = [:]) {
                   sh makeCliCmd + ' deploy'
                 } catch(Exception e) {
                   // If the deploy failed, keep the pod until a user catch the problem (cloud be an errored state, or many reason to keep the workspace)
-                  input message: 'An error happened while applying the terraform plan. Keeping the agent up and running. Delete the agent?'
+                  final String msg = 'An error happened while applying the terraform plan. Keeping the agent up and running. Delete the agent?'
+                  input message: msg
+                  publishChecks name: 'deploy-error',
+                  title: 'An error happened while applying the terraform plan',
+                  summary: msg,
+                  detailsURL: "${env.BUILD_URL}/console"
                 }
               }
             }

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -130,11 +130,14 @@ def call(userConfig = [:]) {
                 } catch(Exception e) {
                   // If the deploy failed, keep the pod until a user catch the problem (cloud be an errored state, or many reason to keep the workspace)
                   final String msg = 'An error happened while applying the terraform plan. Keeping the agent up and running. Delete the agent?'
-                  input message: msg
-                  publishChecks name: 'deploy-error',
-                  title: 'An error happened while applying the terraform plan',
-                  summary: msg,
-                  detailsURL: "${env.BUILD_URL}/console"
+                  try {
+                    publishChecks name: 'deploy-error',
+                    title: 'An error happened while applying the terraform plan',
+                    summary: msg,
+                    detailsURL: "${env.BUILD_URL}/console"
+                  } finally {
+                    input message: msg
+                  }
                 }
               }
             }


### PR DESCRIPTION
This PR adds a status check to know when shipping change failed and that the build is in standby waiting for input from user, with a link in the check run redirecting to the build console log URL where the input links are.