### PR TITLE
feat: add `infra.withFileShareServicePrincipal` function

### DIFF
--- a/resources/get-fileshare-signed-url.sh
+++ b/resources/get-fileshare-signed-url.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eu -o pipefail
+
+: "${JENKINS_INFRA_FILESHARE_CLIENT_ID?}" "${JENKINS_INFRA_FILESHARE_CLIENT_SECRET?}" "${JENKINS_INFRA_FILESHARE_TENANT_ID?}" "${STORAGE_FILESHARE?}" "${STORAGE_NAME?}" "${STORAGE_DURATION_IN_MINUTE?}" "${STORAGE_PERMISSIONS?}"
+
+# Don't print any command
+set +x
+
+# Login without the JSON output from az
+az login --service-principal --user "${JENKINS_INFRA_FILESHARE_CLIENT_ID}" --password "${JENKINS_INFRA_FILESHARE_CLIENT_SECRET}" --tenant "${JENKINS_INFRA_FILESHARE_TENANT_ID}" > /dev/null
+
+# Generate a SAS token
+expiry=$(date --utc --date "+ ${STORAGE_DURATION_IN_MINUTE} minutes" +"%Y-%m-%dT%H:%MZ")
+token=$(az storage share generate-sas \
+--name "${STORAGE_FILESHARE}" \
+--account-name "${STORAGE_NAME}" \
+--https-only \
+--permissions "${STORAGE_PERMISSIONS}" \
+--expiry "${expiry}" \
+--only-show-errors \
+| sed 's/\"//g')
+
+az logout
+
+echo "https://${STORAGE_NAME}.file.core.windows.net/${STORAGE_FILESHARE}?${token}"

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -17,11 +17,19 @@ class InfraStepTests extends BaseTest {
   static final String healthCheckScriptSh = 'curl --fail --silent --show-error --location $HEALTHCHECK'
   static final String healthCheckScriptBat = 'curl --fail --silent --show-error --location %HEALTHCHECK%'
   static final String changeUrl = 'https://github.com/jenkins-infra/pipeline-library/pull/123'
+  static final String defaultServicePrincipalCredentialsId = 'a-service-principal-writer'
+  static final String defaultFileShare = 'a-file-share'
+  static final String defaultFileShareStorageAccount = 'astorageaccount'
+  static final String defaultTokenDuration = '10'
+  static final String defaultTokenPermissions = 'dlrw'
 
   @Override
   @Before
   void setUp() throws Exception {
     super.setUp()
+
+    // Mock Pipeline methods which are not already declared in the parent class
+    helper.registerAllowedMethod('azureServicePrincipal', [Map.class], { m -> m })
   }
 
   @Test
@@ -479,5 +487,102 @@ class InfraStepTests extends BaseTest {
     assertFalse(assertMethodCallContainsPattern('withEnv', 'MAVEN_ARGS=-s /tmp/settings.xml'))
     // then it succeeds
     assertJobStatusSuccess()
+  }
+
+  @Test
+  void testWithFileShareServicePrincipal() throws Exception {
+    // When used on infra.ci.jenkins.io
+    helper.registerAllowedMethod('isInfra', [], { true })
+    def script = loadScript(scriptName)
+    def isOK = false
+    def options = [
+      servicePrincipalCredentialsId: defaultServicePrincipalCredentialsId,
+      fileShare: defaultFileShare,
+      fileShareStorageAccount: defaultFileShareStorageAccount
+    ]
+    script.withFileShareServicePrincipal(options) {
+      isOK = true
+    }
+    printCallStack()
+    // then the correct Azure Service Principal credentials is used
+    assertTrue(assertMethodCallContainsPattern('azureServicePrincipal', "credentialsId=${defaultServicePrincipalCredentialsId}"))
+    // then the correct options are passed as env vars
+    assertTrue(assertMethodCallContainsPattern('withEnv', "STORAGE_NAME=${defaultFileShareStorageAccount}, STORAGE_FILESHARE=${defaultFileShare}, STORAGE_DURATION_IN_MINUTE=${defaultTokenDuration}, STORAGE_PERMISSIONS=${defaultTokenPermissions}"))
+    // then a script to get a file share signed URL is called
+    assertTrue(assertMethodCallOccurrences('sh', 1))
+    // then it sets $FILESHARE_SIGNED_URL to the signed file share URL
+    assertTrue(assertMethodCallContainsPattern('withEnv', "FILESHARE_SIGNED_URL="))
+    // then it inform about the URL expiring in the default amount of minutes
+    assertTrue(assertMethodCallContainsPattern('echo', "INFO: ${defaultFileShare} file share signed URL expiring in ${defaultTokenDuration} minute(s) available in \$FILESHARE_SIGNED_URL"))
+    // then the body closure is executed
+    assertTrue(isOK)
+    // then it succeeds
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testWithFileShareServicePrincipalWithMissingRequiredOption() throws Exception {
+    // When used on infra.ci.jenkins.io
+    helper.registerAllowedMethod('isInfra', [], { true })
+    def script = loadScript(scriptName)
+    def isOK = false
+    def options = [
+      fileShare: defaultFileShare,
+      fileShareStorageAccount: defaultFileShareStorageAccount
+    ]
+    script.withFileShareServicePrincipal(options) {
+      isOK = true
+    }
+    printCallStack()
+    // then an error message is displayed
+    assertTrue(assertMethodCallContainsPattern('echo', 'ERROR: At least one of these required options is missing: servicePrincipalCredentialsId, fileShare, fileShareStorageAccount'))
+    // then the correct Azure Service Principal credentials is not used
+    assertFalse(assertMethodCallContainsPattern('azureServicePrincipal', "credentialsId=${defaultServicePrincipalCredentialsId}"))
+    // then the correct options are not passed as env vars
+    assertFalse(assertMethodCallContainsPattern('withEnv', "STORAGE_NAME=${defaultFileShareStorageAccount}, STORAGE_FILESHARE=${defaultFileShare}, STORAGE_DURATION_IN_MINUTE=${defaultTokenDuration}, STORAGE_PERMISSIONS=${defaultTokenPermissions}"))
+    // then a script to get a file share signed URL is not called
+    assertFalse(assertMethodCallOccurrences('sh', 1))
+    // then it doesn't set $FILESHARE_SIGNED_URL to the signed file share URL
+    assertFalse(assertMethodCallContainsPattern('withEnv', "FILESHARE_SIGNED_URL="))
+    // then it doesn't inform about the URL expiring in the default amount of minutes
+    assertFalse(assertMethodCallContainsPattern('echo', "INFO: ${defaultFileShare} file share signed URL expiring in ${defaultTokenDuration} minute(s) available in \$FILESHARE_SIGNED_URL"))
+    // then the body closure is not executed
+    assertFalse(isOK)
+    // then it doesn't succeeds
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void testWithFileShareServicePrincipalShouldNotRunOutsideInfraOrTrusted() throws Exception {
+    // When not used on infra.ci.jenkins.io or trusted.ci.jenkins.io
+    helper.registerAllowedMethod('isInfra', [], { false })
+    helper.registerAllowedMethod('isTrusted', [], { false })
+    def script = loadScript(scriptName)
+    def isOK = false
+    def options = [
+      servicePrincipalCredentialsId: defaultServicePrincipalCredentialsId,
+      fileShare: defaultFileShare,
+      fileShareStorageAccount: defaultFileShareStorageAccount
+    ]
+    script.withFileShareServicePrincipal(options) {
+      isOK = true
+    }
+    printCallStack()
+    // then an error message is displayed
+    assertTrue(assertMethodCallContainsPattern('echo', 'ERROR: Cannot be used outside of infra.ci.jenkins.io or trusted.ci.jenkins.io'))
+    // then the correct Azure Service Principal credentials is not used
+    assertFalse(assertMethodCallContainsPattern('azureServicePrincipal', "credentialsId=${defaultServicePrincipalCredentialsId}"))
+    // then the correct options are not passed as env vars
+    assertFalse(assertMethodCallContainsPattern('withEnv', "STORAGE_NAME=${defaultFileShareStorageAccount}, STORAGE_FILESHARE=${defaultFileShare}, STORAGE_DURATION_IN_MINUTE=${defaultTokenDuration}, STORAGE_PERMISSIONS=${defaultTokenPermissions}"))
+    // then a script to get a file share signed URL is not called
+    assertFalse(assertMethodCallOccurrences('sh', 1))
+    // then it doesn't set $FILESHARE_SIGNED_URL to the signed file share URL
+    assertFalse(assertMethodCallContainsPattern('withEnv', "FILESHARE_SIGNED_URL="))
+    // then it doesn't inform about the URL expiring in the default amount of minutes
+    assertFalse(assertMethodCallContainsPattern('echo', "INFO: ${defaultFileShare} file share signed URL expiring in ${defaultTokenDuration} minute(s) available in \$FILESHARE_SIGNED_URL"))
+    // then the body closure is not executed
+    assertFalse(isOK)
+    // then it doesn't succeeds
+    assertJobStatusFailure()
   }
 }

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -493,6 +493,9 @@ class InfraStepTests extends BaseTest {
   void testWithFileShareServicePrincipal() throws Exception {
     // When used on infra.ci.jenkins.io
     helper.registerAllowedMethod('isInfra', [], { true })
+    helper.registerAllowedMethod('sh', [Map.class], { m ->
+      return "https://${defaultFileShareStorageAccount}.file.core.windows.net/${defaultFileShare}?sas-token"
+    })
     def script = loadScript(scriptName)
     def isOK = false
     def options = [
@@ -511,7 +514,7 @@ class InfraStepTests extends BaseTest {
     // then a script to get a file share signed URL is called
     assertTrue(assertMethodCallOccurrences('sh', 1))
     // then it sets $FILESHARE_SIGNED_URL to the signed file share URL
-    assertTrue(assertMethodCallContainsPattern('withEnv', "FILESHARE_SIGNED_URL="))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "FILESHARE_SIGNED_URL=https://${defaultFileShareStorageAccount}.file.core.windows.net/${defaultFileShare}?sas-token"))
     // then it inform about the URL expiring in the default amount of minutes
     assertTrue(assertMethodCallContainsPattern('echo', "INFO: ${defaultFileShare} file share signed URL expiring in ${defaultTokenDuration} minute(s) available in \$FILESHARE_SIGNED_URL"))
     // then the body closure is executed

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -128,7 +128,7 @@ Object withFileShareServicePrincipal(Map options, Closure body) {
       writeFile file: scriptTmpPath, text: getSignedUrlScript
 
       // Call the script and retrieve the signed URL
-      signedUrl = sh(script: scriptTmpPath, returnStdout: true).trim()
+      signedUrl = sh(script: "bash ${scriptTmpPath}", returnStdout: true).trim()
 
       withEnv(["FILESHARE_SIGNED_URL=${signedUrl}"]) {
         echo "INFO: ${options.fileShare} file share signed URL expiring in ${options.durationInMinute} minute(s) available in \$FILESHARE_SIGNED_URL"


### PR DESCRIPTION
This PR adds `infra.withFileShareServicePrincipal` function, to encapsulate the logic around generating a SAS token from a service principal for an Azure file share like what has been done at https://github.com/jenkins-infra/contributor-spotlight/blob/1ae6bcbfb5301863889084e776ce6bf628713e5a/Jenkinsfile#L106-L122

- Restricted use to infra.ci.jenkins.io & trusted.ci.jenkins.io
- No Windows support

Tested in:
- https://github.com/jenkins-infra/contributor-spotlight/pull/97
- https://infra.ci.jenkins.io/job/website-jobs/job/contributor-spotlight/job/PR-97/21/console

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414