### PR TITLE
chore(terraform): set build failure if there is a deploy error

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -136,6 +136,7 @@ def call(userConfig = [:]) {
                     summary: msg,
                     detailsURL: "${env.BUILD_URL}/console"
                   } finally {
+                    currentBuild.result = 'FAILURE'
                     input message: msg
                   }
                 }


### PR DESCRIPTION
Currently if there is a deploy error, the build is shown as successful:

![image](https://github.com/jenkins-infra/pipeline-library/assets/91831478/3548e8d3-8d4c-4a81-88f8-386035a2f3f0)

This PR sets the build status to "failure" before asking for input.

Ref:
- #838 