### PR TITLE
fix(withFileShareServicePrincipal): add a trailing `/` to the target

### DIFF
--- a/resources/get-fileshare-signed-url.sh
+++ b/resources/get-fileshare-signed-url.sh
@@ -22,4 +22,4 @@ token=$(az storage share generate-sas \
 
 az logout
 
-echo "https://${STORAGE_NAME}.file.core.windows.net/${STORAGE_FILESHARE}?${token}"
+echo "https://${STORAGE_NAME}.file.core.windows.net/${STORAGE_FILESHARE}/?${token}"


### PR DESCRIPTION
This PR adds a trailing `/` to the target so it's considered as a folder and not a file.

Noticed after https://github.com/jenkins-infra/jenkins.io/pull/7123, from trusted.ci.jenkins.io logs:
> Cannot perform sync due to error: trying to sync between different resource types (either file <-> directory or directory <-> file) which is not allowed.sync must happen between source and destination of the same type, e.g. either file <-> file or directory <-> directory.To make sure target is handled as a directory, add a trailing '/' to the target.

Follow-up of:
- #839 
- https://github.com/jenkins-infra/jenkins.io/pull/7123

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414