### PR TITLE
feat: allow using storage account key to generate a file share SAS token

### DIFF
--- a/resources/get-fileshare-signed-url.sh
+++ b/resources/get-fileshare-signed-url.sh
@@ -1,17 +1,55 @@
 #!/bin/bash
+# Purpose: Shell script to get a file share URL signed with a short-lived SAS token
+# --
+# Description: This script uses either a service principal or either a storage account access key to generate a SAS token
+# and returns the file share URL composed of the storage resource URI and the SAS token.
+# Ref: https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview
+# --
+# Usage: ./get-fileshare-signed-url.sh
+# --
+# Required parameters defined as environment variables:
+# - STORAGE_FILESHARE: the file share name
+# - STORAGE_NAME: the storage account name where the file share is located
+# - STORAGE_DURATION_IN_MINUTE: lifetime of the short-lived SAS token, in minute
+# - STORAGE_PERMISSIONS: the permission(s) granted on the file share, any of "dlrw" (note: the order matters)
+#
+# Depending on wether you want to use a service principal or an access key to generate the SAS token, you'll also need either:
+# - AZURE_STORAGE_KEY: the storage account access key
+# or
+# - JENKINS_INFRA_FILESHARE_CLIENT_ID: the service principal app registration client id
+# - JENKINS_INFRA_FILESHARE_CLIENT_SECRET: the service principal client secret
+# - JENKINS_INFRA_FILESHARE_TENANT_ID: the file share tenant id
+# --------------------------------------------------------------------------------
 set -eu -o pipefail
 
-: "${JENKINS_INFRA_FILESHARE_CLIENT_ID?}" "${JENKINS_INFRA_FILESHARE_CLIENT_SECRET?}" "${JENKINS_INFRA_FILESHARE_TENANT_ID?}" "${STORAGE_FILESHARE?}" "${STORAGE_NAME?}" "${STORAGE_DURATION_IN_MINUTE?}" "${STORAGE_PERMISSIONS?}"
-
-# Don't print any command
+# Don't print any trace
 set +x
 
-# Login without the JSON output from az
-az login --service-principal --user "${JENKINS_INFRA_FILESHARE_CLIENT_ID}" --password "${JENKINS_INFRA_FILESHARE_CLIENT_SECRET}" --tenant "${JENKINS_INFRA_FILESHARE_TENANT_ID}" > /dev/null
+: "${STORAGE_FILESHARE?}" "${STORAGE_NAME?}" "${STORAGE_DURATION_IN_MINUTE?}" "${STORAGE_PERMISSIONS?}"
+
+accountKeyArg=()
+shouldLogout="true"
+# If a storage account key env var exists, use it instead of a service principal to generate a file share SAS token
+if  [[ -n "${AZURE_STORAGE_KEY:=""}" ]]; then
+    accountKeyArg=("--account-key" "${AZURE_STORAGE_KEY}")
+    shouldLogout="false"
+else
+    # If there is no account key env var defined, require env vars needed to use a service principal
+    : "${JENKINS_INFRA_FILESHARE_CLIENT_ID?}" "${JENKINS_INFRA_FILESHARE_CLIENT_SECRET?}" "${JENKINS_INFRA_FILESHARE_TENANT_ID?}"
+
+    # Login without the JSON output from az
+    az login --service-principal \
+    --user "${JENKINS_INFRA_FILESHARE_CLIENT_ID}" \
+    --password "${JENKINS_INFRA_FILESHARE_CLIENT_SECRET}" \
+    --tenant "${JENKINS_INFRA_FILESHARE_TENANT_ID}" > /dev/null
+fi
+
+# date(1) isn't GNU compliant on MacOS, using gdate(1) in that case
+[[ $(uname  || true) == "Darwin" ]] && dateCmd="gdate" || dateCmd="date"
+expiry="$("${dateCmd}" --utc --date "+ ${STORAGE_DURATION_IN_MINUTE} minutes" +"%Y-%m-%dT%H:%MZ")"
 
 # Generate a SAS token, remove double quotes around it and replace potential '/' by '%2F'
-expiry=$(date --utc --date "+ ${STORAGE_DURATION_IN_MINUTE} minutes" +"%Y-%m-%dT%H:%MZ")
-token=$(az storage share generate-sas \
+token="$(az storage share generate-sas "${accountKeyArg[@]}" \
 --name "${STORAGE_FILESHARE}" \
 --account-name "${STORAGE_NAME}" \
 --https-only \
@@ -19,8 +57,8 @@ token=$(az storage share generate-sas \
 --expiry "${expiry}" \
 --only-show-errors \
 | sed 's/\"//g' \
-| sed 's|/|%2F|g')
+| sed 's|/|%2F|g')"
 
-az logout
+[[ "${shouldLogout}" == "true" ]] && az logout
 
 echo "https://${STORAGE_NAME}.file.core.windows.net/${STORAGE_FILESHARE}/?${token}"

--- a/resources/get-fileshare-signed-url.sh
+++ b/resources/get-fileshare-signed-url.sh
@@ -5,7 +5,9 @@
 # and returns the file share URL composed of the storage resource URI and the SAS token.
 # Ref: https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview
 # --
-# Usage: ./get-fileshare-signed-url.sh
+# Usage:
+# - Return a file share signed URL: ./get-fileshare-signed-url.sh
+# - Interact with a file share and azcopy: azcopy list "$(./get-fileshare-signed-url.sh)"
 # --
 # Required parameters defined as environment variables:
 # - STORAGE_FILESHARE: the file share name
@@ -45,7 +47,7 @@ else
 fi
 
 # date(1) isn't GNU compliant on MacOS, using gdate(1) in that case
-[[ $(uname  || true) == "Darwin" ]] && dateCmd="gdate" || dateCmd="date"
+[[ "$(uname  || true)" == "Darwin" ]] && dateCmd="gdate" || dateCmd="date"
 expiry="$("${dateCmd}" --utc --date "+ ${STORAGE_DURATION_IN_MINUTE} minutes" +"%Y-%m-%dT%H:%MZ")"
 
 # Generate a SAS token, remove double quotes around it and replace potential '/' by '%2F'


### PR DESCRIPTION
This PR allows using a storage account access key to generate a file share SAS token instead of a service principal, useful when this access key is already available in the script execution context.

Tested in situ with:
- https://github.com/jenkins-infra/plugin-site/pull/1661

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414