### PR TITLE
fix(buildDockerAndPublishImage) specify platform to `container-structure-test`

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -92,7 +92,7 @@ clean: ## Delete any file generated during the build steps
 
 test: ## Execute the test harness on the Docker Image
 	@echo "== Test $(IMAGE_NAME) with $(call FixPath,$(TEST_HARNESS)) from $(IMAGE_NAME) with container-structure-test:"
-	container-structure-test test --driver=docker --image="$(IMAGE_NAME)" --config="$(call FixPath,$(TEST_HARNESS))"
+	container-structure-test test --driver=docker --image="$(IMAGE_NAME)" --config="$(call FixPath,$(TEST_HARNESS))" --platform=$(BUILD_TARGETPLATFORM)
 	@echo "== Test succeeded"
 
 show: ## Show the output of docker buildx bake --print
@@ -104,13 +104,13 @@ list: ## List the first tag of each target including the same platform than the 
 bake-test: ## Execute the test harness on the Docker image(s) with load
 	@echo "== Load $(IMAGE_NAME) within docker engine from docker bake buildx engine"
 	@make show
-	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" "$(DOCKER_BAKE_TARGET)" --set "*.platform=linux/$(ARCH)"  --load
+	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" "$(DOCKER_BAKE_TARGET)" --set "*.platform=linux/$(ARCH)" --load
 	@make --silent list | while read image; do make --silent "bake-test-$${image}"; done
 	@echo "== All tests succeeded"
 
 bake-test-%: ## Execute the test harness on the tag of an image
 	@echo "== Test $(subst #,/,$*) with $(call FixPath,$(TEST_HARNESS)) from $(IMAGE_NAME) with container-structure-test:"
-	container-structure-test test --driver=docker --image="$(subst #,/,$*)" --config="$(call FixPath,$(TEST_HARNESS))"
+	container-structure-test test --driver=docker --image="$(subst #,/,$*)" --config="$(call FixPath,$(TEST_HARNESS))" --platform=$(BUILD_TARGETPLATFORM)
 	@echo "== Test succeeded"
 
 ## This steps expects that you are logged to the Docker registry to push image into
@@ -120,7 +120,7 @@ deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
 	docker image push "$(IMAGE_DEPLOY_NAME)"
 	@echo "== Deploy succeeded"
 
-bake-deploy:  ## Tag and push the built image as specified by docker bake file
+bake-deploy: ## Tag and push the built image as specified by docker bake file
 	@echo "== Deploying $(DOCKER_BAKE_TARGET) target with docker bake file"
 	@docker buildx bake -f "$(call FixPath,$(DOCKER_BAKE_FILE))" "$(DOCKER_BAKE_TARGET)" --push
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -77,12 +77,11 @@ def call(String imageShortName, Map userConfig=[:]) {
       currentBuild.result = 'FAILURE'
       return
     }
-    // if platform is set, I override platforms with it
     finalConfig.targetplatforms = finalConfig.platform
     echo "WARNING: `platform` is deprecated, use `targetplatforms` instead."
   }
 
-  // Default Value if targetplatforms is not set, I set it to linux/amd64 by default
+  // Defaults to 'linux/amd64' if targetplatforms is not set
   if (finalConfig.targetplatforms == '') {
     finalConfig.targetplatforms = 'linux/amd64'
   }
@@ -125,7 +124,7 @@ def call(String imageShortName, Map userConfig=[:]) {
       "IMAGE_NAME=${imageName}",
       "IMAGE_DIR=${finalConfig.imageDir}",
       "IMAGE_DOCKERFILE=${finalConfig.dockerfile}",
-      "BUILD_TARGETPLATFORM=${finalConfig.targetplatforms}",
+      "BUILD_TARGETPLATFORM=${finalConfig.targetplatforms.split(',')[0]}",
       "BAKE_TARGETPLATFORMS=${finalConfig.targetplatforms}",
     ]) {
       infra.withDockerPullCredentials{


### PR DESCRIPTION
This change allows `container-structure-test` to work with Windows images by passing the `--platform` flag.

Related to https://github.com/jenkins-infra/helpdesk/issues/4048


Tested with the followings:

- Non regression with a Docker bake (case of multiple target platforms passed to the library): https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1598
- Tested the fix for Windows container tests: https://github.com/jenkins-infra/docker-inbound-agents/pull/153


----

Note: The test case for Docker bake was not needed strictly speaking. By setting it up as part of this PR, it makes it explicit and clear that only one of the platforms (`amd64`) on the host OS is tested when passing multiple