### PR TITLE
Read multiple result files with the pattern for PMD and CheckStyle

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -205,7 +205,7 @@ def call(Map params = [:]) {
                   }
                   recordIssues spotbugsArguments
 
-                  Map checkstyleArguments = [tool: checkStyle(pattern: '**/target/checkstyle-result.xml'),
+                  Map checkstyleArguments = [tool: checkStyle(pattern: '**/target/**/checkstyle-result.xml'),
                     sourceCodeEncoding: 'UTF-8',
                     skipBlames: true,
                     trendChartType: 'TOOLS_ONLY',
@@ -215,7 +215,7 @@ def call(Map params = [:]) {
                   }
                   recordIssues checkstyleArguments
 
-                  Map pmdArguments = [tool: pmdParser(pattern: '**/target/pmd.xml'),
+                  Map pmdArguments = [tool: pmdParser(pattern: '**/target/**/pmd.xml'),
                     sourceCodeEncoding: 'UTF-8',
                     skipBlames: true,
                     trendChartType: 'NONE']


### PR DESCRIPTION
When a project build creates multiple CheckStyle or PMD reports (e.g., different rulesets for test and production code, PMD Java and PMD JavaScript results) then the current `buildPlugin` setup cannot handle these results. E.g., my plugins create a structure:

```
target/checkstyle-java/checkstyle-result.xml
target/checkstyle-tests/checkstyle-result.xml
target/pmd-java/pmd.xml
target/pmd-javascript/pmd.xml
target/pmd-tests/pmd.xml
``` 

In order to pick up those files as well, the pattern should be changed to support those structures as well.

Output for projects with subfolder structure:
```
Searching for all files in '/var/data/workspace/history-coverage-model' that match the pattern 'target/**/checkstyle-result.xml'
Traversing of symbolic links: enabled
-> found 2 files
Successfully parsed file /var/data/workspace/history-coverage-model/target/checkstyle-java/checkstyle-result.xml
-> found 0 issues (skipped 0 duplicates)
Successfully processed file 'target/checkstyle-java/checkstyle-result.xml'
Successfully parsed file /var/data/workspace/history-coverage-model/target/checkstyle-tests/checkstyle-result.xml
```

Output for projects with default single report structure:
```
Searching for all files in '/var/data/workspace/history-coverage-model' that match the pattern 'target/**/checkstyle-result.xml'
Traversing of symbolic links: enabled
-> found 1 file
Successfully parsed file /var/data/workspace/history-coverage-model/target/checkstyle-result.xml
-> found 0 issues (skipped 0 duplicates)
Successfully processed file 'target/checkstyle-result.xml'
``` 

