### PR TITLE
feat(publishReports): add `failIfEmpty` parameter

### DIFF
--- a/test/groovy/PublishReportsStepTests.groovy
+++ b/test/groovy/PublishReportsStepTests.groovy
@@ -56,12 +56,12 @@ class PublishReportsStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('withEnv', 'TIMEOUT=60'))
     assertTrue(assertMethodCallContainsPattern('withEnv', "FILENAME=${file}"))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'UPLOADFLAGS=--content-type="text/html"'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'az storage blob upload --account-name=prodjenkinsreports --container=reports --timeout=${TIMEOUT} --file=${FILENAME} --name=${FILENAME} ${UPLOADFLAGS} --overwrite'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'az storage blob upload --account-name=prodjenkinsreports --container=reports --timeout="${TIMEOUT}" --file="${FILENAME}" --name="${FILENAME}" "${UPLOADFLAGS}" --overwrite'))
     // another filename manipulations is in place
     assertTrue(assertMethodCallContainsPattern('withEnv', 'SOURCE_DIRNAME=.'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'DESTINATION_PATH=/'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'PATTERN=foo.html'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'az storage file upload-batch --account-name prodjenkinsreports --destination reports --source ${SOURCE_DIRNAME} --destination-path ${DESTINATION_PATH} --pattern ${PATTERN} ${UPLOADFLAGS}'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'az storage file upload-batch --account-name prodjenkinsreports --destination reports --source "${SOURCE_DIRNAME}" --destination-path "${DESTINATION_PATH}" --pattern "${PATTERN}" "${UPLOADFLAGS}"'))
     assertJobStatusSuccess()
   }
 
@@ -76,12 +76,12 @@ class PublishReportsStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('withEnv', 'TIMEOUT=60'))
     assertTrue(assertMethodCallContainsPattern('withEnv', "FILENAME=${file}"))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'UPLOADFLAGS=--content-type="text/css"'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'az storage blob upload --account-name=prodjenkinsreports --container=reports --timeout=${TIMEOUT} --file=${FILENAME} --name=${FILENAME} ${UPLOADFLAGS} --overwrite'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'az storage blob upload --account-name=prodjenkinsreports --container=reports --timeout="${TIMEOUT}" --file="${FILENAME}" --name="${FILENAME}" "${UPLOADFLAGS}" --overwrite'))
     // another filename manipulations is in place
     assertTrue(assertMethodCallContainsPattern('withEnv', 'SOURCE_DIRNAME=/bar'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'DESTINATION_PATH=/bar'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'PATTERN=foo.css'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'az storage file upload-batch --account-name prodjenkinsreports --destination reports --source ${SOURCE_DIRNAME} --destination-path ${DESTINATION_PATH} --pattern ${PATTERN} ${UPLOADFLAGS}'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'az storage file upload-batch --account-name prodjenkinsreports --destination reports --source "${SOURCE_DIRNAME}" --destination-path "${DESTINATION_PATH}" --pattern "${PATTERN}" "${UPLOADFLAGS}"'))
     assertJobStatusSuccess()
   }
 }

--- a/vars/publishReports.groovy
+++ b/vars/publishReports.groovy
@@ -3,10 +3,14 @@
 /**
  * Wrapper for publishing reports to the reports host
  *
+ * @param timeout: timout in minutes for the blob storage upload (default: 60)
+ * @param failIfEmpty: set to true to fail if the file to upload isn't empty (default: false)
+ *
  * See https://issues.jenkins-ci.org/browse/INFRA-947 for more
  */
 def call(List<String> files, Map params = [:]) {
   def timeout = params.get('timeout') ?: '60'
+  def failIfEmpty = params.get('failIfEmpty') ?: false
 
   if (!infra.isTrusted() && !infra.isInfra()) {
     error 'Can only call publishReports from within the trusted.ci environment'
@@ -52,11 +56,20 @@ def call(List<String> files, Map params = [:]) {
           "DESTINATION_PATH=${dirname ?: '/'}",
           "PATTERN=${ basename ?: '*' }",
         ]) {
-          // Blob container can be removed once files are uploaded on the azure file storage
-          sh 'az storage blob upload --account-name=prodjenkinsreports --container=reports --timeout=${TIMEOUT} --file=${FILENAME} --name=${FILENAME} ${UPLOADFLAGS} --overwrite'
+          sh '''
+          # If the "failIsEmpty" flag is active and the file is empty, fail the pipeline
+          lineCount=$(wc -l "${filename}" | awk '{print $1}')
+          if [[ "${failIsEmpty}" != false && "${lineCount}" -eq 0 ]]; then
+            echo "ERROR: ${filename} is empty."
+            exit 1
+          else
+            # Blob container can be removed once files are uploaded on the azure file storage
+            az storage blob upload --account-name=prodjenkinsreports --container=reports --timeout="${TIMEOUT}" --file="${FILENAME}" --name="${FILENAME}" "${UPLOADFLAGS}" --overwrite
 
-          // `az storage file upload` doesn't support file uploaded in a remote directory that doesn't exist but upload-batch yes. Unfortunately the cli syntax is a bit different and requires filename and directory name to be set differently.
-          sh 'az storage file upload-batch --account-name prodjenkinsreports --destination reports --source ${SOURCE_DIRNAME} --destination-path ${DESTINATION_PATH} --pattern ${PATTERN} ${UPLOADFLAGS}'
+            # `az storage file upload` doesn't support file uploaded in a remote directory that doesn't exist but upload-batch yes. Unfortunately the cli syntax is a bit different and requires filename and directory name to be set differently.
+            az storage file upload-batch --account-name prodjenkinsreports --destination reports --source "${SOURCE_DIRNAME}" --destination-path "${DESTINATION_PATH}" --pattern "${PATTERN}" "${UPLOADFLAGS}"
+          fi
+          '''
         }
       }
     }


### PR DESCRIPTION
This PR adds an optional `failIfEmpty` parameter to fail the call to `publishReports` if the file to upload is empty. (To avoid erasing an existing report for example).
The value of this parameter is set to false by default to keep the current behavior for existing consumers not needing it.

This PR also regroups the two `sh` blocks into one, and adds braces & double quotes around variables to prevent globbing and words splitting.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4056#issuecomment-2085606281