### PR TITLE
fix(get-fileshare-signed-url) ensure the script is re-entrant to allow concurent calls

### DIFF
--- a/resources/get-fileshare-signed-url.sh
+++ b/resources/get-fileshare-signed-url.sh
@@ -29,6 +29,11 @@ set +x
 
 : "${STORAGE_FILESHARE?}" "${STORAGE_NAME?}" "${STORAGE_DURATION_IN_MINUTE?}" "${STORAGE_PERMISSIONS?}"
 
+# Ensure the script is re-entrant by using different `az` configuration dir for each call
+# Ref. https://learn.microsoft.com/en-us/cli/azure/use-azure-cli-successfully?tabs=bash%2Cbash2#concurrent-execution
+AZURE_CONFIG_DIR="$(mktemp -d)"
+export AZURE_CONFIG_DIR
+
 accountKeyArg=()
 shouldLogout="true"
 # If a storage account key env var exists, use it instead of a service principal to generate a file share SAS token

--- a/resources/get-fileshare-signed-url.sh
+++ b/resources/get-fileshare-signed-url.sh
@@ -29,7 +29,7 @@ set +x
 
 : "${STORAGE_FILESHARE?}" "${STORAGE_NAME?}" "${STORAGE_DURATION_IN_MINUTE?}" "${STORAGE_PERMISSIONS?}"
 
-# Ensure the script is re-entrant by using different `az` configuration dir for each call
+# Ensure the script is re-entrant by using unique temporary `az` configuration directory for each call
 # Ref. https://learn.microsoft.com/en-us/cli/azure/use-azure-cli-successfully?tabs=bash%2Cbash2#concurrent-execution
 AZURE_CONFIG_DIR="$(mktemp -d)"
 export AZURE_CONFIG_DIR


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649

This PR fixes the shell script `resources/get-fileshare-signed-url.sh` so it is re-entrant to support concurrent calls as part of https://github.com/jenkins-infra/update-center2/pull/777.

The documentation at https://learn.microsoft.com/en-us/cli/azure/use-azure-cli-successfully?tabs=bash%2Cbash2#concurrent-execution shows that we can use a different configuration dir. on each call


----


Validations:

- Shellcheck (of course)
- Ran the script on my local development machine (smoke test: if it smokes then it is bad ;))
- On the trusted.ci permanent agent:
  - Disabled the puppet agent (to avoid overriding changes)
  - Added the change
  - Waited for 2 consecutive successful builds of update_center2 on trusted.ci