### PR TITLE
Set `pmd.failOnViolation` to `false` in maven build

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -112,6 +112,7 @@ def call(Map params = [:]) {
                   '-Dspotbugs.failOnError=false',
                   '-Dcheckstyle.failOnViolation=false',
                   '-Dcheckstyle.failsOnError=false',
+                  '-Dpmd.failOnViolation=false',
                 ]
                 // jacoco had file locking issues on Windows, so only running on linux
                 if (isUnix()) {


### PR DESCRIPTION
Otherwise maven will fail the build if a PMD warning is found. But it makes more sense to report the warnings in the Jenkins UI. CheckStyle and SpotBugs is configured in the same way.