### PR TITLE
feat(infra.groovy) add new ACP to the valid proxy providers list

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -169,7 +169,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
   // As the env var ARTIFACT_CACHING_PROXY_PROVIDER can't be set on Azure VM agents,
   // we're specifying a default provider if none is specified.
   final String requestedProxyProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure'
-  final String[] validProxyProviders = ['aws', 'azure', 'do']
+  final String[] validProxyProviders = ['aws', 'azure', 'azure-aks-internal', 'do']
   // Useful when a provider is in maintenance (or similar cases), add a global env var in Jenkins controller settings to restrict them.
   // To completely disable the artifact caching proxies, this value can be set to a value absent of validProxyProviders like "none" for example.
   final String configuredAvailableProxyProviders = env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS ?: validProxyProviders.join(',')


### PR DESCRIPTION
follow up of https://github.com/jenkins-infra/jenkins-infra/pull/3427

Related to https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2114950444

This PR ensure using the new ACP provider `azure-aks-internal` does not errors with `WARNING: invalid or unavailable artifact caching proxy provider 'azure-aks-internal' requested by the agent, will use repo.jenkins-ci.org`