### PR TITLE
cleanup: remove blob storage upload from `publishReports`

### DIFF
--- a/test/groovy/PublishReportsStepTests.groovy
+++ b/test/groovy/PublishReportsStepTests.groovy
@@ -52,8 +52,7 @@ class PublishReportsStepTests extends BaseTest {
     // when running with a html filename
     script.call([file])
     printCallStack()
-    // then timeout is default and filename manipulations is in place
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'TIMEOUT=60'))
+    // then filename manipulations is in place
     assertTrue(assertMethodCallContainsPattern('withEnv', "FILENAME=${file}"))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'UPLOADFLAGS=--content-type="text/html"'))
     assertTrue(assertMethodCallContainsPattern('sh', 'az storage blob upload --account-name=prodjenkinsreports --container=reports --timeout=${TIMEOUT} --file=${FILENAME} --name=${FILENAME} ${UPLOADFLAGS} --overwrite'))
@@ -72,8 +71,7 @@ class PublishReportsStepTests extends BaseTest {
     def file = '/bar/foo.css'
     script.call([file])
     printCallStack()
-    // then timeout is default and filename manipulations is in place
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'TIMEOUT=60'))
+    // then filename manipulations is in place
     assertTrue(assertMethodCallContainsPattern('withEnv', "FILENAME=${file}"))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'UPLOADFLAGS=--content-type="text/css"'))
     assertTrue(assertMethodCallContainsPattern('sh', 'az storage blob upload --account-name=prodjenkinsreports --container=reports --timeout=${TIMEOUT} --file=${FILENAME} --name=${FILENAME} ${UPLOADFLAGS} --overwrite'))

--- a/vars/publishReports.groovy
+++ b/vars/publishReports.groovy
@@ -6,8 +6,6 @@
  * See https://issues.jenkins-ci.org/browse/INFRA-947 for more
  */
 def call(List<String> files, Map params = [:]) {
-  def timeout = params.get('timeout') ?: '60'
-
   if (!infra.isTrusted() && !infra.isInfra()) {
     error 'Can only call publishReports from within the trusted.ci environment'
   }
@@ -45,16 +43,12 @@ def call(List<String> files, Map params = [:]) {
         def dirname = Arrays.copyOfRange(directory, 0, directory.size()-1 ).join("/")
 
         withEnv([
-          "TIMEOUT=${timeout}",
           "FILENAME=${filename}",
           "UPLOADFLAGS=${uploadFlags}",
           "SOURCE_DIRNAME=${dirname ?: '.'}",
           "DESTINATION_PATH=${dirname ?: '/'}",
           "PATTERN=${ basename ?: '*' }",
         ]) {
-          // Blob container can be removed once files are uploaded on the azure file storage
-          sh 'az storage blob upload --account-name=prodjenkinsreports --container=reports --timeout=${TIMEOUT} --file=${FILENAME} --name=${FILENAME} ${UPLOADFLAGS} --overwrite'
-
           // `az storage file upload` doesn't support file uploaded in a remote directory that doesn't exist but upload-batch yes. Unfortunately the cli syntax is a bit different and requires filename and directory name to be set differently.
           sh 'az storage file upload-batch --account-name prodjenkinsreports --destination reports --source ${SOURCE_DIRNAME} --destination-path ${DESTINATION_PATH} --pattern ${PATTERN} ${UPLOADFLAGS}'
         }


### PR DESCRIPTION
This PR removes the blob storage upload from `publishReports` as this blob storage isn't used anymore.

As the `az storage file upload-batch` command doesn't have any timout parameter and as there is no call to `publishReports` with a specific timeout across @jenkinsci & @jenkins-infra repositories, I removed all code from the function and the tests related to timeout.

Ref:
- https://github.com/jenkins-infra/pipeline-library/issues/855
- https://github.com/jenkins-infra/pipeline-library/pull/853#issuecomment-2095330451