### PR TITLE
Run CI build and test with Java 21, not Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 pipeline {
   agent {
-    label 'maven-11'
+    label 'maven-21'
   }
   options {
     timestamps()


### PR DESCRIPTION
## Run CI build and test with Java 21, not Java 11

Jenkins core will require Java 17 beginning with 18 Jun 2024.  Let's update the tools to use newer Java versions.

### Testing done

Tested locally with Java 21 and compared the build output between Java 11 and Java 21.  No surprises.  Tests pass in both versions and the Java 21 output has the known:

  "WARNING: All illegal access operations will be denied in a future release"
