### PR TITLE
 fix(terraform) ensure idempotency by downloading published reports (if any) before any Terraform command

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -102,9 +102,9 @@ def call(userConfig = [:]) {
                 // Note: always run after call to getInfraSharedTools() (or it will be overridden)
                 if(finalConfig.publishReports && finalConfig.publishReports.size > 0) {
                   for (int i = 0; i < finalConfig.publishReports.size; i++) {
-                    final String fileRelPath = finalConfig.publishReports[i]
-                    file_text = new URL ("https://reports.jenkins.io/${fileRelPath}").getText()
-                    writeFile(file: fileRelPath, text: file_text)
+                    final String relativeFilePath = finalConfig.publishReports[i]
+                    file_text = new URL ("https://reports.jenkins.io/${relativeFilePath}").getText()
+                    writeFile(file: relativeFilePath, text: file_text)
                   }
                 }
                 try {

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -108,7 +108,6 @@ def call(userConfig = [:]) {
                   }
                 }
                 try {
-                  sh 'ls -l jenkins-infra-data-reports/azure-net.json'
                   sh makeCliCmd + ' plan'
                 }
                 finally {


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/pipeline-library/pull/862

This change ensures Terraform does not mark the `local_file` published to reports.jenkins.io as "created" on each run, eg. idempotency of Terraform projects (unless something is changed in file content).


Tested with success in https://github.com/jenkins-infra/azure-net/pull/248 which shows `No changes. Your infrastructure matches the configuration.`