### PR TITLE
chore(infra) cleanup remnants of AWS and DO ACPs

### DIFF
--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -13,7 +13,7 @@ class InfraStepTests extends BaseTest {
   static final String defaultArtifactCachingProxyProvider = 'azure'
   static final String anotherArtifactCachingProxyProvider = 'azure-aks-internal'
   static final String invalidArtifactCachingProxyProvider = 'foo'
-  static final String artifactCachingProxyProvidersWithoutAnotherProvider = 'azure,azure-aks-internal'
+  static final String artifactCachingProxyProvidersWithoutAnotherProvider = 'azure'
   static final String healthCheckScriptSh = 'curl --fail --silent --show-error --location $HEALTHCHECK'
   static final String healthCheckScriptBat = 'curl --fail --silent --show-error --location %HEALTHCHECK%'
   static final String changeUrl = 'https://github.com/jenkins-infra/pipeline-library/pull/123'

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -11,9 +11,9 @@ import mock.PullRequest
 class InfraStepTests extends BaseTest {
   static final String scriptName = "vars/infra.groovy"
   static final String defaultArtifactCachingProxyProvider = 'azure'
-  static final String anotherArtifactCachingProxyProvider = 'do'
+  static final String anotherArtifactCachingProxyProvider = 'azure-aks-internal'
   static final String invalidArtifactCachingProxyProvider = 'foo'
-  static final String artifactCachingProxyProvidersWithoutAnotherProvider = 'aws,azure'
+  static final String artifactCachingProxyProvidersWithoutAnotherProvider = 'azure,azure-aks-internal'
   static final String healthCheckScriptSh = 'curl --fail --silent --show-error --location $HEALTHCHECK'
   static final String healthCheckScriptBat = 'curl --fail --silent --show-error --location %HEALTHCHECK%'
   static final String changeUrl = 'https://github.com/jenkins-infra/pipeline-library/pull/123'

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -158,10 +158,10 @@ Object checkoutSCM(String repo = null) {
  * Artifact Caching Proxy provider corresponding to the requested one defined
  * via the agent's env.ARTIFACT_CACHING_PROXY variable, or 'azure' if not defined.
  * This allows decreasing JFrog Artifactory bandwidth consumption, and increase reliability.
- * There are currently three providers, one for each cloud used in Jenkins Infrastructure:
- * "aws", "azure" and "do" (DigitalOcean).
+ * There are currently two providers:
+ * "azure" (publick8s cluster) and "azure-internal" (ci.jenkins.io-agents-1 cluster).
  * The available providers can be restricted by setting a global ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS
- * variable on the Jenkins controller, with providers separated by a comma. Ex: 'aws,do' if the Azure provider is unavailable.
+ * variable on the Jenkins controller, with providers separated by a comma. Ex: 'azure,<other>' if the Azure provider is unavailable.
  * A 'skip-artifact-caching-proxy' label can be added to pull request in order to punctually disable it.
  * @param useArtifactCachingProxy (default: true) if possible, use an artifact caching proxy in front of repo.jenkins-ci.org to decrease JFrog Artifactory bandwidth usage and to increase reliability
  */
@@ -169,7 +169,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
   // As the env var ARTIFACT_CACHING_PROXY_PROVIDER can't be set on Azure VM agents,
   // we're specifying a default provider if none is specified.
   final String requestedProxyProvider = env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure'
-  final String[] validProxyProviders = ['aws', 'azure', 'azure-aks-internal', 'do']
+  final String[] validProxyProviders = ['azure', 'azure-aks-internal']
   // Useful when a provider is in maintenance (or similar cases), add a global env var in Jenkins controller settings to restrict them.
   // To completely disable the artifact caching proxies, this value can be set to a value absent of validProxyProviders like "none" for example.
   final String configuredAvailableProxyProviders = env.ARTIFACT_CACHING_PROXY_AVAILABLE_PROVIDERS ?: validProxyProviders.join(',')


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3954

This PR is a minor cleanup of the ACP logic, following https://github.com/jenkins-infra/pipeline-library/pull/858 and https://github.com/jenkins-infra/pipeline-library/pull/859

As the AWS and DO cluster (and their respective ACPs) had been removed, let's remove the (unused) references