### PR TITLE
chore(terraform): add 'FAILURE' conclusion to `deploy-error` status

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -145,6 +145,7 @@ def call(userConfig = [:]) {
                     title: 'An error happened while applying the terraform plan',
                     summary: msg,
                     detailsURL: "${env.BUILD_URL}/console"
+                    conclusion: 'FAILURE'
                   } finally {
                     currentBuild.result = 'FAILURE'
                     input message: msg


### PR DESCRIPTION
This PR adds a 'FAILURE' conclusion to `deploy-error` status in the terraform shared pipeline library function so it doesn't appear as valid (green) anymore:

![image](https://github.com/jenkins-infra/pipeline-library/assets/91831478/52fde85c-9ca8-4590-93ec-d93b48769a64)
