### PR TITLE
fix(updatecli) check if the complete updatecli config folder exists, not only `./updatecli/`

### DIFF
--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -34,8 +34,8 @@ def call(userConfig = [:]) {
     boolean runUpdatecli = true
     stage("Check if ${finalConfig.config} folder exists: ${finalConfig.action}") {
       checkout scm
-      if (!fileExists(finalConfig.action)) {
-        echo "WARNING: no ${finalConfig.action} folder."
+      if (!fileExists(finalConfig.config)) {
+        echo "WARNING: no ${finalConfig.config} folder."
         runUpdatecli = false
         org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(updatecliRunStage)
       }

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -32,10 +32,10 @@ def call(userConfig = [:]) {
   node (finalConfig.updatecliAgentLabel) {
     final String updatecliRunStage = "Run updatecli: ${finalConfig.action}"
     boolean runUpdatecli = true
-    stage("Check if updatecli folder exists: ${finalConfig.action}") {
+    stage("Check if ${finalConfig.config} folder exists: ${finalConfig.action}") {
       checkout scm
-      if (!fileExists('updatecli/')) {
-        echo 'WARNING: no updatecli folder.'
+      if (!fileExists(finalConfig.action)) {
+        echo "WARNING: no ${finalConfig.action} folder."
         runUpdatecli = false
         org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(updatecliRunStage)
       }


### PR DESCRIPTION
This PR checks if the updatecli config folder passed as parameter exists, and warn if not instead of failing.

Tested by https://github.com/jenkins-infra/aws/pull/558/commits/77efcf2a6e27530f0745a159a712e6e2509c02ea with success.

https://infra.ci.jenkins.io/job/updatecli/job/aws/job/PR-558/3/console
> WARNING: no ./updatecli/updatecli.d folder.

Ref:
- https://github.com/jenkins-infra/aws/pull/558#issuecomment-2222847979