### PR TITLE
fix(terraform) ensure success when no remote report file exists (use empty file instead)

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -103,7 +103,13 @@ def call(userConfig = [:]) {
                 if (finalConfig.publishReports && finalConfig.publishReports.size > 0) {
                   for (int i = 0; i < finalConfig.publishReports.size; i++) {
                     final String relativeFilePath = finalConfig.publishReports[i]
-                    fileText = new URL ("https://reports.jenkins.io/${relativeFilePath}").getText()
+                    String fileText = ""
+                    try {
+                      fileText = new URL ("https://reports.jenkins.io/${relativeFilePath}").getText()
+                    }
+                    catch (Exception e) {
+                      echo "No file found at the provided URL: using an empty file instead."
+                    }
                     writeFile(file: relativeFilePath, text: fileText)
                   }
                 }


### PR DESCRIPTION
When you create a new report in a Terraform project, if the file does not already exists on reports.jenkins.io, then the pipeline fails wit `java.io.FileNotFoundException: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json` error message.

