### PR TITLE
hotfix(buildPlugin) use the new ACP Azure unified URL for healthcheck. Stops support of dynamic ACP URL.

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -194,14 +194,9 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
   // Check if the artifact caching proxy provider is unreachable
   if (useArtifactCachingProxy) {
     boolean healthCheckFailed = false
-    String artifactCachingProxyUrl = "https://repo.${requestedProxyProvider}.jenkins.io/health"
-    // The (.*)Kubernetes-hosted ACP marked as internal uses the Kubernetes internal SVC domain name and custom port as there are no ingress
-    // TODO: retrieve the value from the settings.xml to avoid spreading the URLs here and in puppet:
-    // https://github.com/jenkins-infra/jenkins-infra/blob/15967f693d1845843204d981168e9a847a090ecb/hieradata/common.yaml#L249
-    if(requestedProxyProvider.contains('ks-internal')) {
-      // defined in https://github.com/jenkins-infra/jenkins-infra/blob/15967f693d1845843204d981168e9a847a090ecb/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb#L13
-      artifactCachingProxyUrl = 'http://artifact-caching-proxy.artifact-caching-proxy:8080/health'
-    }
+    // TODO: retrieve the value from the settings.xml to support different ACP providers
+    // URL defined in https://github.com/jenkins-infra/jenkins-infra/blob/e05466ddfbdfee0364ccef5cfe11e7f5b5cc35ea/hieradata/common.yaml#L248
+    String artifactCachingProxyUrl = 'http://artifact-caching-proxy.privatelink.azurecr.io:8080/'
     withEnv(["HEALTHCHECK=${artifactCachingProxyUrl}"]) {
       if (isUnix()) {
         healthCheckFailed = sh(script: 'curl --fail --silent --show-error --location $HEALTHCHECK', returnStatus: true) != 0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4204#issuecomment-2278334260

(hot) Fix following https://github.com/jenkins-infra/jenkins-infra/pull/3591