### PR TITLE
fix(buildDockerAndPublishImage) avoid wrong type inference for `recordIssues(skipPublishingChecks=)` argument

### DIFF
--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -117,9 +117,13 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   // Return if the usual static checks had been recorded with the usual pattern
   Boolean assertRecordIssues(String imageName = fullTestImageName) {
     final String reportId = "${imageName}-hadolint-${mockedTimestamp}".replaceAll('/','-').replaceAll(':', '-')
+    boolean skipChecks = false
+    if (env.BRANCH_IS_PRIMARY) {
+      skipChecks = true
+    }
     return assertMethodCallContainsPattern(
         'recordIssues',
-        "{skipPublishingChecks=${env.BRANCH_IS_PRIMARY}, enabledForFailure=true, aggregatingResults=false, tool={id=${reportId}, pattern=${reportId}.json}}",
+        "{skipPublishingChecks=${skipChecks}, enabledForFailure=true, aggregatingResults=false, tool={id=${reportId}, pattern=${reportId}.json}}",
         )
   }
 

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -195,8 +195,12 @@ def call(String imageShortName, Map userConfig=[:]) {
                 powershell 'make lint'
               }
             } finally {
+              boolean skipChecks = false
+              if (env.BRANCH_IS_PRIMARY) {
+                skipChecks = true
+              }
               recordIssues(
-                  skipPublishingChecks: env.BRANCH_IS_PRIMARY,
+                  skipPublishingChecks: skipChecks,
                   enabledForFailure: true,
                   aggregatingResults: false,
                   tool: hadoLint(id: hadolintReportId, pattern: hadoLintReportFile)


### PR DESCRIPTION
This change fixes the error below caused by #879.

~I'm not sure why we have this error as #879 was tested by a dummy PR on a docker-jenkins repo.~
(edited: found the cause: we tested before my suggestion - https://github.com/jenkins-infra/pipeline-library/pull/879#discussion_r1735795782. The code before suggestion worked as it was inffering the `null` to string and then to boolean)

Let's retry with 2 PRs end to end testing this time (including openvpn)

```
Found unhandled java.lang.IllegalArgumentException exception:

Could not instantiate {skipPublishingChecks=null, enabledForFailure=true, aggregatingResults=false, tool=@hadoLint(id=jenkinsciinfra-openvpn-hadolint-1725004944771,pattern=jenkinsciinfra-openvpn-hadolint-1725004944771.json)} for io.jenkins.plugins.analysis.core.steps.RecordIssuesStep: java.lang.IllegalArgumentException
```

----

Tested with 2 pipeline replay builds prefixed with the instruction `@Library('pipeline-library@pull/880/head') _`

- Case with principal branch in https://infra.ci.jenkins.io/job/docker-jobs/job/docker-404/job/main/138/ => checks were not published
- Case with a PR in https://infra.ci.jenkins.io/job/docker-jobs/job/docker-openvpn/job/PR-353/2 => checks were published in the PR as expected

---- 