### PR TITLE
Revert "chore(terraform): archive common tests logs file"

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -59,12 +59,8 @@ def call(userConfig = [:]) {
                 sh makeCliCmd + ' validate'
               }
               if (finalConfig.runCommonTests) {
-                final String commonTestsFileName = 'common-tests.log'
-                withEnv(["COMMON_TESTS_FILE_NAME=${commonTestsFileName}",]) {
-                  stage('✅ Commons Test Terraform Project') {
-                    sh makeCliCmd + ' common-tests'
-                    archiveArtifacts commonTestsFileName
-                  }
+                stage('✅ Commons Test Terraform Project') {
+                  sh makeCliCmd + ' common-tests'
                 }
               }
               if (finalConfig.runTests) {


### PR DESCRIPTION
Reverts jenkins-infra/pipeline-library#836

Capturing logs in  a file and then archiving it is a counter productive pattern:

- When it fails, the archiveArtifacts step is not called 
- All failing cases must be taken in account with try catch
- The build log never been clobbered and we are blind when a PR fails

Makefile content reverted in https://github.com/jenkins-infra/shared-tools/commit/36b7ed5f802fce30416a3008a0e876c175191ff0