### PR TITLE
Add JAVA_HOME to PATH properly

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -317,7 +317,7 @@ Object runWithJava(String command, String jdk = '8', List<String> extraEnv = nul
 
     // Define the environment to ensure that the correct JDK is used
     javaEnv += "JAVA_HOME=${javaHome}"
-    javaEnv += 'PATH+JAVA=${JAVA_HOME}/bin'
+    javaEnv += "PATH+JAVA=${javaHome}/bin"
 
     echo "INFO: Using JAVA_HOME=${javaHome} as default JDK home."
   }


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/helpdesk/issues/4343

verified in https://infra.ci.jenkins.io/job/reports/job/backend-extension-indexer/job/master/127/console

output is:
```
18:52:43  + java -version
18:52:43  openjdk version "17.0.12" 2024-07-16
18:52:43  OpenJDK Runtime Environment Temurin-17.0.12+7 (build 17.0.12+7)
18:52:43  OpenJDK 64-Bit Server VM Temurin-17.0.12+7 (build 17.0.12+7, mixed mode, sharing)
```