### PR TITLE
Read multiple result files with the pattern for CPD

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -232,7 +232,7 @@ def call(Map params = [:]) {
                   }
                   recordIssues pmdArguments
 
-                  Map cpdArguments = [tool: cpd(pattern: '**/target/cpd.xml'),
+                  Map cpdArguments = [tool: cpd(pattern: '**/target/**/cpd.xml'),
                     sourceCodeEncoding: 'UTF-8',
                     skipBlames: true,
                     trendChartType: 'NONE']


### PR DESCRIPTION
When a project build creates multiple CPD reports (e.g., different CPD settings for test and production code) then the current `buildPlugin` setup cannot handle these results. E.g., my plugins create a structure:

```
target/pmd-java/cpd.xml
target/pmd-javascript/cpd.xml
target/pmd-tests/cpd.xml
``` 

In order to pick up those files as well, the pattern should be changed to support those structures as well.

This is a followup to #850 that fixed the same problem for PMD and CheckStyle. I forgot to change the settings for CPD as well.
