### PR TITLE
cleanup(terraform) stop defining a cron trigger expression in the library

### DIFF
--- a/test/groovy/TerraformStepTests.groovy
+++ b/test/groovy/TerraformStepTests.groovy
@@ -83,9 +83,6 @@ class TerraformStepTests extends BaseTest {
     assertFalse(assertMethodCallContainsPattern('withCredentials','PRODUCTION_USR'))
     assertFalse(assertMethodCallContainsPattern('withCredentials','COMMON_SECRET'))
 
-    // And a daily cron trigger for the job
-    assertTrue(assertMethodCallContainsPattern('cron', '@daily'))
-
     // And 2 nodes with default label are spawned
     assertTrue(assertMethodCallContainsPattern('node', 'jnlp-linux-arm64'))
     assertTrue(assertMethodCallOccurrences('node', 2))
@@ -138,8 +135,6 @@ class TerraformStepTests extends BaseTest {
     assertFalse(assertMethodCallContainsPattern('stage', 'Shipping Changes'))
     assertFalse(assertMethodCallContainsPattern('sh', 'make --directory=.shared-tools/terraform/ deploy'))
 
-    // No daily cron trigger for the PR jobs
-    assertFalse(assertMethodCallContainsPattern('cron', '@daily'))
     // Only 5 builds per PR to keep
     assertTrue(assertMethodCallContainsPattern('logRotator', 'numToKeepStr=5'))
   }
@@ -181,9 +176,6 @@ class TerraformStepTests extends BaseTest {
 
     // Ensure that drift-detection is disabled
     assertFalse(assertMethodCallContainsPattern('withEnv','TF_CLI_ARGS_plan=-detailed-exitcode'))
-
-    // And a daily cron trigger for the job
-    assertFalse(assertMethodCallContainsPattern('cron', '@daily'))
   }
 
   @Test
@@ -225,7 +217,6 @@ class TerraformStepTests extends BaseTest {
 
     // When calling the shared library global function with custom parameters
     script.call(
-        cronTriggerExpression: '@weekly',
         stagingCredentials: stagingCustomCreds,
         productionCredentials: productionCustomCreds,
         agentLabel: customLabel,
@@ -240,9 +231,6 @@ class TerraformStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('withCredentials','STAGING_PSW'))
     assertTrue(assertMethodCallContainsPattern('withCredentials','PRODUCTION_USR'))
     assertTrue(assertMethodCallContainsPattern('withCredentials','COMMON_SECRET'))
-
-    // And the custom cron trigger
-    assertTrue(assertMethodCallContainsPattern('cron', '@weekly'))
 
     // And 2 nodes with custom label are spawned
     assertTrue(assertMethodCallContainsPattern('node', customLabel))

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -5,7 +5,6 @@
 
 def call(userConfig = [:]) {
   def defaultConfig = [
-    cronTriggerExpression: '@daily', // Defaults to run once a day (to detect configuration drift)
     stagingCredentials: [], // No custom secrets for staging by default
     productionCredentials: [], // No custom secrets for production by default
     productionBranch: 'main', // Defaults to the principal branch
@@ -28,11 +27,6 @@ def call(userConfig = [:]) {
 
   final String sharedToolsSubDir = '.shared-tools'
   final String makeCliCmd = "make --directory=${sharedToolsSubDir}/terraform/"
-
-  // Only define a cron trigger on the primary branch
-  if (isBuildOnProductionBranch && finalConfig.cronTriggerExpression) {
-    properties([pipelineTriggers([cron(finalConfig.cronTriggerExpression)])])
-  }
 
   properties([
     // Only run 1 build at a time, on a given branch, to ensure that infrastructure changes are sequentials (easier to audit)


### PR DESCRIPTION
It's the pipeline role: good practise and provide better visibility for the pipeline writer

Related, somehow, to the work in https://github.com/jenkins-infra/helpdesk/issues/2778