### PR TITLE
feat(get-fileshare-signed-url) adding set `-E` to catch subshell errors

### DIFF
--- a/resources/get-fileshare-signed-url.sh
+++ b/resources/get-fileshare-signed-url.sh
@@ -22,7 +22,7 @@
 # - JENKINS_INFRA_FILESHARE_CLIENT_SECRET: the service principal client secret
 # - JENKINS_INFRA_FILESHARE_TENANT_ID: the file share tenant id
 # --------------------------------------------------------------------------------
-set -eu -o pipefail
+set -Eeu -o pipefail
 
 # Don't print any trace
 set +x


### PR DESCRIPTION
to follow-up with https://github.com/jenkins-infra/docker-geoipupdate/pull/14#issuecomment-2512055374