### PR TITLE
Allow publishing attachment using junit-attachments

### DIFF
--- a/test/groovy/BaseTest.groovy
+++ b/test/groovy/BaseTest.groovy
@@ -20,6 +20,7 @@ class BaseTest extends DeclarativePipelineTest {
     binding.setProperty('mvnSettingsFile', 'settings.xml')
 
     helper.registerAllowedMethod('archiveArtifacts', [Map.class], { true })
+    helper.registerAllowedMethod('attachments', [])
     helper.registerAllowedMethod('checkout', [String.class], { 'OK' })
     helper.registerAllowedMethod('configFile', [Map.class], { 'OK' })
     helper.registerAllowedMethod('configFileProvider', [List.class, Closure.class], { l, body -> body() })
@@ -36,6 +37,7 @@ class BaseTest extends DeclarativePipelineTest {
     helper.registerAllowedMethod('git', [String.class], { 'OK' })
     helper.registerAllowedMethod('hasDockerLabel', [], { true })
     helper.registerAllowedMethod('isUnix', [], { true })
+    helper.registerAllowedMethod('junit', [Map.class])
     helper.registerAllowedMethod('lock', [String.class, Closure.class], { s, body -> body() })
     helper.registerAllowedMethod('node', [String.class, Closure.class], { s, body -> body() })
     helper.registerAllowedMethod('retry', [Map.class, Closure.class], { m, body ->body() })

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -146,7 +146,10 @@ def call(Map params = [:]) {
                   infra.runMaven(mavenOptions, jdk, null, addToolEnv, useArtifactCachingProxy)
                 } finally {
                   if (!skipTests) {
-                    junit('**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml')
+                    junit(
+                        testResults: '**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml,**/target/invoker-reports/**/*.xml',
+                        testDataPublishers: [attachments()],
+                        )
                     if (first) {
                       discoverReferenceBuild()
                       // Default configuration for JaCoCo can be overwritten using a `jacoco` parameter (map).


### PR DESCRIPTION
My use case is integration tests using maven invoker to run `plugin-modernizer` recipes againts sample plugin.

Since the `junit-attachment` plugin is installed, every maintainer can use it. I would propose to enable the publisher by default when we archive junit results

I've tested this PR by doing a print of the attachement

```java
System.out.printf("[[ATTACHMENT|%s]]%n", Plugin.build(plugin).getLogFile().toAbsolutePath());
```

https://ci.jenkins.io/job/Tools/job/plugin-modernizer-tool/view/change-requests/job/PR-463/35/testReport/io.jenkins.tools.pluginmodernizer.cli/CommandLineITCase/linux_21___Build__linux_21____testBuildMetadata_PluginMetadata__WireMockRuntimeInfo__1_/

![attachment](https://github.com/user-attachments/assets/e85e9e1d-5c42-49a9-b109-1351369f91a2)
