### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jenkins-infra/ci-maintainers
+* @jenkins-infra/core


### PR DESCRIPTION
As per https://github.com/jenkins-infra/pipeline-library/pull/893#issuecomment-2548351277, this PR corrects the code owner file to avoid errors mentioned to contributors.

Thanks @jonesbusy @timja for the reminder!

FTR, it was caused by https://github.com/jenkins-infra/helpdesk/issues/4264#issuecomment-2310246389