### PR TITLE
Default to Java 11 for `jdkVersions`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,7 @@ buildPlugin(
 * `failFast` (default: `true`) - instruct Maven tests to fail fast
 * `platforms` (default: `['linux', 'windows']`) - Labels matching platforms to
   execute the steps against in parallel
-* `jdkVersions` (default: `[8]`) - JDK version numbers, must match a version
+* `jdkVersions` (default: `[11]`) - JDK version numbers, must match a version
   number jdk tool installed
 * `jenkinsVersions`: (default: `[null]`) - a matrix of Jenkins baseline versions to build/test against in parallel (null means default,
   only available for Maven projects)

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -68,8 +68,8 @@ class BuildPluginStepTests extends BaseTest {
     def configurations = script.getConfigurations([:])
 
     def expected = [
-      ['platform': 'linux', 'jdk': '8', 'jenkins': null],
-      ['platform': 'windows', 'jdk': '8', 'jenkins': null],
+      ['platform': 'linux', 'jdk': '11', 'jenkins': null],
+      ['platform': 'windows', 'jdk': '11', 'jenkins': null],
     ]
     assertEquals(expected, configurations)
     printCallStack()
@@ -142,9 +142,9 @@ class BuildPluginStepTests extends BaseTest {
     script.call([useContainerAgent: true])
     printCallStack()
     // then it runs a stage in a linux container by default
-    assertTrue(assertMethodCallContainsPattern('node', 'maven'))
+    assertTrue(assertMethodCallContainsPattern('node', 'maven-11'))
     // then it runs a stage in a Windows container by default
-    assertTrue(assertMethodCallContainsPattern('node', 'maven-windows'))
+    assertTrue(assertMethodCallContainsPattern('node', 'maven-11-windows'))
     assertJobStatusSuccess()
   }
 

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -345,7 +345,7 @@ List<Map<String, String>> getConfigurations(Map params) {
   }
 
   def platforms = params.containsKey('platforms') ? params.platforms : ['linux', 'windows']
-  def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : ['8']
+  def jdkVersions = params.containsKey('jdkVersions') ? params.jdkVersions : ['11']
   def jenkinsVersions = params.containsKey('jenkinsVersions') ? params.jenkinsVersions : [null]
 
   def ret = []


### PR DESCRIPTION
Fix #514 but maybe the opinion is different 2.5 years after

There are still few plugin still using implicit configuration which default to Java 8 still.

Those plugin are difficult for non-maintainer or non-administrator to modernize because it require the Jenkinsfile to be replayed

It would broke some plugin maybe (some are already broken) but I will argue it will benefit a lot modernizing many plugin to Java 11 and above (In more less 6 month Java 17 will be the recommended version for plugin bom in any case)

If for some some plugin still need to build on Java 8 they can move to explicit configuration until Java 8 is completely removed from ci.jenkins.io

Any though ?