### PR TITLE
Use Windows VM until Azure ACI outage is resolved

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -144,7 +144,12 @@ class BuildPluginStepTests extends BaseTest {
     // then it runs a stage in a linux container by default
     assertTrue(assertMethodCallContainsPattern('node', 'maven'))
     // then it runs a stage in a Windows container by default
-    assertTrue(assertMethodCallContainsPattern('node', 'maven-windows'))
+    // TODO: Restore this assertion when ACI outage is resolved
+    // https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/
+    // assertTrue(assertMethodCallContainsPattern('node', 'maven-windows'))
+    // TODO: Delete this assertion when ACI outage is resolved
+    // https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/
+    assertTrue(assertMethodCallContainsPattern('node', 'docker-windows'))
     assertJobStatusSuccess()
   }
 

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -145,10 +145,10 @@ class BuildPluginStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('node', 'maven'))
     // then it runs a stage in a Windows container by default
     // TODO: Restore this assertion when ACI outage is resolved
-    // https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/
+    // https://github.com/jenkins-infra/helpdesk/issues/4490
     // assertTrue(assertMethodCallContainsPattern('node', 'maven-windows'))
     // TODO: Delete this assertion when ACI outage is resolved
-    // https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/
+    // https://github.com/jenkins-infra/helpdesk/issues/4490
     assertTrue(assertMethodCallContainsPattern('node', 'docker-windows'))
     assertJobStatusSuccess()
   }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -44,7 +44,7 @@ def call(Map params = [:]) {
         if (platform == 'windows') {
           agentContainerLabel += '-windows'
           // TODO: Remove when Azure Container (ACI) outage is resolved
-          // https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/
+          // https://github.com/jenkins-infra/helpdesk/issues/4490
           echo "Using Windows virtual machines during Azure ACI outage https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/"
           agentContainerLabel = 'docker-windows'
         }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -43,6 +43,10 @@ def call(Map params = [:]) {
         def agentContainerLabel = jdk == '8' ? 'maven' : 'maven-' + jdk
         if (platform == 'windows') {
           agentContainerLabel += '-windows'
+          // TODO: Remove when Azure Container (ACI) outage is resolved
+          // https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/
+          echo "Using Windows virtual machines during Azure ACI outage https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/"
+          agentContainerLabel = 'docker-windows'
         }
         label = agentContainerLabel
       }


### PR DESCRIPTION
## Use Windows VM until Azure ACI outage is resolved

An Azure outage of the Azure Container Instances service is blocking builds on ci.jenkins.io.  Let's switch to use virtual machines for Windows builds, even if the Jenkinsfile requests a Windows container.

https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/ shows the current status of the Jenkins impact from the outage.
