### PR TITLE
Use LF as git end of line terminator on Windows

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -103,7 +103,6 @@ def call(Map params = [:]) {
               String m2repo
 
               stage("Build (${stageIdentifier})") {
-                String command
                 m2repo = "${pwd tmp: true}/m2repo"
                 List<String> mavenOptions = [
                   '--update-snapshots',

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -142,6 +142,8 @@ Object checkoutSCM(String repo = null) {
   // Enable long paths to avoid problems with tests on Windows agents
   if (!isUnix()) {
     bat 'git config --global core.longpaths true'
+    // TODO: Remove when https://github.com/jenkins-infra/helpdesk/issues/3865 is resolved
+    bat 'git config --global core.eol lf'
   }
 
   if (env.BRANCH_NAME) {


### PR DESCRIPTION
## Use LF as git end of line terminator on Windows

Windows virtual machines are currently configured to not use LF as their git end of line.  That causes failures when spotless formats files on Windows that were originally created with Unix (LF) line termination.

This is a workaround until we update the Windows virtual machine definition to fix:

* https://github.com/jenkins-infra/helpdesk/issues/3865

## Testing done

I added the following text to the start of each Jenkinsfile in the test jobs and confirmed that job output contained the expected git commands on Windows agents and the test jobs passed with both `useContainerAgent: true` and `useContainerAgent: false`.

```groovy
@Library('pipeline-library@set-autocrlf-on-windows') _
```

Plugins that were tested with both settings include:

* Built-on Column plugin [PR-53](https://github.com/jenkinsci/built-on-column-plugin/pull/53) and master branch builds [63](https://ci.jenkins.io/job/Plugins/job/built-on-column-plugin/job/master/63/) and [64](https://ci.jenkins.io/job/Plugins/job/built-on-column-plugin/job/master/64/) - uses spotless
* Apache httpclient 4 API plugin builds [202](https://ci.jenkins.io/job/Plugins/job/apache-httpcomponents-client-4-api-plugin/job/master/202/) and [203](https://ci.jenkins.io/job/Plugins/job/apache-httpcomponents-client-4-api-plugin/job/master/203/) - uses spotless
* GitHub branch source plugin builds [484](https://ci.jenkins.io/job/Plugins/job/github-branch-source-plugin/job/master/484/) and [485](https://ci.jenkins.io/job/Plugins/job/github-branch-source-plugin/job/master/485/) - uses spotless
* JUnit plugin builds [443](https://ci.jenkins.io/job/Plugins/job/junit-plugin/job/master/443/) and [444](https://ci.jenkins.io/job/Plugins/job/junit-plugin/job/master/444/) - uses spotless
* Pipeline input step plugin builds [70](https://ci.jenkins.io/job/Plugins/job/pipeline-input-step-plugin/job/master/70/) and [71](https://ci.jenkins.io/job/Plugins/job/pipeline-input-step-plugin/job/master/71/) - does not use spotless
* Pipeline SCM step plugin builds [74](https://ci.jenkins.io/job/Plugins/job/workflow-scm-step-plugin/job/master/74/) and [75](https://ci.jenkins.io/job/Plugins/job/workflow-scm-step-plugin/job/master/75/) -does not use spotless
* Bitbucket branch source plugin [547](https://ci.jenkins.io/job/Plugins/job/bitbucket-branch-source-plugin/job/master/547/) and [548](https://ci.jenkins.io/job/Plugins/job/bitbucket-branch-source-plugin/job/master/548/) - does not use spotless

Plugins that were tested with only one setting (because they require a virtual machine to run their container based tests):

* SSH build agents plugin build [77](https://ci.jenkins.io/job/Plugins/job/ssh-agents-plugin/job/main/77/) - does not use spotless
* Git client plugin build [1213](https://ci.jenkins.io/job/Plugins/job/git-client-plugin/job/master/1213/) - uses spotless