### PR TITLE
Revert "Use Windows VM until Azure ACI outage is resolved (#898)"

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -144,12 +144,7 @@ class BuildPluginStepTests extends BaseTest {
     // then it runs a stage in a linux container by default
     assertTrue(assertMethodCallContainsPattern('node', 'maven'))
     // then it runs a stage in a Windows container by default
-    // TODO: Restore this assertion when ACI outage is resolved
-    // https://github.com/jenkins-infra/helpdesk/issues/4490
-    // assertTrue(assertMethodCallContainsPattern('node', 'maven-windows'))
-    // TODO: Delete this assertion when ACI outage is resolved
-    // https://github.com/jenkins-infra/helpdesk/issues/4490
-    assertTrue(assertMethodCallContainsPattern('node', 'docker-windows'))
+    assertTrue(assertMethodCallContainsPattern('node', 'maven-windows'))
     assertJobStatusSuccess()
   }
 

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -43,10 +43,6 @@ def call(Map params = [:]) {
         def agentContainerLabel = jdk == '8' ? 'maven' : 'maven-' + jdk
         if (platform == 'windows') {
           agentContainerLabel += '-windows'
-          // TODO: Remove when Azure Container (ACI) outage is resolved
-          // https://github.com/jenkins-infra/helpdesk/issues/4490
-          echo "Using Windows virtual machines during Azure ACI outage https://status.jenkins.io/issues/2025-01-08-ci.jenkins.io-azure-outage/"
-          agentContainerLabel = 'docker-windows'
         }
         label = agentContainerLabel
       }


### PR DESCRIPTION
## Revert "Use Windows VM until Azure ACI outage is resolved (#898)"

Windows virtual machines are configured with Java 11 by default, though they have Java 17 and Java 21 installed.  This change does not propagate the Java version configuration to the Windows virtual machine.  Jobs that are configured to use Java 17 on Windows or Java 21 on Windows are mistakenly using Java 11 on Windows.

Reverting the change so that a complete fix can be tested and confirmed working before a pull request is proposed.

This reverts commit bcd195f5e1694be916fd883f30361592171d5f47.
