### PR TITLE
feat(updatecli): Add custom version execution of updatecli

### DIFF
--- a/test/groovy/UpdatecliStepTests.groovy
+++ b/test/groovy/UpdatecliStepTests.groovy
@@ -142,10 +142,6 @@ class UpdatecliStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('usernamePassword', "credentialsId=${anotherCredentialsId}"))
   }
 
-  /**
-   * New Test Cases for Custom Version Functionality
-   */
-
   // Test that when a custom version is specified, the pipeline includes the download steps.
   @Test
   void itRunSuccessfullyWithCustomVersion() throws Exception {
@@ -159,24 +155,4 @@ class UpdatecliStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('sh', 'updatecli diff'))
   }
 
-  @Test
-  void itFailsWhenCustomVersionNotFound() throws Exception {
-    helper.registerAllowedMethod('sh', [Map.class], { Map args ->
-      if (args.script.contains("curl --silent --show-error --location --output") && args.script.contains("updatecli_Linux")) {
-        return 1  // simulate download failure (non-zero exit status)
-      }
-      if (args.script.contains("uname -m")) {
-        return "x86_64\n"
-      }
-      return 0
-    })
-
-    def script = loadScript(scriptName)
-    try {
-      script.call(version: '0.99.99')
-      fail("Expected error due to custom version not found")
-    } catch (Exception e) {
-      assertTrue(assertMethodCallContainsPattern('sh', 'curl --silent --show-error'))
-    }
-  }
 }

--- a/test/groovy/UpdatecliStepTests.groovy
+++ b/test/groovy/UpdatecliStepTests.groovy
@@ -154,5 +154,4 @@ class UpdatecliStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('sh', 'tar --extract --gzip --file="${tarFileName}" --directory="${CUSTOM_UPDATECLI_PATH}" updatecli'))
     assertTrue(assertMethodCallContainsPattern('sh', 'updatecli diff'))
   }
-
 }

--- a/test/groovy/UpdatecliStepTests.groovy
+++ b/test/groovy/UpdatecliStepTests.groovy
@@ -37,11 +37,11 @@ class UpdatecliStepTests extends BaseTest {
     // And the repository checkouted
     assertTrue(assertMethodCallContainsPattern('checkout', ''))
 
-    
-     // Ensure no download happens
+
+    // Ensure no download happens
     assertFalse(assertMethodCallContainsPattern('sh', 'curl --silent --show-error --location --output'))
     assertFalse(assertMethodCallContainsPattern('sh', 'tar --extract'))
-    
+
     // And only the diff command called with default values
     assertTrue(assertMethodCallContainsPattern('sh','updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.yaml'))
     assertFalse(assertMethodCallContainsPattern('sh','updatecli apply'))
@@ -142,9 +142,9 @@ class UpdatecliStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('usernamePassword', "credentialsId=${anotherCredentialsId}"))
   }
 
-    /**
-  * New Test Cases for Custom Version Functionality
-  */
+  /**
+   * New Test Cases for Custom Version Functionality
+   */
 
   // Test that when a custom version is specified, the pipeline includes the download steps.
   @Test

--- a/test/groovy/UpdatecliStepTests.groovy
+++ b/test/groovy/UpdatecliStepTests.groovy
@@ -161,12 +161,22 @@ class UpdatecliStepTests extends BaseTest {
 
   @Test
   void itFailsWhenCustomVersionNotFound() throws Exception {
+    helper.registerAllowedMethod('sh', [Map.class], { Map args ->
+      if (args.script.contains("curl --silent --show-error --location --output") && args.script.contains("updatecli_Linux")) {
+        return 1  // simulate download failure (non-zero exit status)
+      }
+      if (args.script.contains("uname -m")) {
+        return "x86_64\n"
+      }
+      return 0
+    })
+
     def script = loadScript(scriptName)
     try {
       script.call(version: '0.99.99')
       fail("Expected error due to custom version not found")
     } catch (Exception e) {
-      // Test passes if an exception is thrown due to curl failure.
+      assertTrue(assertMethodCallContainsPattern('sh', 'curl --silent --show-error'))
     }
   }
 }

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -66,7 +66,7 @@ def call(userConfig = [:]) {
                                     # Debugging: Verify PATH and the resolved updatecli binary
                                     echo "Updated PATH: $PATH"
                                     echo "Resolved updatecli path: $(which updatecli)"
-                                    echo "$(ls -l /tmp/custom_updatecli/updatecli)
+                                    echo "$(ls -l /tmp/custom_updatecli/updatecli)"
                                 '''
                             }
                         }

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -47,7 +47,7 @@ def call(userConfig = [:]) {
     // If a custom version is provided, download and install that version of updatecli using tar files in a single sh step
     if (runUpdatecli && finalConfig.version) {
       stage("Download updatecli version ${finalConfig.version}") {
-        withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "PATH+UPDATECLI=${customUpdatecliPath}"]) { //Extend PATH dynamically
+        withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "PATH=$customUpdatecliPath:\$PATH"]) { //Extend PATH dynamically
           sh '''
             versionTag="v${UPDATECLI_VERSION}"
             cpu="$(uname -m)"
@@ -78,6 +78,12 @@ def call(userConfig = [:]) {
     // Do not add the flag "--values" if the provided value is "empty string"
     updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
 
+    // def call(Map params = [:]) {
+    // def finalConfig = params ?: [:] // Ensure finalConfig is always a valid map
+    // def updatecliCommand = finalConfig.version ? "${customUpdatecliPath}/updatecli" : "updatecli"
+    // updatecliCommand += " ${finalConfig.action}"
+    // updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
+    // updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
 
     stage(updatecliRunStage) {
       if (runUpdatecli) {

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -70,20 +70,20 @@ def call(userConfig = [:]) {
       }
     }
 
-    // **Factorized updatecli command builder - defined once, after installation**
-    def updatecliCommand = finalConfig.version ? "${customUpdatecliPath}/updatecli" : "updatecli"
-    updatecliCommand += " ${finalConfig.action}"
-    // Do not add the flag "--config" if the provided value is "empty string"
-    updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
-    // Do not add the flag "--values" if the provided value is "empty string"
-    updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
-
-    // def call(Map params = [:]) {
-    // def finalConfig = params ?: [:] // Ensure finalConfig is always a valid map
+    // // **Factorized updatecli command builder - defined once, after installation**
     // def updatecliCommand = finalConfig.version ? "${customUpdatecliPath}/updatecli" : "updatecli"
     // updatecliCommand += " ${finalConfig.action}"
+    // // Do not add the flag "--config" if the provided value is "empty string"
     // updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
+    // // Do not add the flag "--values" if the provided value is "empty string"
     // updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
+
+    def call(Map params = [:]) {
+    def finalConfig = params ?: [:] // Ensure finalConfig is always a valid map
+    def updatecliCommand = finalConfig.version ? "${customUpdatecliPath}/updatecli" : "updatecli"
+    updatecliCommand += " ${finalConfig.action}"
+    updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
+    updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
 
     stage(updatecliRunStage) {
       if (runUpdatecli) {

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -13,8 +13,8 @@ def call(userConfig = [:]) {
     version: ''                               // New: custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
   ]
 
-  // Merge userConfig into defaultConfig (userConfig overrides defaults)
-  final Map finalConfig = defaultConfig << userConfig
+  // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
+  // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map finalConfig = defaultConfig << userConfig
   final String customUpdatecliPath = "/tmp/custom_updatecli" // Factorized custom path
 
 
@@ -76,7 +76,9 @@ def call(userConfig = [:]) {
     // **Factorized updatecli command builder - defined once, after installation**
     def updatecliCommand = finalConfig.version ? "${customUpdatecliPath}/updatecli" : "updatecli"
     updatecliCommand += " ${finalConfig.action}"
+    // Do not add the flag "--config" if the provided value is "empty string"
     updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
+    // Do not add the flag "--values" if the provided value is "empty string"
     updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
 
 
@@ -85,7 +87,7 @@ def call(userConfig = [:]) {
         withCredentials([
           usernamePassword(
             credentialsId: finalConfig.credentialsId,
-            usernameVariable: 'USERNAME_VALUE',
+            usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
             passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
           )
         ]) {
@@ -95,7 +97,7 @@ def call(userConfig = [:]) {
           }
           sh updatecliCommand
         }
-      }
-    }
-  }
+      } // withCredentials
+    } // if (runUpdateCli)
+  } // stage
 }

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -14,9 +14,10 @@ def call(userConfig = [:]) {
   ]
 
   // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
-  // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map finalConfig = defaultConfig << userConfig
+  // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map 
+  
+  finalConfig = defaultConfig << userConfig
   final String customUpdatecliPath = "/tmp/custom_updatecli" // Factorized custom path
-
 
   // // Build the updatecli command if no custom version is provided
   // def updatecliCommand = ""

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -3,103 +3,92 @@
  **/
 
 def call(userConfig = [:]) {
-  def defaultConfig = [
-    action: 'diff',                         // Updatecli subcommand to execute
-    config: './updatecli/updatecli.d',        // Config manifest (file or directory) for updatecli
-    values: './updatecli/values.yaml',        // Values file used by updatecli
-    updatecliAgentLabel: 'jnlp-linux-arm64',  // Label to select the Jenkins node (agent)
-    cronTriggerExpression: '',                // When specified, it enables cron trigger for the calling pipeline
-    credentialsId: 'github-app-updatecli-on-jenkins-infra', // Credentials for GitHub access
-    version: '0.92.0'                               // New: custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
-  ]
+    def defaultConfig = [
+        action: 'diff',                         // Updatecli subcommand to execute
+        config: './updatecli/updatecli.d',      // Config manifest (file or directory) for updatecli
+        values: './updatecli/values.yaml',      // Values file used by updatecli
+        updatecliAgentLabel: 'jnlp-linux-arm64', // Label to select the Jenkins node (agent)
+        cronTriggerExpression: '',               // Enables cron trigger if specified
+        credentialsId: 'github-app-updatecli-on-jenkins-infra', // GitHub credentials
+        version: ''                               // Custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
+    ]
 
-  // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
-  // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map 
-  
-  finalConfig = defaultConfig << userConfig
-  final String customUpdatecliPath = "/tmp/custom_updatecli" // Factorized custom path
+    // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
+    // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map
+    finalConfig = defaultConfig << userConfig
+    final String customUpdatecliPath = "/tmp/custom_updatecli" // Factorized custom path
 
-  // // Build the updatecli command if no custom version is provided
-  // def updatecliCommand = ""
-  // if (!finalConfig.version) {
-  //   updatecliCommand = "updatecli ${finalConfig.action}"
-  //   updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
-  //   updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
-  // }
-
-  // Set cron trigger if requested
-  if (finalConfig.cronTriggerExpression) {
-    properties([pipelineTriggers([cron(finalConfig.cronTriggerExpression)])])
-  }
-
-  node (finalConfig.updatecliAgentLabel) {
-    final String updatecliRunStage = "Run updatecli: ${finalConfig.action}"
-    boolean runUpdatecli = true
-
-    stage("Check if ${finalConfig.config} folder exists: ${finalConfig.action}") {
-      checkout scm
-      if (!fileExists(finalConfig.config)) {
-        echo "WARNING: no ${finalConfig.config} folder."
-        runUpdatecli = false
-        org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(updatecliRunStage)
-      }
+    // Set cron trigger if requested
+    if (finalConfig.cronTriggerExpression) {
+        properties([pipelineTriggers([cron(finalConfig.cronTriggerExpression)])])
     }
 
-    // If a custom version is provided, download and install that version of updatecli using tar files in a single sh step
-    if (runUpdatecli && finalConfig.version) {
-      stage("Download updatecli version ${finalConfig.version}") {
-        sh 'echo $PATH'
-        withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "PATH+CUSTOM=$customUpdatecliPath", "CUSTOM_UPDATECLI_PATH=${customUpdatecliPath}"]) { //Extend PATH dynamically
-          sh 'echo $PATH'
-          sh '''
-            versionTag="v${UPDATECLI_VERSION}"
-            cpu="$(uname -m)"
-            # Normalize CPU architecture for Updatecli release filenames
-            if [ "$cpu" = "aarch64" ] || [ "$cpu" = "arm64" ]; then
-              cpu="arm64"
-            fi
-            # Construct the tar file name based on the CPU architecture.
-            tarFileName="updatecli_Linux_${cpu}.tar.gz" 
-            downloadUrl="https://github.com/updatecli/updatecli/releases/download/${versionTag}/${tarFileName}"
-            echo "Downloading updatecli version ${UPDATECLI_VERSION} from ${downloadUrl}"
-            curl --silent --location --output ${tarFileName} ${downloadUrl} || { echo "Download failed"; exit 1; }
-            echo "customUpdatecliPath is: ${PATH}"
-            # Create destination directory for extraction.
-            mkdir -p ${CUSTOM_UPDATECLI_PATH}
-            # Extract the updatecli binary from the tar file.
-            tar --extract --gzip --file="${tarFileName}" --directory=${CUSTOM_UPDATECLI_PATH} updatecli
-            # Remove the tar file leaving only the executable binary.
-            rm -f ${tarFileName}
-            # Debugging: Verify PATH and the resolved updatecli binary
-            echo "Updated PATH: $PATH"
-            echo "Resolved updatecli path: $(which updatecli)"
-          '''
-        }
-      }
-    }
+    node(finalConfig.updatecliAgentLabel) {
+        final String updatecliRunStage = "Run updatecli: ${finalConfig.action}"
+        boolean runUpdatecli = true
 
-    // **Factorized updatecli command builder - defined once, after installation**
-    def updatecliCommand = finalConfig.version ? "${customUpdatecliPath}/updatecli" : "updatecli"
-    updatecliCommand += " ${finalConfig.action}"
-    // Do not add the flag "--config" if the provided value is "empty string"
-    updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
-    // Do not add the flag "--values" if the provided value is "empty string"
-    updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
-
-    stage(updatecliRunStage) {
-      if (runUpdatecli) {
-        withCredentials([
-          usernamePassword(
-            credentialsId: finalConfig.credentialsId,
-            usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
-            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-          )
-        ]) {
-          // check the existing updatecli version.
-          sh "${updatecliCommand} version"
-          sh updatecliCommand
+        stage("Check if ${finalConfig.config} folder exists: ${finalConfig.action}") {
+            checkout scm
+            if (!fileExists(finalConfig.config)) {
+                echo "WARNING: no ${finalConfig.config} folder."
+                runUpdatecli = false
+                org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(updatecliRunStage)
+            }
         }
-      } // withCredentials
-    } // if (runUpdateCli)
-  } // stage
+
+        stage(updatecliRunStage) {
+            withEnv(["PATH+CUSTOM=$customUpdatecliPath"]) { // Wrap entire execution inside PATH update
+                if (runUpdatecli) {
+                    // If a custom version is provided, download and install that version of updatecli
+                    if (finalConfig.version) {
+                        stage("Download updatecli version ${finalConfig.version}") {
+                            sh 'echo $PATH'
+                            withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "CUSTOM_UPDATECLI_PATH=${customUpdatecliPath}"]) { // Only custom installation vars
+                                sh '''
+                                    versionTag="v${UPDATECLI_VERSION}"
+                                    cpu="$(uname -m)"
+                                    # Normalize CPU architecture for Updatecli release filenames
+                                    if [ "$cpu" = "aarch64" ] || [ "$cpu" = "arm64" ]; then
+                                        cpu="arm64"
+                                    fi
+                                    # Construct the tar file name based on the CPU architecture.
+                                    tarFileName="updatecli_Linux_${cpu}.tar.gz"
+                                    downloadUrl="https://github.com/updatecli/updatecli/releases/download/${versionTag}/${tarFileName}"
+                                    echo "Downloading updatecli version ${UPDATECLI_VERSION} from ${downloadUrl}"
+                                    curl --silent --location --output ${tarFileName} ${downloadUrl} || { echo "Download failed"; exit 1; }
+                                    echo "customUpdatecliPath is: ${PATH}"
+                                    # Create destination directory for extraction.
+                                    mkdir -p ${CUSTOM_UPDATECLI_PATH}
+                                    # Extract the updatecli binary from the tar file.
+                                    tar --extract --gzip --file="${tarFileName}" --directory=${CUSTOM_UPDATECLI_PATH} updatecli
+                                    # Remove the tar file leaving only the executable binary.
+                                    rm -f ${tarFileName}
+                                    # Debugging: Verify PATH and the resolved updatecli binary
+                                    echo "Updated PATH: $PATH"
+                                    echo "Resolved updatecli path: $(which updatecli)"
+                                '''
+                            }
+                        }
+                    }
+
+                    // Build the updatecli command
+                    def updatecliCommand = ""
+                    updatecliCommand = "updatecli ${finalConfig.action}"
+                    updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
+                    updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
+                    withCredentials([
+                        usernamePassword(
+                            credentialsId: finalConfig.credentialsId,
+                            usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
+                            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
+                        )
+                    ]) {
+                        // check the existing updatecli version.
+                        sh 'updatecli version'
+                        sh updatecliCommand
+                    }
+                } // if (runUpdatecli)
+            } // withEnv (["PATH+CUSTOM=$customUpdatecliPath"])
+        } // stage(updatecliRunStage)
+    } // node
 }

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -57,6 +57,7 @@ def call(userConfig = [:]) {
             downloadUrl="https://github.com/updatecli/updatecli/releases/download/${versionTag}/${tarFileName}"
             echo "Downloading updatecli version ${UPDATECLI_VERSION} from ${downloadUrl}"
             curl --silent --location --output ${tarFileName} ${downloadUrl} || { echo "Download failed"; exit 1; }
+            echo "customUpdatecliPath is: ${customUpdatecliPath}"
             # Create destination directory for extraction.
             mkdir -p ${customUpdatecliPath}
             # Extract the updatecli binary from the tar file.

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -49,7 +49,7 @@ def call(userConfig = [:]) {
     if (runUpdatecli && finalConfig.version) {
       stage("Download updatecli version ${finalConfig.version}") {
         sh 'echo $PATH'
-        withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "PATH+CUSTOM=$customUpdatecliPath"]) { //Extend PATH dynamically
+        withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "PATH+CUSTOM=$customUpdatecliPath", "CUSTOM_UPDATECLI_PATH=${customUpdatecliPath}"]) { //Extend PATH dynamically
           sh 'echo $PATH'
           sh '''
             versionTag="v${UPDATECLI_VERSION}"
@@ -61,9 +61,9 @@ def call(userConfig = [:]) {
             curl --silent --location --output ${tarFileName} ${downloadUrl} || { echo "Download failed"; exit 1; }
             echo "customUpdatecliPath is: ${PATH}"
             # Create destination directory for extraction.
-            mkdir -p ${customUpdatecliPath}
+            mkdir -p ${CUSTOM_UPDATECLI_PATH}
             # Extract the updatecli binary from the tar file.
-            tar --extract --gzip --file="${tarFileName}" --directory=${customUpdatecliPath} updatecli
+            tar --extract --gzip --file="${tarFileName}" --directory=${CUSTOM_UPDATECLI_PATH} updatecli
             # Remove the tar file leaving only the executable binary.
             rm -f ${tarFileName}
             # Debugging: Verify PATH and the resolved updatecli binary

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -96,7 +96,7 @@ def call(userConfig = [:]) {
           )
         ]) {
           // check the existing updatecli version.
-          sh '${updatecliCommand} version'
+          sh "${updatecliCommand} version"
           sh updatecliCommand
         }
       } // withCredentials

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -88,10 +88,8 @@ def call(userConfig = [:]) {
             passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
           )
         ]) {
-          // For the default case (no custom version), check the existing updatecli version.
-          if (!finalConfig.version) {
-            sh 'updatecli version'
-          }
+          // check the existing updatecli version.
+          sh 'updatecli version'
           sh updatecliCommand
         }
       } // withCredentials

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -48,7 +48,9 @@ def call(userConfig = [:]) {
     // If a custom version is provided, download and install that version of updatecli using tar files in a single sh step
     if (runUpdatecli && finalConfig.version) {
       stage("Download updatecli version ${finalConfig.version}") {
+        sh 'echo $PATH'
         withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "PATH+CUSTOM=$customUpdatecliPath"]) { //Extend PATH dynamically
+          sh 'echo $PATH'
           sh '''
             versionTag="v${UPDATECLI_VERSION}"
             cpu="$(uname -m)"

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -1,37 +1,38 @@
 /**
- Note: this shared pipeline is tailored to Jenkins infrastructure usage and thus set some default values which might not be desirable for yours.
+ Note: this shared pipeline is tailored to Jenkins infrastructure usage and thus sets some default values which might not be desirable for yours.
  **/
 
 def call(userConfig = [:]) {
   def defaultConfig = [
     action: 'diff', // Updatecli subcommand to execute
-    config: './updatecli/updatecli.d', // Config manifest used by updatecli (can be a file or a directory)
+    config: './updatecli/updatecli.d', // Config manifest (file or directory) for updatecli
     values: './updatecli/values.yaml', // Values file used by updatecli
-    updatecliAgentLabel: 'jnlp-linux-arm64', // replace updatecliDockerImage
+    updatecliAgentLabel: 'jnlp-linux-arm64', // Label to select the Jenkins node (agent)
     cronTriggerExpression: '', // When specified, it enables cron trigger for the calling pipeline
-    credentialsId: 'github-app-updatecli-on-jenkins-infra', // githubApp or usernamePassword credentials id to use to get an Access Token. The corresponding populated env vars are USERNAME_VALUE & UPDATECLI_GITHUB_TOKEN
+    credentialsId: 'github-app-updatecli-on-jenkins-infra', // Credentials for GitHub access (used for token generation)
+    version: '' // New: custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
   ]
 
-  // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
-
-  // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
+  // Merge userConfig into defaultConfig (userConfig overrides defaults)
   final Map finalConfig = defaultConfig << userConfig
 
-  def updatecliCommand = 'updatecli ' +  finalConfig.action
-  // Do not add the flag "--config" if the provided value is "empty string"
-  updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ''
-  // Do not add the flag "--values" if the provided value is "empty string"
-  updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ''
+  // Build the updatecli command if no custom version is provided
+  def updatecliCommand = ""
+  if (!finalConfig.version) {
+    updatecliCommand = "updatecli ${finalConfig.action}"
+    updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
+    updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
+  }
 
-  // Define a cron trigger only if requested by the user through attribute
+  // Set cron trigger if requested
   if (finalConfig.cronTriggerExpression) {
     properties([pipelineTriggers([cron(finalConfig.cronTriggerExpression)])])
   }
 
-
   node (finalConfig.updatecliAgentLabel) {
     final String updatecliRunStage = "Run updatecli: ${finalConfig.action}"
     boolean runUpdatecli = true
+
     stage("Check if ${finalConfig.config} folder exists: ${finalConfig.action}") {
       checkout scm
       if (!fileExists(finalConfig.config)) {
@@ -40,19 +41,78 @@ def call(userConfig = [:]) {
         org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(updatecliRunStage)
       }
     }
+
+    // If a custom version is provided, download that version of updatecli
+    if (runUpdatecli && finalConfig.version) {
+      stage("Download updatecli version ${finalConfig.version}") {
+        // Detect operating system (we expect Linux or Windows)
+        def os = isUnix() ? "linux" : "windows"
+        // Determine CPU architecture
+        def cpu = ""
+        if (isUnix()) {
+          cpu = sh(script: "uname -m", returnStdout: true).trim()
+        } else {
+          cpu = bat(script: "echo %PROCESSOR_ARCHITECTURE%", returnStdout: true).trim()
+        }
+        // Normalize CPU names to expected values
+        if (cpu == "x86_64" || cpu == "AMD64") {
+          cpu = "amd64"
+        } else if (cpu == "aarch64" || cpu == "arm64") {
+          cpu = "arm64"
+        }
+        // Construct the file name (append .exe for Windows)
+        def fileName = "updatecli-${os}-${cpu}"
+        if (!isUnix()) {
+          fileName += ".exe"
+        }
+        // Build the download URL (note the "v" prefix in the version tag)
+        def versionTag = "v${finalConfig.version}"
+        def downloadUrl = "https://github.com/updatecli/updatecli/releases/download/${versionTag}/${fileName}"
+        echo "Downloading updatecli version ${finalConfig.version} from ${downloadUrl}"
+        // Download the binary using curl (Unix) or PowerShell (Windows)
+        def downloadResult = 0
+        if (isUnix()) {
+          downloadResult = sh(script: "curl -fL ${downloadUrl} -o updatecli", returnStatus: true)
+        } else {
+          downloadResult = bat(script: "powershell -Command \"Invoke-WebRequest -Uri '${downloadUrl}' -OutFile 'updatecli.exe'\"", returnStatus: true)
+        }
+        if (downloadResult != 0) {
+          error "Specified updatecli version ${finalConfig.version} not found at ${downloadUrl}"
+        }
+        // For Unix, make the binary executable and build the command using the downloaded binary
+        if (isUnix()) {
+          sh "chmod +x updatecli"
+          updatecliCommand = "./updatecli ${finalConfig.action}"
+        } else {
+          updatecliCommand = "updatecli.exe ${finalConfig.action}"
+        }
+        updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
+        updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
+        // Optionally, verify the downloaded binary's version
+        if (isUnix()) {
+          sh "./updatecli version"
+        } else {
+          sh "updatecli.exe version"
+        }
+      }
+    }
+
     stage(updatecliRunStage) {
       if (runUpdatecli) {
         withCredentials([
           usernamePassword(
-          credentialsId: finalConfig.credentialsId,
-          usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
-          passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
+            credentialsId: finalConfig.credentialsId,
+            usernameVariable: 'USERNAME_VALUE',
+            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
           )
         ]) {
-          sh 'updatecli version'
+          // For the default case (no custom version), check the existing updatecli version
+          if (!finalConfig.version) {
+            sh 'updatecli version'
+          }
           sh updatecliCommand
-        } // withCredentials
-      } // if (runUpdateCli)
-    } // stage
+        }
+      }
+    }
   }
 }

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -48,7 +48,7 @@ def call(userConfig = [:]) {
     // If a custom version is provided, download and install that version of updatecli using tar files in a single sh step
     if (runUpdatecli && finalConfig.version) {
       stage("Download updatecli version ${finalConfig.version}") {
-        withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "PATH=$customUpdatecliPath:\$PATH"]) { //Extend PATH dynamically
+        withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "PATH+CUSTOM=$customUpdatecliPath"]) { //Extend PATH dynamically
           sh '''
             versionTag="v${UPDATECLI_VERSION}"
             cpu="$(uname -m)"

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -96,7 +96,7 @@ def call(userConfig = [:]) {
           )
         ]) {
           // check the existing updatecli version.
-          sh 'updatecli version'
+          sh '${updatecliCommand} version'
           sh updatecliCommand
         }
       } // withCredentials

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -67,9 +67,6 @@ def call(userConfig = [:]) {
             echo "Resolved updatecli path: $(which updatecli)"
           '''
         }
-        updatecliCommand = "${customUpdatecliPath}/updatecli ${finalConfig.action}"
-        updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
-        updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
       }
     }
 

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -10,7 +10,7 @@ def call(userConfig = [:]) {
     updatecliAgentLabel: 'jnlp-linux-arm64',  // Label to select the Jenkins node (agent)
     cronTriggerExpression: '',                // When specified, it enables cron trigger for the calling pipeline
     credentialsId: 'github-app-updatecli-on-jenkins-infra', // Credentials for GitHub access
-    version: ''                               // New: custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
+    version: '0.92.0'                               // New: custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
   ]
 
   // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -82,5 +82,15 @@ def call(userConfig = [:]) {
         } // withEnv (["PATH+CUSTOM=$customUpdatecliPath"])
       } // if (runUpdatecli)
     } // stage(updatecliRunStage)
-  } // node
+  } // executeUpdatecli closure
+
+  // Execute updatecli in the correct context based on runInCurrentAgent option
+  if (finalConfig.runInCurrentAgent) {
+      executeUpdatecli()
+    }
+  } else {
+    node(finalConfig.updatecliAgentLabel) {
+      executeUpdatecli()
+    }
+  }
 }

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -57,7 +57,7 @@ def call(userConfig = [:]) {
             downloadUrl="https://github.com/updatecli/updatecli/releases/download/${versionTag}/${tarFileName}"
             echo "Downloading updatecli version ${UPDATECLI_VERSION} from ${downloadUrl}"
             curl --silent --location --output ${tarFileName} ${downloadUrl} || { echo "Download failed"; exit 1; }
-            echo "customUpdatecliPath is: ${PATH+CUSTOM}"
+            echo "customUpdatecliPath is: ${PATH}"
             # Create destination directory for extraction.
             mkdir -p ${customUpdatecliPath}
             # Extract the updatecli binary from the tar file.

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -70,21 +70,13 @@ def call(userConfig = [:]) {
       }
     }
 
-    // // **Factorized updatecli command builder - defined once, after installation**
-    // def updatecliCommand = finalConfig.version ? "${customUpdatecliPath}/updatecli" : "updatecli"
-    // updatecliCommand += " ${finalConfig.action}"
-    // // Do not add the flag "--config" if the provided value is "empty string"
-    // updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
-    // // Do not add the flag "--values" if the provided value is "empty string"
-    // updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
-
-    def call(Map params = [:]) {
-    def finalConfig = params ?: [:] // Ensure finalConfig is always a valid map
+    // **Factorized updatecli command builder - defined once, after installation**
     def updatecliCommand = finalConfig.version ? "${customUpdatecliPath}/updatecli" : "updatecli"
     updatecliCommand += " ${finalConfig.action}"
+    // Do not add the flag "--config" if the provided value is "empty string"
     updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
+    // Do not add the flag "--values" if the provided value is "empty string"
     updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
-    }
 
     stage(updatecliRunStage) {
       if (runUpdatecli) {

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -63,7 +63,7 @@ def call(userConfig = [:]) {
                     }
 
                     // Build the updatecli command
-                    String updatecliCommand = ""
+                    def updatecliCommand = ""
                     updatecliCommand = "updatecli ${finalConfig.action}"
                     updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
                     updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -16,7 +16,6 @@ def call(userConfig = [:]) {
     // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
     // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map
     finalConfig = defaultConfig << userConfig
-    final String customUpdatecliPath = "${pwd tmp: true}/custom_updatecli"
 
     // Set cron trigger if requested
     if (finalConfig.cronTriggerExpression) {
@@ -24,6 +23,7 @@ def call(userConfig = [:]) {
     }
 
     node(finalConfig.updatecliAgentLabel) {
+        final String customUpdatecliPath = "${pwd tmp: true}/custom_updatecli"
         final String updatecliRunStage = "Run updatecli: ${finalConfig.action}"
         boolean runUpdatecli = true
 
@@ -63,7 +63,7 @@ def call(userConfig = [:]) {
                     }
 
                     // Build the updatecli command
-                    def updatecliCommand = ""
+                    String updatecliCommand = ""
                     updatecliCommand = "updatecli ${finalConfig.action}"
                     updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
                     updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -84,6 +84,7 @@ def call(userConfig = [:]) {
     updatecliCommand += " ${finalConfig.action}"
     updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
     updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
+    }
 
     stage(updatecliRunStage) {
       if (runUpdatecli) {

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -53,7 +53,7 @@ def call(userConfig = [:]) {
           sh 'echo $PATH'
           sh '''
             versionTag="v${UPDATECLI_VERSION}"
-            cpu="$(uname -m)"
+            cpu="$(uname -p)"
             # Construct the tar file name based on the CPU architecture.
             tarFileName="updatecli_Linux_${cpu}.tar.gz" 
             downloadUrl="https://github.com/updatecli/updatecli/releases/download/${versionTag}/${tarFileName}"

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -82,15 +82,5 @@ def call(userConfig = [:]) {
         } // withEnv (["PATH+CUSTOM=$customUpdatecliPath"])
       } // if (runUpdatecli)
     } // stage(updatecliRunStage)
-  } // executeUpdatecli closure
-
-  // Execute updatecli in the correct context based on runInCurrentAgent option
-  if (finalConfig.runInCurrentAgent) {
-      executeUpdatecli()
-    }
-  } else {
-    node(finalConfig.updatecliAgentLabel) {
-      executeUpdatecli()
-    }
-  }
+  } // node
 }

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -43,19 +43,16 @@ def call(userConfig = [:]) {
           // If a custom version is provided, download and install that version of updatecli
           if (finalConfig.version) {
             stage("Download updatecli version ${finalConfig.version}") {
-              sh 'echo $PATH'
               withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "CUSTOM_UPDATECLI_PATH=${customUpdatecliPath}"]) {
-                // Only custom installation vars
                 sh '''
                                     cpu="$(uname -m)"
                                     # Normalize CPU architecture for Updatecli release filenames
+                                    # Caused by https://github.com/updatecli/updatecli/blob/main/.goreleaser.yml#L4-L9
                                     if [ "$cpu" = "aarch64" ] || [ "$cpu" = "arm64" ]; then
                                         cpu="arm64"
                                     fi
-                                    # Construct the tar file name based on the CPU architecture.
                                     tarFileName="updatecli_Linux_${cpu}.tar.gz"
-                                    downloadUrl="https://github.com/updatecli/updatecli/releases/download/v${UPDATECLI_VERSION}/${tarFileName}"
-                                    curl --silent --show-error --location --output ${tarFileName} ${downloadUrl}
+                                    curl --silent --show-error --location --output ${tarFileName} "https://github.com/updatecli/updatecli/releases/download/v${UPDATECLI_VERSION}/${tarFileName}"
                                     mkdir -p "${CUSTOM_UPDATECLI_PATH}"
                                     tar --extract --gzip --file="${tarFileName}" --directory="${CUSTOM_UPDATECLI_PATH}" updatecli
                                     rm -f "${tarFileName}"

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -57,7 +57,7 @@ def call(userConfig = [:]) {
             downloadUrl="https://github.com/updatecli/updatecli/releases/download/${versionTag}/${tarFileName}"
             echo "Downloading updatecli version ${UPDATECLI_VERSION} from ${downloadUrl}"
             curl --silent --location --output ${tarFileName} ${downloadUrl} || { echo "Download failed"; exit 1; }
-            echo "customUpdatecliPath is: ${customUpdatecliPath}"
+            echo "customUpdatecliPath is: ${PATH+CUSTOM}"
             # Create destination directory for extraction.
             mkdir -p ${customUpdatecliPath}
             # Extract the updatecli binary from the tar file.

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -53,7 +53,11 @@ def call(userConfig = [:]) {
           sh 'echo $PATH'
           sh '''
             versionTag="v${UPDATECLI_VERSION}"
-            cpu="$(uname -p)"
+            cpu="$(uname -m)"
+            # Normalize CPU architecture for Updatecli release filenames
+            if [ "$cpu" = "aarch64" ] || [ "$cpu" = "arm64" ]; then
+              cpu="arm64"
+            fi
             # Construct the tar file name based on the CPU architecture.
             tarFileName="updatecli_Linux_${cpu}.tar.gz" 
             downloadUrl="https://github.com/updatecli/updatecli/releases/download/${versionTag}/${tarFileName}"

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -66,6 +66,7 @@ def call(userConfig = [:]) {
                                     # Debugging: Verify PATH and the resolved updatecli binary
                                     echo "Updated PATH: $PATH"
                                     echo "Resolved updatecli path: $(which updatecli)"
+                                    echo "$(ls -l /tmp/custom_updatecli/updatecli)
                                 '''
                             }
                         }

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -3,48 +3,50 @@
  **/
 
 def call(userConfig = [:]) {
-    def defaultConfig = [
-        action: 'diff',                         // Updatecli subcommand to execute
-        config: './updatecli/updatecli.d',      // Config manifest (file or directory) for updatecli
-        values: './updatecli/values.yaml',      // Values file used by updatecli
-        updatecliAgentLabel: 'jnlp-linux-arm64', // Label to select the Jenkins node (agent)
-        cronTriggerExpression: '',               // Enables cron trigger if specified
-        credentialsId: 'github-app-updatecli-on-jenkins-infra', // GitHub credentials
-        version: ''                               // Custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
-    ]
+  def defaultConfig = [
+    action: 'diff',                         // Updatecli subcommand to execute
+    config: './updatecli/updatecli.d',      // Config manifest (file or directory) for updatecli
+    values: './updatecli/values.yaml',      // Values file used by updatecli
+    updatecliAgentLabel: 'jnlp-linux-arm64', // Label to select the Jenkins node (agent)
+    cronTriggerExpression: '',               // Enables cron trigger if specified
+    credentialsId: 'github-app-updatecli-on-jenkins-infra', // GitHub credentials
+    version: ''                               // Custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
+  ]
 
-    // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
-    // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map
-    finalConfig = defaultConfig << userConfig
+  // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
+  // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map
+  finalConfig = defaultConfig << userConfig
 
-    // Set cron trigger if requested
-    if (finalConfig.cronTriggerExpression) {
-        properties([pipelineTriggers([cron(finalConfig.cronTriggerExpression)])])
+  // Set cron trigger if requested
+  if (finalConfig.cronTriggerExpression) {
+    properties([pipelineTriggers([cron(finalConfig.cronTriggerExpression)])])
+  }
+
+  node(finalConfig.updatecliAgentLabel) {
+    final String customUpdatecliPath = "${pwd tmp: true}/custom_updatecli"
+    final String updatecliRunStage = "Run updatecli: ${finalConfig.action}"
+    boolean runUpdatecli = true
+
+    stage("Check if ${finalConfig.config} folder exists: ${finalConfig.action}") {
+      checkout scm
+      if (!fileExists(finalConfig.config)) {
+        echo "WARNING: no ${finalConfig.config} folder."
+        runUpdatecli = false
+        org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(updatecliRunStage)
+      }
     }
 
-    node(finalConfig.updatecliAgentLabel) {
-        final String customUpdatecliPath = "${pwd tmp: true}/custom_updatecli"
-        final String updatecliRunStage = "Run updatecli: ${finalConfig.action}"
-        boolean runUpdatecli = true
-
-        stage("Check if ${finalConfig.config} folder exists: ${finalConfig.action}") {
-            checkout scm
-            if (!fileExists(finalConfig.config)) {
-                echo "WARNING: no ${finalConfig.config} folder."
-                runUpdatecli = false
-                org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(updatecliRunStage)
-            }
-        }
-
-        stage(updatecliRunStage) {
-            if (runUpdatecli) {
-                withEnv(["PATH+CUSTOM=$customUpdatecliPath"]) { // Wrap entire execution inside PATH update
-                    // If a custom version is provided, download and install that version of updatecli
-                    if (finalConfig.version) {
-                        stage("Download updatecli version ${finalConfig.version}") {
-                            sh 'echo $PATH'
-                            withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "CUSTOM_UPDATECLI_PATH=${customUpdatecliPath}"]) { // Only custom installation vars
-                                sh '''
+    stage(updatecliRunStage) {
+      if (runUpdatecli) {
+        withEnv(["PATH+CUSTOM=$customUpdatecliPath"]) {
+          // Wrap entire execution inside PATH update
+          // If a custom version is provided, download and install that version of updatecli
+          if (finalConfig.version) {
+            stage("Download updatecli version ${finalConfig.version}") {
+              sh 'echo $PATH'
+              withEnv(["UPDATECLI_VERSION=${finalConfig.version}", "CUSTOM_UPDATECLI_PATH=${customUpdatecliPath}"]) {
+                // Only custom installation vars
+                sh '''
                                     cpu="$(uname -m)"
                                     # Normalize CPU architecture for Updatecli release filenames
                                     if [ "$cpu" = "aarch64" ] || [ "$cpu" = "arm64" ]; then
@@ -58,30 +60,30 @@ def call(userConfig = [:]) {
                                     tar --extract --gzip --file="${tarFileName}" --directory="${CUSTOM_UPDATECLI_PATH}" updatecli
                                     rm -f "${tarFileName}"
                                 '''
-                            }
-                        }
-                    }
+              }
+            }
+          }
 
-                    // Build the updatecli command
-                    String updatecliCommand = ""
-                    updatecliCommand = "updatecli ${finalConfig.action}"
-                    updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
-                    updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
-                    withCredentials([
-                        usernamePassword(
-                            credentialsId: finalConfig.credentialsId,
-                            usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
-                            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-                        )
-                    ]) {
-                        sh '''
+          // Build the updatecli command
+          String updatecliCommand = ""
+          updatecliCommand = "updatecli ${finalConfig.action}"
+          updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
+          updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
+          withCredentials([
+            usernamePassword(
+            credentialsId: finalConfig.credentialsId,
+            usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
+            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
+            )
+          ]) {
+            sh '''
                         which updatecli
                         updatecli version
                         '''
-                        sh updatecliCommand
-                    }
-                } // withEnv (["PATH+CUSTOM=$customUpdatecliPath"])
-            } // if (runUpdatecli)
-        } // stage(updatecliRunStage)
-    } // node
+            sh updatecliCommand
+          }
+        } // withEnv (["PATH+CUSTOM=$customUpdatecliPath"])
+      } // if (runUpdatecli)
+    } // stage(updatecliRunStage)
+  } // node
 }


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4539

This PR adds `custom version` execution of updatecli,

Tested on infra.ci successfully. The test harness has also been modified to test the changes in `updatecli.groovy`

Custom version `0.92` set – https://infra.ci.jenkins.io/job/updatecli/job/terraform-aws-sponsorship/job/PR-164/15/
When custom version not set (non-regressive test) – https://infra.ci.jenkins.io/job/updatecli/job/terraform-aws-sponsorship/job/PR-161/29/