### PR TITLE
fix(infra/Windows/checkoutSCM) Ensure Git LongPath is set at system level

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -143,8 +143,8 @@ Object checkoutSCM(String repo = null) {
   // Fix https://github.com/jenkins-infra/helpdesk/issues/3865 with autocrlf
   if (!isUnix()) {
     bat '''
-        git config --global core.autocrlf true
-        git config --global core.longpaths true
+        git config set --system core.autocrlf true
+        git config set --system core.longPaths true
         '''
   }
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4574

- The `--global` flag writes at the user level. We want to be sure the setting is scoped to all usages on the machine
  - Ref. https://git-scm.com/docs/git-config which says `For writing options: write to global ~/.gitconfig` whicle `--system` states `For writing options: write to system-wide $(prefix)/etc/gitconfig rather than the repository .git/config.` (adapt path to windows of course)

- Change casing of the option `longPaths` to comply with https://github.com/git-for-windows/build-extra/blob/9953c6ca5b5863feb83d0bb657d23afdba2c37d6/ReleaseNotes.md?plain=1#L21

- Not specifying the `set` subcommand is deprecated as per https://git-scm.com/docs/git-config#_deprecated_modes. Lets be explicit about this command setting up a value (ref. https://git-scm.com/docs/git-config#Documentation/git-config.txt-set).


=> note: these changes, most probably, won't solve the problem in the issue https://github.com/jenkins-infra/helpdesk/issues/4574 but will help in diagnosing (and are part of cleanups)