### PR TITLE
fix(infra) fix a potential memory leak related to missing type for `orgAndCredentialsId`

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -59,12 +59,12 @@ Object withDockerCredentials(Map orgAndCredentialsId, Closure body) {
 }
 
 Object withDockerPushCredentials(Closure body) {
-  orgAndCredentialsId = new InfraConfig(env).getDockerPushOrgAndCredentialsId()
+  Map orgAndCredentialsId = new InfraConfig(env).getDockerPushOrgAndCredentialsId()
   return withDockerCredentials(orgAndCredentialsId, body)
 }
 
 Object withDockerPullCredentials(Closure body) {
-  orgAndCredentialsId = new InfraConfig(env).getDockerPullOrgAndCredentialsId()
+  Map orgAndCredentialsId = new InfraConfig(env).getDockerPullOrgAndCredentialsId()
   return withDockerCredentials(orgAndCredentialsId, body)
 }
 


### PR DESCRIPTION
This change aims at getting fixing the warning message below seen in our private controller pipeline outputs:

```
Did you forget the `def` keyword? infra seems to be setting a field named orgAndCredentialsId (to a value of type LinkedHashMap) which could lead to memory leaks or other issues.
```