### PR TITLE
fix(buildPlugin,buildPluginWithGradle): deprecate `maven`, `windows` and `maven-windows` labels in favor of explicits `maven-8` and `maven-8-windows`

### DIFF
--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -125,9 +125,9 @@ class BuildPluginStepTests extends BaseTest {
     script.call([:])
     printCallStack()
     // then it runs a stage in a linux VM by default
-    assertTrue(assertMethodCallContainsPattern('node', 'vm && linux'))
+    assertTrue(assertMethodCallContainsPattern('node', 'linux-8-false'))
     // then it runs a stage in a Windows VM by default
-    assertTrue(assertMethodCallContainsPattern('node', 'docker-windows'))
+    assertTrue(assertMethodCallContainsPattern('node', 'windows-8-false'))
     // then it runs the junit step by default
     assertTrue(assertMethodCall('junit'))
     // then it runs the junit step with the maven test format
@@ -142,9 +142,9 @@ class BuildPluginStepTests extends BaseTest {
     script.call([useContainerAgent: true])
     printCallStack()
     // then it runs a stage in a linux container by default
-    assertTrue(assertMethodCallContainsPattern('node', 'maven'))
+    assertTrue(assertMethodCallContainsPattern('node', 'linux-8-true'))
     // then it runs a stage in a Windows container by default
-    assertTrue(assertMethodCallContainsPattern('node', 'maven-windows'))
+    assertTrue(assertMethodCallContainsPattern('node', 'windows-8-true'))
     assertJobStatusSuccess()
   }
 
@@ -176,12 +176,10 @@ class BuildPluginStepTests extends BaseTest {
     // when running with useContainerAgent set to true
     script.call(platforms: ['openbsd', 'maven-windows-experimental'])
     printCallStack()
-    // then it runs a stage in an openbsd node with a warning message
-    assertTrue(assertMethodCallContainsPattern('node', 'openbsd'))
-    assertTrue(assertMethodCallContainsPattern('echo', 'WARNING: Unknown Virtual Machine platform \'openbsd\''))
+    // then it runs a stage in an openbsd node
+    assertTrue(assertMethodCallContainsPattern('node', 'openbsd-8-false'))
     // then it runs a stage in a maven-windows-experimental node with a warning message
-    assertTrue(assertMethodCallContainsPattern('node', 'maven-windows-experimental'))
-    assertTrue(assertMethodCallContainsPattern('echo', 'WARNING: Unknown Virtual Machine platform \'maven-windows-experimental\''))
+    assertTrue(assertMethodCallContainsPattern('node', 'maven-windows-experimental-8-false'))
     assertJobStatusSuccess()
   }
 

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -476,4 +476,54 @@ class InfraStepTests extends BaseTest {
     // then it doesn't succeeds
     assertJobStatusFailure()
   }
+
+  @Test
+  void testGetBuildAgentLabelWithLinuxJDK21Container() throws Exception {
+    def script = loadScript(scriptName)
+    String gotResult = script.getBuildAgentLabel('linux', '21', true)
+    printCallStack()
+    assertTrue(gotResult == 'maven-21')
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING: Unknown Virtual Machine platform'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testGetBuildAgentLabelWithLinuxJDK8VM() throws Exception {
+    def script = loadScript(scriptName)
+    String gotResult = script.getBuildAgentLabel('linux', '8', false)
+    printCallStack()
+    assertTrue(gotResult == 'vm && linux')
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING: Unknown Virtual Machine platform'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testGetBuildAgentLabelWithWindowsJDK17Container() throws Exception {
+    def script = loadScript(scriptName)
+    String gotResult = script.getBuildAgentLabel('windows', '17', true)
+    printCallStack()
+    assertTrue(gotResult == 'maven-17-windows')
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING: Unknown Virtual Machine platform'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testGetBuildAgentLabelWithWindowsJDK8VM() throws Exception {
+    def script = loadScript(scriptName)
+    String gotResult = script.getBuildAgentLabel('windows', '8', false)
+    printCallStack()
+    assertTrue(gotResult == 'docker-windows')
+    assertFalse(assertMethodCallContainsPattern('echo', 'WARNING: Unknown Virtual Machine platform'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testGetBuildAgentLabelUnsupportedPlatform() throws Exception {
+    def script = loadScript(scriptName)
+    String gotResult = script.getBuildAgentLabel('openbsd', '11', false)
+    printCallStack()
+    assertTrue(gotResult == 'openbsd')
+    assertTrue(assertMethodCallContainsPattern('echo', 'WARNING: Unknown Virtual Machine platform'))
+    assertJobStatusSuccess()
+  }
 }

--- a/test/groovy/mock/Infra.groovy
+++ b/test/groovy/mock/Infra.groovy
@@ -56,4 +56,8 @@ class Infra implements Serializable {
   public void maybePublishIncrementals() { }
 
   void publishDeprecationCheck(String deprecationSummary, String deprecationMessage) { }
+
+  String getBuildAgentLabel(String platform, String jdk, Boolean useContainerAgent) {
+    return "${platform}-${jdk}-${useContainerAgent.toString()}"
+  }
 }

--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -7,6 +7,7 @@ def call(Map params = [:]) {
   properties([buildDiscarder(logRotator(numToKeepStr: '5'))])
 
   def repo = params.containsKey('repo') ? params.repo : null
+  def useContainerAgent = params.containsKey('useContainerAgent') ? params.useContainerAgent : false
   def failFast = params.containsKey('failFast') ? params.failFast : true
   def timeoutValue = params.containsKey('timeout') ? params.timeout : 60
   if (timeoutValue > 180) {
@@ -19,7 +20,7 @@ def call(Map params = [:]) {
   boolean archivedArtifacts = false
   Map tasks = [failFast: failFast]
   buildPlugin.getConfigurations(params).each { config ->
-    String label = config.platform
+    String label = infra.getBuildAgentLabel(config.platform, config.jdk, useContainerAgent)
     String jdk = config.jdk
     String jenkinsVersion = config.jenkins
 

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -436,3 +436,27 @@ void publishDeprecationCheck(String deprecationSummary, String deprecationMessag
   echo "WARNING: ${deprecationMessage}"
   publishChecks name: 'pipeline-library', summary: deprecationSummary, conclusion: 'NEUTRAL', text: deprecationMessage
 }
+
+String getBuildAgentLabel(String platform, String jdk, Boolean useContainerAgent) {
+  if (useContainerAgent) {
+    if (platform == 'linux' || platform == 'windows') {
+      String agentContainerLabel = 'maven-' + jdk
+      if (platform == 'windows') {
+        agentContainerLabel += '-windows'
+      }
+      return agentContainerLabel
+    }
+  } else {
+    switch(platform) {
+      case 'windows':
+        return 'docker-windows'
+        break
+      case 'linux':
+        return 'vm && linux'
+        break
+      default:
+        echo "WARNING: Unknown Virtual Machine platform '${platform}'. Set useContainerAgent to 'true' unless you want to be in uncharted territory."
+        return platform
+    }
+  }
+}


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/4620, I forgot to migrate the `maven-windows` and `maven` labels.

These labels are confusing as they do not clearly define an explicit JDK mainline version and should not be used for clarity.

End users are not expected to use these labels: it is only the 2 functions `buildPlugin()` and `buildPluginWithGradle()` which does.

This PR does naively factorize the logic behind the label specification into the `infra` library (with tests showing a few major use cases for the contributor comprehension), so that it can be used without repetition in the 2 functions `buildPlugin()` and `buildPluginWithGradle()`.


Note: there are further possible improvements, in particular the "spot/non spot" logic could also be factorized and reused, but I prefer starting simple.