### PR TITLE
feat:(buildDockerAndPublishImage)!: Enable `automaticSemanticVersioning` by default

### DIFF
--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -180,8 +180,8 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // And `unstash` isn't called
     assertFalse(assertMethodCall('unstash'))
 
-    // But no release created automatically
-    assertFalse(assertTagPushed(defaultGitTag))
+    // And release created automatically
+    assertTrue(assertTagPushed(defaultGitTag))
 
     // And all mocked/stubbed methods have to be called
     verifyMocks()
@@ -212,8 +212,8 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertMethodCallContainsPattern('sh','make bake-deploy')
     assertMethodCallContainsPattern('withEnv', "IMAGE_DEPLOY_NAME=${fullCustomImageName}")
 
-    // But no tag pushed
-    assertFalse(assertTagPushed(defaultGitTag))
+    // When Tag is manually pushed
+    assertTrue(assertTagPushed(defaultGitTag))
     // And all mocked/stubbed methods have to be called
     verifyMocks()
   }
@@ -484,8 +484,8 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // And `unstash` is called
     assertTrue(assertMethodCallContainsPattern('unstash', 'stashName'))
 
-    // But no release created automatically
-    assertFalse(assertTagPushed(defaultGitTag))
+    // And release created automatically
+    assertTrue(assertTagPushed(defaultGitTag))
 
     // And all mocked/stubbed methods have to be called
     verifyMocks()

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -40,7 +40,7 @@ def makecall(String action, String imageDeployName, String targetOperationSystem
 def call(String imageShortName, Map userConfig=[:]) {
   def defaultConfig = [
     agentLabels: 'docker || linux-amd64-docker', // String expression for the labels the agent must match
-    automaticSemanticVersioning: false, // Do not automagically increase semantic version by default
+    automaticSemanticVersioning: true, // automagically increase semantic version by default
     dockerfile: 'Dockerfile', // Obvious default
     targetplatforms: '', // // Define the (comma separated) list of Docker supported platforms to build the image for. Defaults to `linux/amd64` when unspecified. Incompatible with the legacy `platform` attribute.
     nextVersionCommand: 'jx-release-version', // Commmand line used to retrieve the next version


### PR DESCRIPTION
BREKING CHANGE:

Related to - https://github.com/jenkins-infra/helpdesk/issues/4165

This PR sets `automaticSemanticVersioning` by default. To avoid automatic versioning explicitly set it as false in the script call.