### PR TITLE
feat(updatecli) allow enabling debug

### DIFF
--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -4,14 +4,15 @@
 
 def call(userConfig = [:]) {
   def defaultConfig = [
-    action: 'diff',                         // Updatecli subcommand to execute
-    config: './updatecli/updatecli.d',      // Config manifest (file or directory) for updatecli
-    values: './updatecli/values.yaml',      // Values file used by updatecli
+    action: 'diff',                          // Updatecli subcommand to execute
+    config: './updatecli/updatecli.d',       // Config manifest (file or directory) for updatecli
+    values: './updatecli/values.yaml',       // Values file used by updatecli
     updatecliAgentLabel: 'jnlp-linux-arm64', // Label to select the Jenkins node (agent)
-    cronTriggerExpression: '',              // Enables cron trigger if specified
+    cronTriggerExpression: '',               // Enables cron trigger if specified
     credentialsId: 'github-app-updatecli-on-jenkins-infra', // GitHub credentials
-    version: '', // Custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
-    runInCurrentAgent: false,               // New option: if true, run updatecli in the current node
+    version: '',                             // Custom updatecli version (e.g. '0.92.0' or '0.86.0-rc.1')
+    runInCurrentAgent: false,                // Specify wether to allocate an agent to run updatecli (default) or reuse the current one
+    debug: false,                            // Enable debug output on updatecli
   ]
 
   // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
@@ -66,6 +67,9 @@ def call(userConfig = [:]) {
           // Build the updatecli command
           String updatecliCommand = ""
           updatecliCommand = "updatecli ${finalConfig.action}"
+          if (finalConfig.debug) {
+            updatecliCommand += '--debug'
+          }
           updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
           updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""
           withCredentials([

--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -15,9 +15,8 @@ def call(userConfig = [:]) {
     debug: false,                            // Enable debug output on updatecli
   ]
 
-  // TODO: use isInfra() to set a default githubApp credentials id for infra & for ci
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map
-  finalConfig = defaultConfig << userConfig
+  def finalConfig = defaultConfig << userConfig
 
   // Set cron trigger if requested
   if (finalConfig.cronTriggerExpression) {
@@ -68,7 +67,7 @@ def call(userConfig = [:]) {
           String updatecliCommand = ""
           updatecliCommand = "updatecli ${finalConfig.action}"
           if (finalConfig.debug) {
-            updatecliCommand += '--debug'
+            updatecliCommand += ' --debug'
           }
           updatecliCommand += finalConfig.config ? " --config ${finalConfig.config}" : ""
           updatecliCommand += finalConfig.values ? " --values ${finalConfig.values}" : ""


### PR DESCRIPTION
This PR introduces a new boolean argument to the `updatecli()` shared library which allows turning on the debug output for `updatecli`.

It must stay disabled by default as it might output sensitive data.


Tested with https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/225


It also fixes a minor warning around a missing `def` keyword