### PR TITLE
feat(publishBuildStatusReport): publishes controller job status on reports.jenkins.io

### DIFF
--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+set -x
 
 # Extract hostname from JENKINS_URL
 CONTROLLER_HOSTNAME=$(echo "$JENKINS_URL" | sed 's|https\?://||' | cut -d'/' -f1)

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -32,11 +32,3 @@ cd "$REPORT_DIR"
 azcopy logout >/dev/null 2>&1 || true
 test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
 azcopy login --identity
-
-# Try azcopy with error handling
-if ! azcopy copy "status.json" "$DESTINATION_URL"; then
-    echo "azcopy failed, collecting logs for debugging"
-    # Retrieve azcopy logs to archive them
-    cat /home/jenkins/.azcopy/*.log > "$WORKSPACE/azcopy.log" 2>/dev/null
-    exit 1
-fi

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -23,7 +23,7 @@ cat > "$REPORT_FILE" << EOF
 EOF
 
 # Upload with azcopy
-DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME"
+DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$JENKINS_URL/$JOB_NAME"
 
 cd "$REPORT_DIR"
 azcopy logout 2>/dev/null || true

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Extract controller hostname from JENKINS_URL
-CONTROLLER_HOSTNAME=$(echo "$JENKINS_URL" | sed 's|https\?://||' | cut -d'/' -f1 | cut -d':' -f1 | sed 's/[^a-zA-Z0-9.-]/_/g')
-
 # Build file path
 REPORT_DIR="$WORKSPACE/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME"
 REPORT_FILE="$REPORT_DIR/status.json"
@@ -17,7 +14,7 @@ REPORT_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 # Generate JSON report
 cat > "$REPORT_FILE" << EOF
 {
-  "controller_hostname": "$CONTROLLER_HOSTNAME",
+  "controller_url": "$JENKINS_URL",
   "job_name": "$JOB_NAME",
   "build_number": "$BUILD_NUMBER",
   "build_status": "$BUILD_STATUS",

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -27,10 +27,11 @@ cat > "$REPORT_FILE" << EOF
 EOF
 
 # Upload with azcopy
-DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME"
+DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME/"
 
 cd "$REPORT_DIR"
 azcopy logout >/dev/null 2>&1 || true
 test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
 azcopy login --identity
-azcopy copy "status.json" "$DESTINATION_URL" --recursive
+azcopy make "$DESTINATION_URL"
+azcopy copy "status.json" "$DESTINATION_URL"

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Build file path
-REPORT_DIR="$WORKSPACE/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME"
+REPORT_DIR="$WORKSPACE/build_status_reports/$JENKINS_URL/$JOB_NAME"
 REPORT_FILE="$REPORT_DIR/status.json"
 
 # Create directory

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -27,10 +27,10 @@ cat > "$REPORT_FILE" << EOF
 EOF
 
 # Upload with azcopy
-DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME/status.json"
+DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME"
 
 cd "$REPORT_DIR"
 azcopy logout >/dev/null 2>&1 || true
 test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
 azcopy login --identity
-azcopy copy "status.json" "$DESTINATION_URL"
+azcopy copy "status.json" "$DESTINATION_URL" --recursive

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+set -x
 
 # Build file path
 REPORT_DIR="$WORKSPACE/build_status_reports/$JENKINS_URL/$JOB_NAME"

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -32,3 +32,4 @@ cd "$REPORT_DIR"
 azcopy logout >/dev/null 2>&1 || true
 test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
 azcopy login --identity
+azcopy copy "status.json" "$DESTINATION_URL"

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -33,4 +33,4 @@ cd "$REPORT_DIR"
 azcopy logout >/dev/null 2>&1 || true
 test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
 azcopy login --identity
-azcopy sync "$REPORT_DIR/" "$DESTINATION_URL"
+azcopy copy "status.json" "$DESTINATION_URL" --recursive

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-set -x
 
 # Extract hostname from JENKINS_URL
 CONTROLLER_HOSTNAME=$(echo "$JENKINS_URL" | sed 's|https\?://||' | cut -d'/' -f1)

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -38,6 +38,6 @@ azcopy login --identity
 if ! azcopy copy "status.json" "$DESTINATION_URL"; then
     echo "azcopy failed, collecting logs for debugging"
     # Retrieve azcopy logs to archive them
-    cat /home/jenkins/.azcopy/*.log > "$WORKSPACE/azcopy.log" 2>/dev/null || echo "No azcopy logs found"
+    cat /home/jenkins/.azcopy/*.log > "$WORKSPACE/azcopy.log" 2>/dev/null
     exit 1
 fi

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -27,7 +27,7 @@ cat > "$REPORT_FILE" << EOF
 EOF
 
 # Upload with azcopy
-DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME/"
+DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME/status.json"
 
 cd "$REPORT_DIR"
 azcopy logout >/dev/null 2>&1 || true

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -27,7 +27,7 @@ cat > "$REPORT_FILE" << EOF
 EOF
 
 # Upload with azcopy
-DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME"
+DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME/"
 
 cd "$REPORT_DIR"
 azcopy logout >/dev/null 2>&1 || true

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -33,5 +33,4 @@ cd "$REPORT_DIR"
 azcopy logout >/dev/null 2>&1 || true
 test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
 azcopy login --identity
-azcopy make "$DESTINATION_URL"
-azcopy copy "status.json" "$DESTINATION_URL"
+azcopy sync "status.json" "$DESTINATION_URL"

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+#
+# It expects the following environment variables to be set:
+#   ENV_CONTROLLER_HOSTNAME
+#   ENV_JOB_NAME
+#   ENV_BUILD_NUMBER
+#   ENV_BUILD_STATUS
+#   ENV_TARGET_JSON_FILE_PATH
+
+set -euo pipefail # Exit on error, treat unset variables as an error, and fail on pipe errors.
+                  # 'set -u' will cause an error if any ENV_ var below is not set.
+
+# Extract the directory part from the target file path.
+# Example: if ENV_TARGET_JSON_FILE_PATH is "foo/bar/status.json", TARGET_DIR will be "foo/bar"
+TARGET_DIR=$(dirname "$ENV_TARGET_JSON_FILE_PATH")
+
+# Create the target directory and any parent directories if they don't exist.
+mkdir -p "$TARGET_DIR"
+
+# Generate timestamp.
+REPORT_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Construct JSON using cat and heredoc, redirecting output directly to the target file.
+# The DELIMITER (EOF) is unquoted, so shell variables ($VAR) inside will be expanded.
+# This version assumes input ENV_... variables are "clean" for JSON string values.
+cat > "$ENV_TARGET_JSON_FILE_PATH" << EOF
+{
+  "controller_hostname": "$ENV_CONTROLLER_HOSTNAME",
+  "job_name": "$ENV_JOB_NAME",
+  "build_number": "$ENV_BUILD_NUMBER",
+  "build_status": "$ENV_BUILD_STATUS",
+  "report_timestamp": "$REPORT_TIMESTAMP"
+}
+EOF
+
+# Optional: echo to stderr for debugging when running manually
+# echo "Debug: Report written to $ENV_TARGET_JSON_FILE_PATH" >&2

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -33,4 +33,4 @@ cd "$REPORT_DIR"
 azcopy logout >/dev/null 2>&1 || true
 test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
 azcopy login --identity
-azcopy sync "status.json" "$DESTINATION_URL"
+azcopy sync "$REPORT_DIR/" "$DESTINATION_URL"

--- a/test/groovy/PublishBuildStatusReportStepTests.groovy
+++ b/test/groovy/PublishBuildStatusReportStepTests.groovy
@@ -33,7 +33,6 @@ class PublishBuildStatusReportStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('libraryResource', 'io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh'))
     assertTrue(assertMethodCallContainsPattern('writeFile', 'generateAndWriteBuildStatusReport.sh'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'BUILD_STATUS=SUCCESS'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'chmod +x'))
     assertTrue(assertMethodCallContainsPattern('sh', 'bash'))
   }
 

--- a/test/groovy/PublishBuildStatusReportStepTests.groovy
+++ b/test/groovy/PublishBuildStatusReportStepTests.groovy
@@ -1,0 +1,79 @@
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+import java.util.TimeZone
+
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class PublishBuildStatusReportStepTests extends BaseTest {
+  static final String scriptName = 'vars/publishBuildStatusReport.groovy'
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    helper.registerAllowedMethod('publishReports', [List.class], { _ -> })
+    // Mock the .format() extension method on the Date class
+    Date.metaClass.format = { String format, TimeZone tz -> '2025-06-17T15:10:00Z' }
+  }
+
+  void mockPrincipalBranch() {
+    addEnvVar('BRANCH_IS_PRIMARY', 'true')
+  }
+
+  @Test
+  void it_succeeds_on_principal_branch() throws Exception {
+    def script = loadScript(scriptName)
+    mockPrincipalBranch()
+    addEnvVar('JENKINS_URL', 'https://ci.jenkins.io/')
+    addEnvVar('JOB_NAME', 'my-folder/my-job')
+    addEnvVar('BUILD_NUMBER', '123')
+    binding.getVariable('currentBuild').currentResult = 'SUCCESS'
+
+    script.call()
+    printCallStack()
+
+    assertJobStatusSuccess()
+    assertTrue(assertMethodCallContainsPattern('libraryResource', 'generateAndWriteBuildStatusReport.sh'))
+    assertTrue(assertMethodCallContainsPattern('writeFile', '.jenkins-scripts/exec_generate_report_'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'chmod +x '))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'ENV_CONTROLLER_HOSTNAME=ci.jenkins.io'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'ENV_JOB_NAME=my-folder/my-job'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'ENV_BUILD_NUMBER=123'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'ENV_BUILD_STATUS=SUCCESS'))
+    assertTrue(assertMethodCallContainsPattern('sh', '.jenkins-scripts/exec_generate_report_'))
+    assertTrue(assertMethodCallContainsPattern('publishReports', 'build_status_reports/ci.jenkins.io/my-folder/my-job/status.json'))
+  }
+
+  @Test
+  void it_uses_fallback_values_when_env_vars_missing() throws Exception {
+    def script = loadScript(scriptName)
+    mockPrincipalBranch()
+    // No env vars set
+
+    script.call()
+    printCallStack()
+
+    assertJobStatusSuccess()
+    assertMethodCallContainsPattern('withEnv', 'ENV_CONTROLLER_HOSTNAME=unknown_controller')
+    assertMethodCallContainsPattern('withEnv', 'ENV_JOB_NAME=unknown_job')
+    assertMethodCallContainsPattern('withEnv', 'ENV_BUILD_NUMBER=unknown_build')
+    assertMethodCallContainsPattern('withEnv', 'ENV_BUILD_STATUS=UNKNOWN')
+  }
+
+  @Test
+  void it_does_nothing_on_non_principal_branch() throws Exception {
+    def script = loadScript(scriptName)
+    // No mockPrincipalBranch() call
+
+    script.call()
+    printCallStack()
+
+    assertJobStatusSuccess()
+    assertMethodCallContainsPattern('echo', 'Not on a principal branch')
+    assertFalse(assertMethodCall('libraryResource'))
+    assertFalse(assertMethodCall('writeFile'))
+    assertFalse(assertMethodCall('publishReports'))
+  }
+}

--- a/test/groovy/PublishBuildStatusReportStepTests.groovy
+++ b/test/groovy/PublishBuildStatusReportStepTests.groovy
@@ -1,5 +1,3 @@
-// test/groovy/PublishBuildStatusReportStepTests.groovy
-
 import org.junit.Before
 import org.junit.Test
 import static org.junit.Assert.assertFalse
@@ -32,8 +30,11 @@ class PublishBuildStatusReportStepTests extends BaseTest {
 
     assertJobStatusSuccess()
     assertTrue(assertMethodCallContainsPattern('pwd', 'tmp=true'))
+    assertTrue(assertMethodCallContainsPattern('libraryResource', 'io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh'))
+    assertTrue(assertMethodCallContainsPattern('writeFile', 'generateAndWriteBuildStatusReport.sh'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'BUILD_STATUS=SUCCESS'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'bash ${tempDir}/generateAndWriteBuildStatusReport.sh'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'chmod +x'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'bash'))
   }
 
   @Test
@@ -51,6 +52,7 @@ class PublishBuildStatusReportStepTests extends BaseTest {
 
     printCallStack()
     assertFalse(assertMethodCall('pwd'))
+    assertFalse(assertMethodCall('writeFile'))
     assertFalse(assertMethodCall('sh'))
   }
 
@@ -64,6 +66,7 @@ class PublishBuildStatusReportStepTests extends BaseTest {
 
     assertJobStatusSuccess()
     assertFalse(assertMethodCall('pwd'))
+    assertFalse(assertMethodCall('writeFile'))
     assertFalse(assertMethodCall('withEnv'))
     assertFalse(assertMethodCall('sh'))
   }

--- a/test/groovy/PublishBuildStatusReportStepTests.groovy
+++ b/test/groovy/PublishBuildStatusReportStepTests.groovy
@@ -2,11 +2,8 @@
 
 import org.junit.Before
 import org.junit.Test
-import java.util.Date
-import java.util.TimeZone
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
-import static org.junit.Assert.assertEquals // Adding for precise path check
 
 class PublishBuildStatusReportStepTests extends BaseTest {
   static final String scriptName = 'vars/publishBuildStatusReport.groovy'
@@ -15,14 +12,6 @@ class PublishBuildStatusReportStepTests extends BaseTest {
   @Before
   void setUp() throws Exception {
     super.setUp()
-    // Mock the .format() extension method on the Date class for predictable timestamps in logs
-    Date.metaClass.format = { String format, TimeZone tz -> '2025-06-17T15:10:00Z' }
-
-    // Mock the dir() step
-    helper.registerAllowedMethod('dir', [String.class, Closure.class], { String path, Closure body ->
-      binding.setVariable("dirCalledWithPath", path) // Capture path for verification
-      body.call() // Execute the closure passed to dir()
-    })
   }
 
   void mockPrincipalBranch() {
@@ -33,7 +22,6 @@ class PublishBuildStatusReportStepTests extends BaseTest {
   void it_succeeds_on_principal_branch() throws Exception {
     def script = loadScript(scriptName)
     mockPrincipalBranch()
-    addEnvVar('WORKSPACE', '/home/jenkins/workspace/test-job')
     addEnvVar('JENKINS_URL', 'https://ci.jenkins.io/')
     addEnvVar('JOB_NAME', 'my-folder/my-job')
     addEnvVar('BUILD_NUMBER', '123')
@@ -43,66 +31,40 @@ class PublishBuildStatusReportStepTests extends BaseTest {
     printCallStack()
 
     assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('libraryResource', 'generateAndWriteBuildStatusReport.sh'))
-    assertTrue(assertMethodCallContainsPattern('writeFile', '.jenkins-scripts/exec_generate_report_'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'chmod +x '))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'ENV_CONTROLLER_HOSTNAME=ci.jenkins.io'))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'ENV_JOB_NAME=my-folder/my-job'))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'ENV_BUILD_NUMBER=123'))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'ENV_BUILD_STATUS=SUCCESS'))
-    assertTrue(assertMethodCallContainsPattern('sh', '.jenkins-scripts/exec_generate_report_'))
-
-
-    // 1. Verify that the dir() step was called with the correct directory path
-    String expectedUploadDirectory = '/home/jenkins/workspace/test-job/build_status_reports/ci.jenkins.io/my-folder/my-job'
-    assertEquals("The dir() step was not called with the correct directory path", expectedUploadDirectory, binding.getVariable("dirCalledWithPath"))
-
-    // 2. Verify the withEnv block inside the dir() step and the azcopy commands
-    String expectedRemoteDir = 'build_status_reports/ci.jenkins.io/my-folder/my-job'
-    String expectedRemoteUrl = "https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/${expectedRemoteDir}"
-
-    assertTrue("AZCOPY_FILENAME was not set correctly in withEnv", assertMethodCallContainsPattern('withEnv', "AZCOPY_FILENAME=status.json"))
-    assertTrue("AZCOPY_DESTINATION_URL was not set correctly in withEnv", assertMethodCallContainsPattern('withEnv', "AZCOPY_DESTINATION_URL=${expectedRemoteUrl}"))
-    assertTrue(assertMethodCallContainsPattern('sh', 'azcopy logout'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'azcopy login --identity'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'azcopy copy'))
+    assertTrue(assertMethodCallContainsPattern('pwd', 'tmp=true'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'BUILD_STATUS=SUCCESS'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'bash ${tempDir}/generateAndWriteBuildStatusReport.sh'))
   }
 
   @Test
-  void it_uses_fallback_values_when_env_vars_missing() throws Exception {
+  void it_errors_on_missing_jenkins_url() throws Exception {
     def script = loadScript(scriptName)
     mockPrincipalBranch()
-    addEnvVar('WORKSPACE', '/home/jenkins/workspace/fallback-job')
+    // No JENKINS_URL set
 
-    script.call()
+    try {
+      script.call()
+      assertFalse("Expected error() to be called", true)
+    } catch (Exception e) {
+      assertTrue("Expected error about JENKINS_URL", e.getMessage().contains("JENKINS_URL is not set or empty"))
+    }
+
     printCallStack()
-
-    assertJobStatusSuccess()
-    assertMethodCallContainsPattern('withEnv', 'ENV_CONTROLLER_HOSTNAME=unknown_controller')
-    assertMethodCallContainsPattern('withEnv', 'ENV_JOB_NAME=unknown_job')
-    assertMethodCallContainsPattern('withEnv', 'ENV_BUILD_NUMBER=unknown_build')
-    assertMethodCallContainsPattern('withEnv', 'ENV_BUILD_STATUS=UNKNOWN')
-
-    // Verify the dir() step was called with the correct fallback directory path
-    String expectedUploadDirectory = '/home/jenkins/workspace/fallback-job/build_status_reports/unknown_controller/unknown_job'
-    assertEquals("The dir() step was not called with the correct fallback directory path", expectedUploadDirectory, binding.getVariable("dirCalledWithPath"))
-
-    // Verify that azcopy was still called
-    assertTrue(assertMethodCallContainsPattern('sh', 'azcopy copy'))
+    assertFalse(assertMethodCall('pwd'))
+    assertFalse(assertMethodCall('sh'))
   }
 
   @Test
   void it_does_nothing_on_non_principal_branch() throws Exception {
     def script = loadScript(scriptName)
-    // No env vars set, so env.BRANCH_IS_PRIMARY will be null
+    // No BRANCH_IS_PRIMARY set, so it should return early
 
     script.call()
     printCallStack()
 
     assertJobStatusSuccess()
-    assertMethodCallContainsPattern('echo', 'Not on a principal branch')
-    assertFalse(assertMethodCall('libraryResource'))
-    assertFalse(assertMethodCall('writeFile'))
-    assertFalse(assertMethodCallContainsPattern('sh', 'azcopy'))
+    assertFalse(assertMethodCall('pwd'))
+    assertFalse(assertMethodCall('withEnv'))
+    assertFalse(assertMethodCall('sh'))
   }
 }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -133,6 +133,10 @@ def call(Map config = [:]) {
   }
   echo "publishBuildStatusReport - Utility shell script execution completed."
 
+   // --- Step 5: Display generated status.json from workspace (FOR DEBUGGING/VERIFICATION) ---
+  echo "publishBuildStatusReport - Displaying content of generated report file: ${finalReportPathOnAgent}" {
+    sh "cat '${finalReportPathOnAgent}'"
+  }
   // --- Step 5: Publish the report (which was created by the shell script) ---
   // No Groovy-side validation of file content here, as per "no unnecessary validations".
   // We trust the shell script did its job if the 'sh' call above didn't fail (due to set -e in shell script).

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -59,10 +59,10 @@ def call(Map config = [:]) {
 
   // --- Step 0: Principal Branch Check ---
   // Only proceed if running on a principal branch.
-  // if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
-  //   echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
-  //   return
-  // }
+  if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
+    echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
+    return
+  }
 
   echo "publishBuildStatusReport - Principal branch execution. Proceeding..."
 

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -1,7 +1,7 @@
 // vars/publishBuildStatusReport.groovy
 
 import java.text.SimpleDateFormat
-import java.util.Date        
+import java.util.Date
 import java.util.TimeZone
 import java.net.URL
 
@@ -57,91 +57,91 @@ import java.net.URL
  */
 def call(Map config = [:]) {
 
-    // --- Step 0: Principal Branch Check ---
-    // Only proceed if running on a principal branch.
-    if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
-        echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
-        return
-    }
+  // --- Step 0: Principal Branch Check ---
+  // Only proceed if running on a principal branch.
+  if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
+    echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
+    return
+  }
 
-    echo "publishBuildStatusReport - Principal branch execution. Proceeding..."
+  echo "publishBuildStatusReport - Principal branch execution. Proceeding..."
 
-    // --- Step 1: Collect Jenkins-specific information ---
-    String jenkinsUrl = env.JENKINS_URL
-    String controllerHostname = "unknown_controller"
+  // --- Step 1: Collect Jenkins-specific information ---
+  String jenkinsUrl = env.JENKINS_URL
+  String controllerHostname = "unknown_controller"
 
-    if (jenkinsUrl != null && !jenkinsUrl.trim().isEmpty()) {
-        controllerHostname = new URL(jenkinsUrl).getHost()
-        // Sanitize for use in file paths: remove port and replace non-alphanumeric (except . -) with _
-        controllerHostname = controllerHostname.tokenize(':')[0].replaceAll("[^a-zA-Z0-9.-]", "_")
-    } else {
-        echo "WARN: publishBuildStatusReport - JENKINS_URL environment variable is not set or is empty. Using default hostname '${controllerHostname}'."
-    }
+  if (jenkinsUrl != null && !jenkinsUrl.trim().isEmpty()) {
+    controllerHostname = new URL(jenkinsUrl).getHost()
+    // Sanitize for use in file paths: remove port and replace non-alphanumeric (except . -) with _
+    controllerHostname = controllerHostname.tokenize(':')[0].replaceAll("[^a-zA-Z0-9.-]", "_")
+  } else {
+    echo "WARN: publishBuildStatusReport - JENKINS_URL environment variable is not set or is empty. Using default hostname '${controllerHostname}'."
+  }
 
-    String jobName = env.JOB_NAME ?: "unknown_job" // e.g., "MyFolder/MyJob"
-    String buildNumber = env.BUILD_NUMBER ?: "unknown_build"
-    String buildStatus = currentBuild.currentResult ?: "UNKNOWN"
+  String jobName = env.JOB_NAME ?: "unknown_job" // e.g., "MyFolder/MyJob"
+  String buildNumber = env.BUILD_NUMBER ?: "unknown_build"
+  String buildStatus = currentBuild.currentResult ?: "UNKNOWN"
 
-    // Log data being prepared by Groovy
-    def groovyTimeForLog = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone('UTC'))
-    echo "publishBuildStatusReport - Groovy-side time: ${groovyTimeForLog}"
-    echo "publishBuildStatusReport - Data for shell script: Controller='${controllerHostname}', Job='${jobName}', Build='${buildNumber}', Status='${buildStatus}'"
+  // Log data being prepared by Groovy
+  def groovyTimeForLog = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone('UTC'))
+  echo "publishBuildStatusReport - Groovy-side time: ${groovyTimeForLog}"
+  echo "publishBuildStatusReport - Data for shell script: Controller='${controllerHostname}', Job='${jobName}', Build='${buildNumber}', Status='${buildStatus}'"
 
-    // --- Step 2: Define the final path for the JSON report on the agent ---
-    // This path is constructed in Groovy as it uses Jenkins context (WORKSPACE, controllerHostname, jobName).
-    // The shell script will be responsible for creating this path and writing the file.
-    String finalReportDirOnAgent = "${env.WORKSPACE}/build_status_reports/${controllerHostname}/${jobName}"
-    String finalReportFileName = "status.json"
-    String finalReportPathOnAgent = "${finalReportDirOnAgent}/${finalReportFileName}"
-    echo "publishBuildStatusReport - Shell script will be instructed to write final report to: ${finalReportPathOnAgent}"
+  // --- Step 2: Define the final path for the JSON report on the agent ---
+  // This path is constructed in Groovy as it uses Jenkins context (WORKSPACE, controllerHostname, jobName).
+  // The shell script will be responsible for creating this path and writing the file.
+  String finalReportDirOnAgent = "${env.WORKSPACE}/build_status_reports/${controllerHostname}/${jobName}"
+  String finalReportFileName = "status.json"
+  String finalReportPathOnAgent = "${finalReportDirOnAgent}/${finalReportFileName}"
+  echo "publishBuildStatusReport - Shell script will be instructed to write final report to: ${finalReportPathOnAgent}"
 
-    // --- Step 3: Prepare and deploy the utility shell script to the agent ---
-    final String shellScriptResourcePath = 'io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh' // Assuming this is the agreed name and path
-    String shellScriptContent = libraryResource shellScriptResourcePath
-    
-    String tempScriptDir = "${env.WORKSPACE}/.jenkins-scripts"
-    String tempScriptName = "exec_generate_report_${env.BUILD_ID ?: System.currentTimeMillis()}.sh"
-    String tempScriptPathOnAgent = "${tempScriptDir}/${tempScriptName}"
+  // --- Step 3: Prepare and deploy the utility shell script to the agent ---
+  final String shellScriptResourcePath = 'io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh' // Assuming this is the agreed name and path
+  String shellScriptContent = libraryResource shellScriptResourcePath
 
-    // Ensure the temporary script directory exists
-    sh "mkdir -p '${tempScriptDir}'" // Single quotes for safety if tempScriptDir could have spaces (unlikely for .jenkins-scripts)
+  String tempScriptDir = "${env.WORKSPACE}/.jenkins-scripts"
+  String tempScriptName = "exec_generate_report_${env.BUILD_ID ?: System.currentTimeMillis()}.sh"
+  String tempScriptPathOnAgent = "${tempScriptDir}/${tempScriptName}"
 
-    writeFile file: tempScriptPathOnAgent, text: shellScriptContent
-    sh "chmod +x '${tempScriptPathOnAgent}'"
-    echo "publishBuildStatusReport - Utility shell script deployed to agent at: ${tempScriptPathOnAgent}"
+  // Ensure the temporary script directory exists
+  sh "mkdir -p '${tempScriptDir}'" // Single quotes for safety if tempScriptDir could have spaces (unlikely for .jenkins-scripts)
 
-    // --- Step 4: Execute the utility shell script ---
-    // Escape Groovy variables for safe inclusion as environment variable *values*.
-    String escController = controllerHostname.replaceAll("'", "'\\\\''")
-    String escJobName = jobName.replaceAll("'", "'\\\\''") // jobName can have '/' - this escaping handles single quotes within.
-    String escBuildNumber = buildNumber.replaceAll("'", "'\\\\''")
-    String escBuildStatus = buildStatus.replaceAll("'", "'\\\\''")
-    // finalReportPathOnAgent is constructed from WORKSPACE and sanitized names, less likely to need escaping for this purpose,
-    // but for consistency, we can escape it too.
-    String escFinalReportPathOnAgent = finalReportPathOnAgent.replaceAll("'", "'\\\\''")
+  writeFile file: tempScriptPathOnAgent, text: shellScriptContent
+  sh "chmod +x '${tempScriptPathOnAgent}'"
+  echo "publishBuildStatusReport - Utility shell script deployed to agent at: ${tempScriptPathOnAgent}"
 
-    withEnv([
-        "ENV_CONTROLLER_HOSTNAME=${escController}",
-        "ENV_JOB_NAME=${escJobName}",
-        "ENV_BUILD_NUMBER=${escBuildNumber}",
-        "ENV_BUILD_STATUS=${escBuildStatus}",
-        "ENV_TARGET_JSON_FILE_PATH=${escFinalReportPathOnAgent}" // Pass the target path
-    ]) {
-        echo "publishBuildStatusReport - Executing utility shell script: '${tempScriptPathOnAgent}'"
-        // Execute the script. It will handle its own file I/O. No stdout capture.
-        sh "'${tempScriptPathOnAgent}'" 
-    }
-    echo "publishBuildStatusReport - Utility shell script execution completed."
+  // --- Step 4: Execute the utility shell script ---
+  // Escape Groovy variables for safe inclusion as environment variable *values*.
+  String escController = controllerHostname.replaceAll("'", "'\\\\''")
+  String escJobName = jobName.replaceAll("'", "'\\\\''") // jobName can have '/' - this escaping handles single quotes within.
+  String escBuildNumber = buildNumber.replaceAll("'", "'\\\\''")
+  String escBuildStatus = buildStatus.replaceAll("'", "'\\\\''")
+  // finalReportPathOnAgent is constructed from WORKSPACE and sanitized names, less likely to need escaping for this purpose,
+  // but for consistency, we can escape it too.
+  String escFinalReportPathOnAgent = finalReportPathOnAgent.replaceAll("'", "'\\\\''")
 
-    // --- Step 5: Publish the report (which was created by the shell script) ---
-    // No Groovy-side validation of file content here, as per "no unnecessary validations".
-    // We trust the shell script did its job if the 'sh' call above didn't fail (due to set -e in shell script).
-    // A fileExists check could be added here if deemed essential minimal validation.
-    echo "publishBuildStatusReport - Publishing report from: ${finalReportPathOnAgent}"
-    publishReports([finalReportPathOnAgent]) 
+  withEnv([
+    "ENV_CONTROLLER_HOSTNAME=${escController}",
+    "ENV_JOB_NAME=${escJobName}",
+    "ENV_BUILD_NUMBER=${escBuildNumber}",
+    "ENV_BUILD_STATUS=${escBuildStatus}",
+    "ENV_TARGET_JSON_FILE_PATH=${escFinalReportPathOnAgent}" // Pass the target path
+  ]) {
+    echo "publishBuildStatusReport - Executing utility shell script: '${tempScriptPathOnAgent}'"
+    // Execute the script. It will handle its own file I/O. No stdout capture.
+    sh "'${tempScriptPathOnAgent}'"
+  }
+  echo "publishBuildStatusReport - Utility shell script execution completed."
 
-    // Cleanup of the temporary utility shell script is omitted as per last discussion.
-    // Jenkins workspace cleanup will eventually remove it.
+  // --- Step 5: Publish the report (which was created by the shell script) ---
+  // No Groovy-side validation of file content here, as per "no unnecessary validations".
+  // We trust the shell script did its job if the 'sh' call above didn't fail (due to set -e in shell script).
+  // A fileExists check could be added here if deemed essential minimal validation.
+  echo "publishBuildStatusReport - Publishing report from: ${finalReportPathOnAgent}"
+  publishReports([finalReportPathOnAgent])
 
-    echo "publishBuildStatusReport - Process completed for ${jobName}#${buildNumber}."
+  // Cleanup of the temporary utility shell script is omitted as per last discussion.
+  // Jenkins workspace cleanup will eventually remove it.
+
+  echo "publishBuildStatusReport - Process completed for ${jobName}#${buildNumber}."
 }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -133,7 +133,7 @@ def call(Map config = [:]) {
   }
   echo "publishBuildStatusReport - Utility shell script execution completed."
 
-   // --- Step 5: Display generated status.json from workspace (FOR DEBUGGING/VERIFICATION) ---
+  // --- Step 5: Display generated status.json from workspace (FOR DEBUGGING/VERIFICATION) ---
   echo "publishBuildStatusReport - Displaying content of generated report file: ${finalReportPathOnAgent}"
   sh "cat '${finalReportPathOnAgent}'"
 

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -1,148 +1,40 @@
-// vars/publishBuildStatusReport.groovy
-
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
-import java.net.URL
-
 /**
- * Orchestrates the generation and publication of a JSON build status report
- * by an external shell script.
+ * Generates and publishes a JSON build status report for monitoring Jenkins builds.
  *
- * This function will:
- * 1. Collect necessary Jenkins environment data.
- * 2. Prepare and deploy a utility shell script (from library resources) to the agent.
- * 3. Define the final path where the shell script should write its JSON report.
- * 4. Execute the utility shell script, passing all collected data and the target path
- *    as environment variables. The shell script handles JSON creation, directory creation,
- *    and writing the JSON to the target path.
- * 5. Call the 'publishReports' shared library function to upload the generated report.
+ * This function deploys and executes a shell script that handles all processing:
+ * hostname extraction, path construction, JSON generation, and upload to Azure storage.
  *
- * IMPORTANT: This function is intended for use on PRINCIPAL (e.g., main/master)
- * BRANCH BUILDS ONLY. It will return early and do nothing if called on a non-principal branch.
+ * IMPORTANT: Only runs on principal branches (BRANCH_IS_PRIMARY=true).
  *
- * Example usage in a Jenkinsfile (typically for a principal branch build):
+ * Example usage:
  *
- * --------------------------------------------------------------------------
- * // Jenkinsfile
- * @Library('your-pipeline-library-name@main') _
- *
- * properties([
- *     buildDiscarder(logRotator(numToKeepStr: '20')),
- *     disableConcurrentBuilds()
+ * @Library('pipeline-library@main') _
+ * buildDockerAndPublishImage('404', [
+ *     targetplatforms: 'linux/amd64,linux/arm64',
  * ])
- *
- * pipeline {
- *     agent { label 'your-agent-label' } // Agent must have 'jq' (or be shell-script compatible) & 'az' CLI
- *     stages {
- *         stage('Main Work') {
- *             steps {
- *                 script {
- *                     sh './build-and-deploy.sh' // Example main work
- *                     echo "Main work completed."
- *                 }
- *             }
- *         }
- *     }
- *     post {
- *         always {
- *             script {
- *                 echo "Post-build: Attempting to publish build status. Current result: ${currentBuild.currentResult}"
- *                 publishBuildStatusReport()
- *             }
- *         }
+ * node('linux-arm64') {
+ *     stage('[Post-Build] Status Report') {
+ *         publishBuildStatusReport()
  *     }
  * }
- * --------------------------------------------------------------------------
  */
 def call(Map config = [:]) {
-
-  // --- Step 0: Principal Branch Check ---
-  // Only proceed if running on a principal branch.
   if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
-    echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
     return
   }
 
-  echo "publishBuildStatusReport - Principal branch execution. Proceeding..."
-
-  // --- Step 1: Collect Jenkins-specific information ---
-  String jenkinsUrl = env.JENKINS_URL
-  String controllerHostname = "unknown_controller"
-
-  if (jenkinsUrl != null && !jenkinsUrl.trim().isEmpty()) {
-    controllerHostname = new URL(jenkinsUrl).getHost()
-    // Sanitize for use in file paths: remove port and replace non-alphanumeric (except . -) with _
-    controllerHostname = controllerHostname.tokenize(':')[0].replaceAll("[^a-zA-Z0-9.-]", "_")
-  } else {
-    echo "WARN: publishBuildStatusReport - JENKINS_URL environment variable is not set or is empty. Using default hostname '${controllerHostname}'."
+  if (!env.JENKINS_URL?.trim()) {
+    error("JENKINS_URL is not set or empty")
   }
 
-  String jobName = env.JOB_NAME ?: "unknown_job"
-  String buildNumber = env.BUILD_NUMBER ?: "unknown_build"
-  String buildStatus = currentBuild.currentResult ?: "UNKNOWN"
+  def tempDir = pwd(tmp: true)
 
-  // Log data being prepared by Groovy
-  def groovyTimeForLog = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone('UTC'))
-  echo "publishBuildStatusReport - Groovy-side time: ${groovyTimeForLog}"
-  echo "publishBuildStatusReport - Data for shell script: Controller='${controllerHostname}', Job='${jobName}', Build='${buildNumber}', Status='${buildStatus}'"
-
-  // --- Step 2: Define the final path for the JSON report on the agent ---
-  String finalReportPathAbsolute = "${env.WORKSPACE}/build_status_reports/${controllerHostname}/${jobName}/status.json"
-  echo "publishBuildStatusReport - Shell script will be instructed to write final report to: ${finalReportPathAbsolute}"
-
-  // --- Step 3: Prepare and deploy the utility shell script to the agent ---
-  final String shellScriptResourcePath = 'io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh'
-  String shellScriptContent = libraryResource shellScriptResourcePath
-
-  String tempScriptPathOnAgent = ".jenkins-scripts/exec_generate_report_${env.BUILD_ID ?: System.currentTimeMillis()}.sh"
-
-  sh "mkdir -p '.jenkins-scripts'"
-
-  writeFile file: tempScriptPathOnAgent, text: shellScriptContent
-  sh "chmod +x '${tempScriptPathOnAgent}'"
-  echo "publishBuildStatusReport - Utility shell script deployed to agent at: ${tempScriptPathOnAgent}"
-
-  // --- Step 4: Execute the utility shell script ---
-  withEnv([
-    "ENV_CONTROLLER_HOSTNAME=${controllerHostname.replaceAll("'", "'\\\\''")}",
-    "ENV_JOB_NAME=${jobName.replaceAll("'", "'\\\\''")}",
-    "ENV_BUILD_NUMBER=${buildNumber.replaceAll("'", "'\\\\''")}",
-    "ENV_BUILD_STATUS=${buildStatus.replaceAll("'", "'\\\\''")}",
-    "ENV_TARGET_JSON_FILE_PATH=${finalReportPathAbsolute.replaceAll("'", "'\\\\''")}"
-  ]) {
-    echo "publishBuildStatusReport - Executing utility shell script: '${tempScriptPathOnAgent}'"
-    sh "'${tempScriptPathOnAgent}'"
+  withEnv(["BUILD_STATUS=${currentBuild.currentResult ?: 'UNKNOWN'}"]) {
+    sh '''
+            cat > ${tempDir}/generateAndWriteBuildStatusReport.sh << 'SCRIPT_EOF'
+            ${libraryResource('io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh')}
+            SCRIPT_EOF
+            bash ${tempDir}/generateAndWriteBuildStatusReport.sh
+        '''
   }
-  echo "publishBuildStatusReport - Utility shell script execution completed."
-
-  // --- Step 5: Publish the generated report using azcopy ---
-  final String fullDestinationUrl = "https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/${controllerHostname}/${jobName}"
-
-  echo "publishBuildStatusReport - Publishing local file 'status.json' from directory '${new File(finalReportPathAbsolute).parent}' to remote destination '${fullDestinationUrl}'"
-
-  // Use the dir step to change into the correct directory on the agent
-  dir(new File(finalReportPathAbsolute).parent) {
-    // Escape variables for safe use inside the sh command string.
-    withEnv([
-      "AZCOPY_FILENAME=status.json",
-      "AZCOPY_DESTINATION_URL=${fullDestinationUrl.replaceAll("'", "'\\\\''")}"
-    ]) {
-      sh '''
-          set -ex
-
-          azcopy logout 2>/dev/null || true
-
-          # If the federated token file variable exists and is not empty, set the login type to WORKLOAD.
-          test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
-
-          # Login using the agent's Managed Identity (credential-less).
-          azcopy login --identity
-
-          azcopy copy "$AZCOPY_FILENAME" "$AZCOPY_DESTINATION_URL"
-      '''
-    }
-  }
-
-  echo "publishBuildStatusReport - Process completed for ${jobName}#${buildNumber}."
 }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -19,9 +19,9 @@
  * }
  */
 def call(Map config = [:]) {
-  // if (!env.BRANCH_IS_PRIMARY) {
-  //   return
-  // }
+  if (!env.BRANCH_IS_PRIMARY) {
+    return
+  }
 
   if (!env.JENKINS_URL?.trim()) {
     error("JENKINS_URL is not set or empty")

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -35,9 +35,6 @@ def call(Map config = [:]) {
 
   // Make script executable and run it
   withEnv(["BUILD_STATUS=${currentBuild.currentResult ?: 'UNKNOWN'}"]) {
-    sh '''
-        chmod +x ${scriptPath}
-        bash ${scriptPath}
-    '''
+    sh "chmod +x ${scriptPath} && bash ${scriptPath}"
   }
 }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -34,7 +34,9 @@ def call(Map config = [:]) {
   writeFile file: scriptPath, text: libraryResource('io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh')
 
   // Make script executable and run it
-  withEnv(["BUILD_STATUS=${currentBuild.currentResult ?: 'UNKNOWN'}"]) {
-    sh "chmod +x ${scriptPath} && bash ${scriptPath}"
+  withEnv(["BUILD_STATUS=${currentBuild.currentResult ?: 'UNKNOWN'}", "SCRIPT_PATH=${scriptPath}"]) {
+    sh '''
+          bash ${SCRIPT_PATH}
+      '''
   }
 }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -19,7 +19,7 @@
  * }
  */
 def call(Map config = [:]) {
-  // if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
+  // if (!env.BRANCH_IS_PRIMARY) {
   //   return
   // }
 

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -59,10 +59,10 @@ def call(Map config = [:]) {
 
   // --- Step 0: Principal Branch Check ---
   // Only proceed if running on a principal branch.
-  if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
-    echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
-    return
-  }
+  // if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
+  //   echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
+  //   return
+  // }
 
   echo "publishBuildStatusReport - Principal branch execution. Proceeding..."
 

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -59,10 +59,10 @@ def call(Map config = [:]) {
 
   // --- Step 0: Principal Branch Check ---
   // Only proceed if running on a principal branch.
-  if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
-    echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
-    return
-  }
+//   if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
+//     echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
+//     return
+//   }
 
   echo "publishBuildStatusReport - Principal branch execution. Proceeding..."
 

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -1,0 +1,147 @@
+// vars/publishBuildStatusReport.groovy
+
+import java.text.SimpleDateFormat
+import java.util.Date        
+import java.util.TimeZone
+import java.net.URL
+
+/**
+ * Orchestrates the generation and publication of a JSON build status report
+ * by an external shell script.
+ *
+ * This function will:
+ * 1. Collect necessary Jenkins environment data.
+ * 2. Prepare and deploy a utility shell script (from library resources) to the agent.
+ * 3. Define the final path where the shell script should write its JSON report.
+ * 4. Execute the utility shell script, passing all collected data and the target path
+ *    as environment variables. The shell script handles JSON creation, directory creation,
+ *    and writing the JSON to the target path.
+ * 5. Call the 'publishReports' shared library function to upload the generated report.
+ *
+ * IMPORTANT: This function is intended for use on PRINCIPAL (e.g., main/master)
+ * BRANCH BUILDS ONLY. It will return early and do nothing if called on a non-principal branch.
+ *
+ * Example usage in a Jenkinsfile (typically for a principal branch build):
+ *
+ * --------------------------------------------------------------------------
+ * // Jenkinsfile
+ * @Library('your-pipeline-library-name@main') _
+ *
+ * properties([
+ *     buildDiscarder(logRotator(numToKeepStr: '20')),
+ *     disableConcurrentBuilds()
+ * ])
+ *
+ * pipeline {
+ *     agent { label 'your-agent-label' } // Agent must have 'jq' (or be shell-script compatible) & 'az' CLI
+ *     stages {
+ *         stage('Main Work') {
+ *             steps {
+ *                 script {
+ *                     sh './build-and-deploy.sh' // Example main work
+ *                     echo "Main work completed."
+ *                 }
+ *             }
+ *         }
+ *     }
+ *     post {
+ *         always {
+ *             script {
+ *                 echo "Post-build: Attempting to publish build status. Current result: ${currentBuild.currentResult}"
+ *                 publishBuildStatusReport()
+ *             }
+ *         }
+ *     }
+ * }
+ * --------------------------------------------------------------------------
+ */
+def call(Map config = [:]) {
+
+    // --- Step 0: Principal Branch Check ---
+    // Only proceed if running on a principal branch.
+    if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
+        echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
+        return
+    }
+
+    echo "publishBuildStatusReport - Principal branch execution. Proceeding..."
+
+    // --- Step 1: Collect Jenkins-specific information ---
+    String jenkinsUrl = env.JENKINS_URL
+    String controllerHostname = "unknown_controller"
+
+    if (jenkinsUrl != null && !jenkinsUrl.trim().isEmpty()) {
+        controllerHostname = new URL(jenkinsUrl).getHost()
+        // Sanitize for use in file paths: remove port and replace non-alphanumeric (except . -) with _
+        controllerHostname = controllerHostname.tokenize(':')[0].replaceAll("[^a-zA-Z0-9.-]", "_")
+    } else {
+        echo "WARN: publishBuildStatusReport - JENKINS_URL environment variable is not set or is empty. Using default hostname '${controllerHostname}'."
+    }
+
+    String jobName = env.JOB_NAME ?: "unknown_job" // e.g., "MyFolder/MyJob"
+    String buildNumber = env.BUILD_NUMBER ?: "unknown_build"
+    String buildStatus = currentBuild.currentResult ?: "UNKNOWN"
+
+    // Log data being prepared by Groovy
+    def groovyTimeForLog = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone('UTC'))
+    echo "publishBuildStatusReport - Groovy-side time: ${groovyTimeForLog}"
+    echo "publishBuildStatusReport - Data for shell script: Controller='${controllerHostname}', Job='${jobName}', Build='${buildNumber}', Status='${buildStatus}'"
+
+    // --- Step 2: Define the final path for the JSON report on the agent ---
+    // This path is constructed in Groovy as it uses Jenkins context (WORKSPACE, controllerHostname, jobName).
+    // The shell script will be responsible for creating this path and writing the file.
+    String finalReportDirOnAgent = "${env.WORKSPACE}/build_status_reports/${controllerHostname}/${jobName}"
+    String finalReportFileName = "status.json"
+    String finalReportPathOnAgent = "${finalReportDirOnAgent}/${finalReportFileName}"
+    echo "publishBuildStatusReport - Shell script will be instructed to write final report to: ${finalReportPathOnAgent}"
+
+    // --- Step 3: Prepare and deploy the utility shell script to the agent ---
+    final String shellScriptResourcePath = 'io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh' // Assuming this is the agreed name and path
+    String shellScriptContent = libraryResource shellScriptResourcePath
+    
+    String tempScriptDir = "${env.WORKSPACE}/.jenkins-scripts"
+    String tempScriptName = "exec_generate_report_${env.BUILD_ID ?: System.currentTimeMillis()}.sh"
+    String tempScriptPathOnAgent = "${tempScriptDir}/${tempScriptName}"
+
+    // Ensure the temporary script directory exists
+    sh "mkdir -p '${tempScriptDir}'" // Single quotes for safety if tempScriptDir could have spaces (unlikely for .jenkins-scripts)
+
+    writeFile file: tempScriptPathOnAgent, text: shellScriptContent
+    sh "chmod +x '${tempScriptPathOnAgent}'"
+    echo "publishBuildStatusReport - Utility shell script deployed to agent at: ${tempScriptPathOnAgent}"
+
+    // --- Step 4: Execute the utility shell script ---
+    // Escape Groovy variables for safe inclusion as environment variable *values*.
+    String escController = controllerHostname.replaceAll("'", "'\\\\''")
+    String escJobName = jobName.replaceAll("'", "'\\\\''") // jobName can have '/' - this escaping handles single quotes within.
+    String escBuildNumber = buildNumber.replaceAll("'", "'\\\\''")
+    String escBuildStatus = buildStatus.replaceAll("'", "'\\\\''")
+    // finalReportPathOnAgent is constructed from WORKSPACE and sanitized names, less likely to need escaping for this purpose,
+    // but for consistency, we can escape it too.
+    String escFinalReportPathOnAgent = finalReportPathOnAgent.replaceAll("'", "'\\\\''")
+
+    withEnv([
+        "ENV_CONTROLLER_HOSTNAME=${escController}",
+        "ENV_JOB_NAME=${escJobName}",
+        "ENV_BUILD_NUMBER=${escBuildNumber}",
+        "ENV_BUILD_STATUS=${escBuildStatus}",
+        "ENV_TARGET_JSON_FILE_PATH=${escFinalReportPathOnAgent}" // Pass the target path
+    ]) {
+        echo "publishBuildStatusReport - Executing utility shell script: '${tempScriptPathOnAgent}'"
+        // Execute the script. It will handle its own file I/O. No stdout capture.
+        sh "'${tempScriptPathOnAgent}'" 
+    }
+    echo "publishBuildStatusReport - Utility shell script execution completed."
+
+    // --- Step 5: Publish the report (which was created by the shell script) ---
+    // No Groovy-side validation of file content here, as per "no unnecessary validations".
+    // We trust the shell script did its job if the 'sh' call above didn't fail (due to set -e in shell script).
+    // A fileExists check could be added here if deemed essential minimal validation.
+    echo "publishBuildStatusReport - Publishing report from: ${finalReportPathOnAgent}"
+    publishReports([finalReportPathOnAgent]) 
+
+    // Cleanup of the temporary utility shell script is omitted as per last discussion.
+    // Jenkins workspace cleanup will eventually remove it.
+
+    echo "publishBuildStatusReport - Process completed for ${jobName}#${buildNumber}."
+}

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -19,9 +19,9 @@
  * }
  */
 def call(Map config = [:]) {
-  if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
-    return
-  }
+  // if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
+  //   return
+  // }
 
   if (!env.JENKINS_URL?.trim()) {
     error("JENKINS_URL is not set or empty")

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -43,7 +43,7 @@ def call(Map config = [:]) {
       currentBuild.result = 'FAILURE'
       sh '''
             # Retrieve azcopy logs to archive them
-            cat /home/jenkins/.azcopy/*.log > azcopy.log 2>/dev/null || echo "No azcopy logs found"
+            cat $HOME/.azcopy/*.log > azcopy.log 2>/dev/null || echo "No azcopy logs found"
         '''
       archiveArtifacts 'azcopy.log'
       throw err

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -59,10 +59,10 @@ def call(Map config = [:]) {
 
   // --- Step 0: Principal Branch Check ---
   // Only proceed if running on a principal branch.
-//   if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
-//     echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
-//     return
-//   }
+  if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
+    echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
+    return
+  }
 
   echo "publishBuildStatusReport - Principal branch execution. Proceeding..."
 

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -134,9 +134,9 @@ def call(Map config = [:]) {
   echo "publishBuildStatusReport - Utility shell script execution completed."
 
    // --- Step 5: Display generated status.json from workspace (FOR DEBUGGING/VERIFICATION) ---
-  echo "publishBuildStatusReport - Displaying content of generated report file: ${finalReportPathOnAgent}" {
-    sh "cat '${finalReportPathOnAgent}'"
-  }
+  echo "publishBuildStatusReport - Displaying content of generated report file: ${finalReportPathOnAgent}"
+  sh "cat '${finalReportPathOnAgent}'"
+
   // --- Step 5: Publish the report (which was created by the shell script) ---
   // No Groovy-side validation of file content here, as per "no unnecessary validations".
   // We trust the shell script did its job if the 'sh' call above didn't fail (due to set -e in shell script).

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -35,7 +35,9 @@ def call(Map config = [:]) {
 
   // Make script executable and run it
   withEnv(["BUILD_STATUS=${currentBuild.currentResult ?: 'UNKNOWN'}"]) {
-    sh "chmod +x ${scriptPath}"
-    sh "bash ${scriptPath}"
+    sh '''
+        chmod +x ${scriptPath}
+        bash ${scriptPath}
+    '''
   }
 }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -28,13 +28,14 @@ def call(Map config = [:]) {
   }
 
   def tempDir = pwd(tmp: true)
+  def scriptPath = "${tempDir}/generateAndWriteBuildStatusReport.sh"
 
+  // Write the script to temp directory
+  writeFile file: scriptPath, text: libraryResource('io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh')
+
+  // Make script executable and run it
   withEnv(["BUILD_STATUS=${currentBuild.currentResult ?: 'UNKNOWN'}"]) {
-    sh '''
-            cat > ${tempDir}/generateAndWriteBuildStatusReport.sh << 'SCRIPT_EOF'
-            ${libraryResource('io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh')}
-            SCRIPT_EOF
-            bash ${tempDir}/generateAndWriteBuildStatusReport.sh
-        '''
+    sh "chmod +x ${scriptPath}"
+    sh "bash ${scriptPath}"
   }
 }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -59,10 +59,10 @@ def call(Map config = [:]) {
 
   // --- Step 0: Principal Branch Check ---
   // Only proceed if running on a principal branch.
-  if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
-    echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
-    return
-  }
+  // if (env.BRANCH_IS_PRIMARY == null || !env.BRANCH_IS_PRIMARY.toBoolean()) {
+  //   echo "WARN: publishBuildStatusReport - Not on a principal branch (BRANCH_IS_PRIMARY: '${env.BRANCH_IS_PRIMARY}', BRANCH_NAME: '${env.BRANCH_NAME}'). Skipping report generation."
+  //   return
+  // }
 
   echo "publishBuildStatusReport - Principal branch execution. Proceeding..."
 
@@ -145,7 +145,11 @@ def call(Map config = [:]) {
         
         # Ensure any previous azcopy login is cleared to avoid conflicts.
         azcopy logout 2>/dev/null || true
-        
+
+        # Support for container agents using Workload Identity Federation.
+        # If the federated token file variable exists and is not empty, set the login type to WORKLOAD.
+        test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
+
         # Login using the agent's Managed Identity (credential-less).
         azcopy login --identity
         

--- a/vars/publishReports.groovy
+++ b/vars/publishReports.groovy
@@ -31,7 +31,7 @@ def call(List<String> files, Map params = [:]) {
             uploadFlags = '--content-type="application/json"'
             break
           case ~/(?i).*\.js/:
-            uploadFlags = '--content-type="application/javascript"'
+            uploadFlags = '--content-type="application/javascript"'3
             break
           case ~/(?i).*\.gif/:
             uploadFlags = '--content-type="image/gif"'

--- a/vars/publishReports.groovy
+++ b/vars/publishReports.groovy
@@ -31,7 +31,7 @@ def call(List<String> files, Map params = [:]) {
             uploadFlags = '--content-type="application/json"'
             break
           case ~/(?i).*\.js/:
-            uploadFlags = '--content-type="application/javascript"'3
+            uploadFlags = '--content-type="application/javascript"'
             break
           case ~/(?i).*\.gif/:
             uploadFlags = '--content-type="image/gif"'


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/2843#issuecomment-2883040380

`publishBuildStatusReport` will publish the build status report on reports.jenkins.io using pre-existing `publishReports` shared library script.

Once completed we can move on to the next phase of monitoring the reports. 


Testing with https://github.com/jenkins-infra/docker-404/pull/46