### PR TITLE
fix(`buildDockerAndPublishImage`) enable `cacheTo` only on principal branch builds

### DIFF
--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -786,6 +786,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   @Test
   void itBuildsWithCacheToParameterProvided() throws Exception {
     def script = loadScript(scriptName)
+    mockPrincipalBranch()
     final String cacheValue = "type=inline"
     withMocks {
       script.call(testImageName, [cacheTo: cacheValue])

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -17,7 +17,7 @@ def makecall(String action, String imageDeployName, String targetOperationSystem
           "DOCKER_BAKE_FILE=${specificDockerBakeFile}",
           "DOCKER_BAKE_TARGET=${dockerBakeTarget}",
           "IMAGE_DEPLOY_NAME=${imageDeployName}"
-        ] + ((cacheTo && !cacheTo.isEmpty()) ? ["DOCKER_CACHE_TO=${cacheTo}"] : []) // Conditionally add cacheTo
+        ] + ((cacheTo && !cacheTo.isEmpty() && env.BRANCH_IS_PRIMARY) ? ["DOCKER_CACHE_TO=${cacheTo}"] : []) // Conditionally add cacheTo
         ) {
           sh 'export BUILDX_BUILDER_NAME=buildx-builder; docker buildx use "${BUILDX_BUILDER_NAME}" 2>/dev/null || docker buildx create --use --name="${BUILDX_BUILDER_NAME}"'
           sh "make bake-$action"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4683

This PR makes sure `cacheTo` creates cache export only on principal branch builds.