### PR TITLE
fix(buildPluginWithGradle) use valid signature when calling `infra.getBuildAgentLabel()` method (`jdk` should be a String)

### DIFF
--- a/vars/buildPluginWithGradle.groovy
+++ b/vars/buildPluginWithGradle.groovy
@@ -20,10 +20,10 @@ def call(Map params = [:]) {
   boolean archivedArtifacts = false
   Map tasks = [failFast: failFast]
   buildPlugin.getConfigurations(params).each { config ->
-    String label = infra.getBuildAgentLabel(config.platform, config.jdk, useContainerAgent)
     String jdk = config.jdk
+    String platform = config.platform
     String jenkinsVersion = config.jenkins
-
+    String label = infra.getBuildAgentLabel(platform, jdk, useContainerAgent)
     String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
     boolean first = tasks.size() == 1
     boolean skipTests = params?.tests?.skip


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/pipeline-library/issues/945

Fixup of #926 

This PR is a bugfix (started as debug) which corrects the call to the `infra.getBuildAgentLabel()` method.

The second argument is expected to be the JDK major version but as a **String** (yes poor design I made in #926), while the `config.jdk` seems to be casted implicitly to something else.

The bugfix defines local variables inside the loop which are explicitly typed as `String` which fix the error message `No such DSL method 'getBuildAgentLabel' found among steps [...] or globals [...]` by using the proper method signature call.


Tested with https://ci.jenkins.io/job/Plugins/job/ecu-test-execution-plugin/job/PR-237/8/console (replay with the line `@Library('pipeline-library@pull/946/head') _` added in top of the `Jenkinsfile`)