### PR TITLE
Use workspace tmp as Java temp dir for performance

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -224,7 +224,7 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
  * @see withArtifactCachingProxy
  */
 Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true) {
-  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors', '--no-transfer-progress']
+  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors', '--no-transfer-progress', '-Djava.io.tmpdir=' + env.WORKSPACE_TMP]
   withArtifactCachingProxy(useArtifactCachingProxy) {
     mvnOptions.addAll(options)
     mvnOptions.unique()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -224,7 +224,13 @@ Object withArtifactCachingProxy(boolean useArtifactCachingProxy = true, Closure 
  * @see withArtifactCachingProxy
  */
 Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = null, Boolean addToolEnv = true, Boolean useArtifactCachingProxy = true) {
-  List<String> mvnOptions = ['--batch-mode', '--show-version', '--errors', '--no-transfer-progress', '-Djava.io.tmpdir=' + env.WORKSPACE_TMP]
+  List<String> mvnOptions = [
+    '--batch-mode',
+    '--show-version',
+    '--errors',
+    '--no-transfer-progress',
+    '-Djava.io.tmpdir=' + env.WORKSPACE_TMP
+  ]
   withArtifactCachingProxy(useArtifactCachingProxy) {
     mvnOptions.addAll(options)
     mvnOptions.unique()

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -336,6 +336,10 @@ Object runWithJava(String command, String jdk = '8', List<String> extraEnv = nul
     javaEnv.addAll(extraEnv)
   }
 
+  // Use workspace TMP instead of system temporary directory
+  javaEnv += "TMP=" + env.WORKSPACE_TMP
+  javaEnv += "TEMP=" + env.WORKSPACE_TMP
+
   withEnv(javaEnv) {
     if (isUnix()) {
       // TODO JENKINS-44231 candidate for simplification


### PR DESCRIPTION
## Use workspace tmp as Java temp dir for performance

Windows agents on ci.jenkins.io use a local NVMe drive for the workspace and they use an EBS volume for the Windows system disk.  Use the NVMe drive for Java temporary files.

## Testing done

* Confirmed that the markdown formatter plugin use of `buildPlugin` honors the setting in [this build](https://ci.jenkins.io/job/Plugins/job/markdown-formatter-plugin/job/master/253/) by adding the line
  `@Library(value='pipeline-library@be3f75289c81e3aec8e0222002e25982ac9bc007', changelog=false) _`.  
  Confirmed that the setting of java.io.tmpdir was passed to Maven as expected.
* Confirmed that Jenkins core honors the setting in [this build](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10752/7/) by adding the line 
  `@Library(value='pipeline-library@be3f75289c81e3aec8e0222002e25982ac9bc007', changelog=false) _`.  
  Confirmed that the setting of java.io.tmpdir was passed to Maven as expected.

Unfortunately, the performance difference in the tests that I compared were not enough to show a clearly measurable improvement from the change.  Some tests seemed to show a slight improvement (hudson.bugs.LoginRedirectTest went from 50 seconds to 48.4 seconds), but not enough to claim any detectable difference in overall job time.

I am curious if the change reduced the demand on the EBS storage for the Windows machine.  We could also adjust the Windows environment variables `TMP` and `TEMP` in hopes of improvement.