### PR TITLE
feat(publishBuildStatusReport): change report timestamp from ISO 8601 to Unix epoch format

### DIFF
--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -13,7 +13,7 @@ REPORT_FILE="$REPORT_DIR/status.json"
 mkdir -p "$REPORT_DIR"
 
 # Generate timestamp
-REPORT_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+REPORT_TIMESTAMP=$(date -u +%s)
 
 # Generate JSON report
 cat > "$REPORT_FILE" << EOF


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/2843#issuecomment-3187753080

This PR

- Update generateAndWriteBuildStatusReport.sh to use Unix timestamp
- Change from ISO format to epoch seconds for better monitoring compatibility
- Prepare for timestamp age validation in Datadog synthetics