### PR TITLE
fix(terraform): remove the github-app for shared-tools checkout as for now

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -187,7 +187,7 @@ def getInfraSharedTools(String sharedToolsSubDir) {
       [$class: 'CleanBeforeCheckout', deleteUntrackedNestedRepositories: true],
       [$class: 'RelativeTargetDirectory', relativeTargetDir: sharedToolsSubDir],
       [$class: 'GitSCMStatusChecksExtension', skip: true],
-    ], userRemoteConfigs: [[credentialsId: 'github-app-infra', url: 'https://github.com/jenkins-infra/shared-tools.git']]]
+    ], userRemoteConfigs: [[url: 'https://github.com/jenkins-infra/shared-tools.git']]]
 
   return outputs
 }


### PR DESCRIPTION
following https://plugins.jenkins.io/github-branch-source/releases/#version_1844.v4a_9883d49126

the checkout of the shared-tools is failing with:

```
2025-09-04T12:58:21.002Z] [Pipeline] sh
[2025-09-04T12:58:21.236Z] + rm -rf .shared-tools
[2025-09-04T12:58:21.274Z] [Pipeline] checkout
[2025-09-04T12:58:21.289Z] The recommended git tool is: NONE
[2025-09-04T12:58:21.364Z] + rm -rf .shared-tools
[2025-09-04T12:58:21.403Z] [Pipeline] checkout
[2025-09-04T12:58:21.418Z] The recommended git tool is: NONE
[2025-09-04T12:58:21.742Z] using credential github-app-infra
[2025-09-04T12:58:21.742Z] using credential github-app-infra
[2025-09-04T12:58:21.755Z] Cloning the remote Git repository
[2025-09-04T12:58:21.765Z] Cloning the remote Git repository
[2025-09-04T12:58:22.046Z] ERROR: Error cloning remote repo 'origin'
[2025-09-04T12:58:22.046Z] hudson.plugins.git.GitException: hudson.remoting.ProxyException: java.lang.IllegalArgumentException: Failed to generate GitHub App installation token for app ID 96324
[2025-09-04T12:58:22.046Z] 	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler.execute(RemoteGitImpl.java:157)
[2025-09-04T12:58:22.046Z] 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
[2025-09-04T12:58:22.046Z] 	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
```

as a temporary measure, lets remove the githubapp usage and take advantage of the public repository.
