### PR TITLE
Pass `-P-consume-incrementals` unless a PR specifically includes marker file `consume-incrementals`

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -316,7 +316,7 @@ def call(Map params = [:]) {
     infra.maybePublishIncrementals()
   }
   if (consumingIncrementals) {
-    unstable 'This build consumed Incremental dependencies. Remove the `consume-incrementals` file before reading for review.'
+    unstable "This build consumed Incremental dependencies. Remove the 'consume-incrementals' file before reading for review."
   }
 }
 

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -316,7 +316,7 @@ def call(Map params = [:]) {
     infra.maybePublishIncrementals()
   }
   if (consumingIncrementals) {
-    unstable "This build consumed Incremental dependencies. Remove the 'consume-incrementals' file before reading for review."
+    unstable "This build consumed Incremental dependencies. Remove the 'consume-incrementals' file before readying for review."
   }
 }
 

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -123,6 +123,9 @@ def call(Map params = [:]) {
                     mavenOptions += "help:evaluate -Dexpression=changelist -Doutput=$changelistF"
                   }
                 }
+                if (env.CHANGE_FORK == null) {
+                  mavenOptions += '-P-consume-incrementals'
+                }
                 if (jenkinsVersion) {
                   mavenOptions += "-Djenkins.version=${jenkinsVersion} -Daccess-modifier-checker.failOnError=false"
                 }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -126,7 +126,7 @@ def call(Map params = [:]) {
                     mavenOptions += "help:evaluate -Dexpression=changelist -Doutput=$changelistF"
                   }
                 }
-                if (fileExists 'consume-incrementals') {
+                if (fileExists('consume-incrementals')) {
                   consumingIncrementals = true
                 } else {
                   echo 'Forbidding use of Incremental dependencies. If you need to consume Incrementals, add a file named `consume-incrementals` to the repository root. (Contents arbitrary but conventionally a list of upstream PRs.) Then keep this PR in draft until the dependency has been switched to a release version and the marker file can be removed.'

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -316,7 +316,7 @@ def call(Map params = [:]) {
     infra.maybePublishIncrementals()
   }
   if (consumingIncrementals) {
-    warning 'This build consumed Incremental dependencies. Remove the `consume-incrementals` file before reading for review.'
+    unstable 'This build consumed Incremental dependencies. Remove the `consume-incrementals` file before reading for review.'
   }
 }
 


### PR DESCRIPTION
Block usage of Incrementals dependencies not just during releases as https://github.com/jenkins-infra/jenkins-maven-cd-action/issues/3 does, but “shifting left” into branch builds (`master`) as well as all PR builds by default including those used by both Dependabot and Renovate, so that the `consume-incrementals` profile would be active only locally (due to `.mvn/maven.config`) and in PR builds that specifically request it. Should offer a first line of defense against problems like https://github.com/jenkins-infra/helpdesk/issues/4990#issuecomment-3872131821.

Required by https://github.com/jenkins-infra/helpdesk/issues/4998. Probably harmless to merge first, but useless because as seen in https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/212 the Incrementals deps are loaded anyway, pending https://github.com/jenkins-infra/helpdesk/issues/4998.