### PR TITLE
Fix terraform production credentials using wrong config map

### DIFF
--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -71,7 +71,7 @@ def call(userConfig = [:]) {
     parallelStages['production'] = {
       stage('Production') {
         agentTemplate(finalConfig.agentLabel, {
-          withCredentials(defaultConfig.productionCredentials) {
+          withCredentials(finalConfig.productionCredentials) {
             final String planFileName = 'terraform-plan-for-humans.txt'
             def scmOutput
             stage('🦅 Generate Terraform Plan') {


### PR DESCRIPTION
Fixes #1000

## Changes

Replaces `defaultConfig.productionCredentials` with `finalConfig.productionCredentials` on [line 74](https://github.com/jenkins-infra/pipeline-library/blob/master/vars/terraform.groovy#L74) of [`vars/terraform.groovy`](https://github.com/jenkins-infra/pipeline-library/blob/master/vars/terraform.groovy).

The `defaultConfig` map is initialized with empty arrays and never modified. User-supplied credentials are merged into `finalConfig` via the `<<` operator ([line 18](https://github.com/jenkins-infra/pipeline-library/blob/master/vars/terraform.groovy#L18)), but the production stage was reading from the wrong map, causing all custom production credentials to be silently ignored.

This matches the existing pattern used for staging credentials ([line 49](https://github.com/jenkins-infra/pipeline-library/blob/master/vars/terraform.groovy#L49)).

## Testing Done

- Verified the change doesn't introduce new test failures: `mvn test` shows the same 73 pre-existing failures as `master` (unrelated to this change)
- The fix is a single-variable rename with no logic changes
- Existing `TerraformStepTests` pass for staging credentials (which correctly use `finalConfig`); production credentials were untested because the bug prevented them from ever being used

## Submitter Checklist

- [x] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira