### PR TITLE
feat(BuildDockerAndPublishImage) publish build status report in BuildDockerAndPublishImage

### DIFF
--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -351,6 +351,8 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertFalse(assertMethodCallContainsPattern('sh','make bake-deploy'))
     // And no release (no tag)
     assertFalse(assertTagPushed(defaultGitTag))
+    // Does not publish build status report
+    assertFalse(assertMethodCall('publishBuildStatusReport'))
     // And all mocked/stubbed methods have to be called
     verifyMocks()
   }

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -70,6 +70,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     helper.registerAllowedMethod('powershell', [Map.class], { m ->
       return shellMock(m.script)
     })
+    helper.registerAllowedMethod('publishBuildStatusReport', [], {})
 
     addEnvVar('WORKSPACE', '/tmp')
 

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -185,6 +185,9 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // And release created automatically
     assertTrue(assertTagPushed(defaultGitTag))
 
+    // Publish build status report on main branch
+    assertTrue(assertMethodCall('publishBuildStatusReport'))
+
     // And all mocked/stubbed methods have to be called
     verifyMocks()
   }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -326,6 +326,7 @@ def call(String imageShortName, Map userConfig=[:]) {
           } // withEnv NEXT_VERSION
         } // if
       } // infra.withDockerPullCredentials
+      publishBuildStatusReport()
     } // withEnv (outer)
   } // node
 } // call

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -324,9 +324,9 @@ def call(String imageShortName, Map userConfig=[:]) {
               } // stage
             } // if
           } // withEnv NEXT_VERSION
+          publishBuildStatusReport()
         } // if
       } // infra.withDockerPullCredentials
-      publishBuildStatusReport()
     } // withEnv (outer)
   } // node
 } // call


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/2843

Adds publishBuildStatusReport() as the final step in buildDockerAndPublishImage, so build status reports are automatically published for all Docker image pipelines without requiring changes to individual Jenkinsfiles.

Tested locally with success

```
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.38 s -- in BuildDockerAndPublishImageStepTests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```