### PR TITLE
feat(Terraform) publish build status report in Terraform pipeline library

### DIFF
--- a/test/groovy/TerraformStepTests.groovy
+++ b/test/groovy/TerraformStepTests.groovy
@@ -31,6 +31,7 @@ class TerraformStepTests extends BaseTest {
     binding.setProperty('scm', ['GIT_URL': 'https://github.com/lesfurets/jenkins-unit-test.git'])
     helper.registerAllowedMethod('ansiColor', [String.class, Closure.class], { s, body ->body() })
     helper.registerAllowedMethod('checkout', [Map.class], { m -> m })
+    helper.registerAllowedMethod('publishBuildStatusReport', [], {})
 
     // Used by the publish checks
     addEnvVar('BUILD_URL', dummyBuildUrl)
@@ -98,6 +99,9 @@ class TerraformStepTests extends BaseTest {
     // Default pipeline properties
     assertTrue(assertMethodCallContainsPattern('disableConcurrentBuilds', ''))
     assertTrue(assertMethodCallContainsPattern('logRotator', 'numToKeepStr=50'))
+
+    // Publish Build Report Status
+    assertTrue(assertMethodCall('publishBuildStatusReport'))
   }
 
   @Test
@@ -137,6 +141,9 @@ class TerraformStepTests extends BaseTest {
 
     // Only 5 builds per PR to keep
     assertTrue(assertMethodCallContainsPattern('logRotator', 'numToKeepStr=5'))
+
+    // Does not publish Build Report Status
+    assertFalse(assertMethodCall('publishBuildStatusReport'))
   }
 
   @Test
@@ -176,6 +183,9 @@ class TerraformStepTests extends BaseTest {
 
     // Ensure that drift-detection is disabled
     assertFalse(assertMethodCallContainsPattern('withEnv','TF_CLI_ARGS_plan=-detailed-exitcode'))
+
+    // Does not publish Build Report Status
+    assertFalse(assertMethodCall('publishBuildStatusReport'))
   }
 
   @Test
@@ -208,6 +218,9 @@ class TerraformStepTests extends BaseTest {
 
     // Terraform is set up through environment to NOT detect configuration drift
     assertFalse(assertMethodCallContainsPattern('withEnv','TF_CLI_ARGS_plan=-detailed-exitcode'))
+
+    // Publish Build Report Status
+    assertTrue(assertMethodCall('publishBuildStatusReport'))
   }
 
   @Test
@@ -235,5 +248,7 @@ class TerraformStepTests extends BaseTest {
     // And 2 nodes with custom label are spawned
     assertTrue(assertMethodCallContainsPattern('node', customLabel))
     assertTrue(assertMethodCallOccurrences('node', 2))
+    // Publish Build Report Status
+    assertTrue(assertMethodCall('publishBuildStatusReport'))
   }
 }

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -159,6 +159,9 @@ def call(userConfig = [:]) {
 
     // Execute parallel stages from the map
     parallel parallelStages
+    if (isBuildOnProductionBranch) {
+      publishBuildStatusReport()
+    }
   }
 }
 


### PR DESCRIPTION
Ref: 
- https://github.com/jenkins-infra/helpdesk/issues/2843

Adds publishBuildStatusReport() to the terraform shared pipeline step, so build status reports are automatically published for all terraform pipelines on the production branch without requiring changes to individual Jenkinsfiles.

Only runs on the production branch (isBuildOnProductionBranch). If any stage fails before reaching it, the report is never uploaded and the existing stale build monitor handles the failure case.

Tested locally with success

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.451 s -- in TerraformStepTests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.948 s
[INFO] Finished at: 2026-04-13T17:05:54+05:30
[INFO] ------------------------------------------------------------------------
```