### PR TITLE
fix(PublishBuildStatusReport) Remove BRANCH_IS_PRIMARY check from PublishBuildStatusReport

### DIFF
--- a/test/groovy/PublishBuildStatusReportStepTests.groovy
+++ b/test/groovy/PublishBuildStatusReportStepTests.groovy
@@ -64,6 +64,7 @@ class PublishBuildStatusReportStepTests extends BaseTest {
 
     assertJobStatusSuccess()
     assertFalse(assertMethodCall('pwd'))
+    assertFalse(assertMethodCall('libraryResource'))
     assertFalse(assertMethodCall('writeFile'))
     assertFalse(assertMethodCall('withEnv'))
     assertFalse(assertMethodCall('sh'))

--- a/test/groovy/PublishBuildStatusReportStepTests.groovy
+++ b/test/groovy/PublishBuildStatusReportStepTests.groovy
@@ -63,6 +63,7 @@ class PublishBuildStatusReportStepTests extends BaseTest {
     printCallStack()
 
     assertJobStatusSuccess()
+    assertTrue(assertMethodCallContainsPattern('echo', 'Not publishing any build status report from a pull request'))
     assertFalse(assertMethodCall('pwd'))
     assertFalse(assertMethodCall('writeFile'))
     assertFalse(assertMethodCall('withEnv'))

--- a/test/groovy/PublishBuildStatusReportStepTests.groovy
+++ b/test/groovy/PublishBuildStatusReportStepTests.groovy
@@ -55,21 +55,17 @@ class PublishBuildStatusReportStepTests extends BaseTest {
   }
 
   @Test
-  void it_succeeds_on_non_principal_branch() throws Exception {
+  void it_does_nothing_on_pull_request_build() throws Exception {
     def script = loadScript(scriptName)
-    addEnvVar('JENKINS_URL', 'https://ci.jenkins.io/')
-    addEnvVar('JOB_NAME', 'my-folder/my-job')
-    addEnvVar('BUILD_NUMBER', '123')
-    binding.getVariable('currentBuild').currentResult = 'SUCCESS'
+    addEnvVar('CHANGE_ID', '42')
 
     script.call()
     printCallStack()
 
     assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('pwd', 'tmp=true'))
-    assertTrue(assertMethodCallContainsPattern('libraryResource', 'io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh'))
-    assertTrue(assertMethodCallContainsPattern('writeFile', 'generateAndWriteBuildStatusReport.sh'))
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'BUILD_STATUS=SUCCESS'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'bash'))
+    assertFalse(assertMethodCall('pwd'))
+    assertFalse(assertMethodCall('writeFile'))
+    assertFalse(assertMethodCall('withEnv'))
+    assertFalse(assertMethodCall('sh'))
   }
 }

--- a/test/groovy/PublishBuildStatusReportStepTests.groovy
+++ b/test/groovy/PublishBuildStatusReportStepTests.groovy
@@ -64,7 +64,6 @@ class PublishBuildStatusReportStepTests extends BaseTest {
 
     assertJobStatusSuccess()
     assertFalse(assertMethodCall('pwd'))
-    assertFalse(assertMethodCall('libraryResource'))
     assertFalse(assertMethodCall('writeFile'))
     assertFalse(assertMethodCall('withEnv'))
     assertFalse(assertMethodCall('sh'))

--- a/test/groovy/PublishBuildStatusReportStepTests.groovy
+++ b/test/groovy/PublishBuildStatusReportStepTests.groovy
@@ -39,7 +39,6 @@ class PublishBuildStatusReportStepTests extends BaseTest {
   @Test
   void it_errors_on_missing_jenkins_url() throws Exception {
     def script = loadScript(scriptName)
-    mockPrincipalBranch()
     // No JENKINS_URL set
 
     try {
@@ -56,17 +55,21 @@ class PublishBuildStatusReportStepTests extends BaseTest {
   }
 
   @Test
-  void it_does_nothing_on_non_principal_branch() throws Exception {
+  void it_succeeds_on_non_principal_branch() throws Exception {
     def script = loadScript(scriptName)
-    // No BRANCH_IS_PRIMARY set, so it should return early
+    addEnvVar('JENKINS_URL', 'https://ci.jenkins.io/')
+    addEnvVar('JOB_NAME', 'my-folder/my-job')
+    addEnvVar('BUILD_NUMBER', '123')
+    binding.getVariable('currentBuild').currentResult = 'SUCCESS'
 
     script.call()
     printCallStack()
 
     assertJobStatusSuccess()
-    assertFalse(assertMethodCall('pwd'))
-    assertFalse(assertMethodCall('writeFile'))
-    assertFalse(assertMethodCall('withEnv'))
-    assertFalse(assertMethodCall('sh'))
+    assertTrue(assertMethodCallContainsPattern('pwd', 'tmp=true'))
+    assertTrue(assertMethodCallContainsPattern('libraryResource', 'io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh'))
+    assertTrue(assertMethodCallContainsPattern('writeFile', 'generateAndWriteBuildStatusReport.sh'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'BUILD_STATUS=SUCCESS'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'bash'))
   }
 }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -19,10 +19,6 @@
  * }
  */
 def call(Map config = [:]) {
-  if (!env.BRANCH_IS_PRIMARY) {
-    return
-  }
-
   if (!env.JENKINS_URL?.trim()) {
     error("JENKINS_URL is not set or empty")
   }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -19,6 +19,11 @@
  * }
  */
 def call(Map config = [:]) {
+  // Fast-fail on pull request builds to prevent external PRs from writing status
+  if (env.CHANGE_ID) {
+    return
+  }
+
   if (!env.JENKINS_URL?.trim()) {
     error("JENKINS_URL is not set or empty")
   }

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -21,8 +21,8 @@
 def call(Map config = [:]) {
   // Fast-fail on pull request builds to prevent external PRs from writing status
   if (env.CHANGE_ID) {
-    echo 'Not publishing any build status report from a pull request, skipping
-    return'
+    echo 'Not publishing any build status report from a pull request, skipping'
+    return
   }
 
   if (!env.JENKINS_URL?.trim()) {

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -22,7 +22,7 @@ def call(Map config = [:]) {
   // Fast-fail on pull request builds to prevent external PRs from writing status
   if (env.CHANGE_ID) {
     echo 'Not publishing any build status report from a pull request, skipping
-    return
+    return'
   }
 
   if (!env.JENKINS_URL?.trim()) {

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -21,6 +21,7 @@
 def call(Map config = [:]) {
   // Fast-fail on pull request builds to prevent external PRs from writing status
   if (env.CHANGE_ID) {
+    echo 'Not publishing any build status report from a pull request, skipping
     return
   }
 


### PR DESCRIPTION
Ref: 

- https://github.com/jenkins-infra/helpdesk/issues/2843


Removes the BRANCH_IS_PRIMARY check from publishBuildStatusReport() so it can be called by any pipeline regardless of branch naming.

Branch gating is already handled by the callers (buildDockerAndPublishImage checks BRANCH_IS_PRIMARY || TAG_NAME, terraform checks isBuildOnProductionBranch). This allows standalone jobs like acceptance-tests (which run on non-standard branch names) to publish reports directly.

We are implementing fast-fail on pull request builds to prevent external PRs from writing status.

Asserting on libraryResource (the first action after the pr build check) confirms it exited before doing any work.

Tested locally with success:

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.367 s -- in PublishBuildStatusReportStepTests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.861 s
[INFO] Finished at: 2026-04-13T18:05:50+05:30
[INFO] ------------------------------------------------------------------------
```