### PR TITLE
fix(terraform): wrap publishBuildStatusReport in node block

### DIFF
--- a/test/groovy/TerraformStepTests.groovy
+++ b/test/groovy/TerraformStepTests.groovy
@@ -86,7 +86,7 @@ class TerraformStepTests extends BaseTest {
 
     // And 2 nodes with default label are spawned
     assertTrue(assertMethodCallContainsPattern('node', 'jnlp-linux-arm64'))
-    assertTrue(assertMethodCallOccurrences('node', 2))
+    assertTrue(assertMethodCallOccurrences('node', 3))
 
     // xterm color enabled (easier to read Terraform plans)
     assertTrue(assertMethodCallContainsPattern('ansiColor', 'xterm'))
@@ -247,7 +247,7 @@ class TerraformStepTests extends BaseTest {
 
     // And 2 nodes with custom label are spawned
     assertTrue(assertMethodCallContainsPattern('node', customLabel))
-    assertTrue(assertMethodCallOccurrences('node', 2))
+    assertTrue(assertMethodCallOccurrences('node', 3))
     // Publish Build Report Status
     assertTrue(assertMethodCall('publishBuildStatusReport'))
   }

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -160,7 +160,9 @@ def call(userConfig = [:]) {
     // Execute parallel stages from the map
     parallel parallelStages
     if (isBuildOnProductionBranch) {
-      publishBuildStatusReport()
+      node(finalConfig.agentLabel) {
+        publishBuildStatusReport()
+      }
     }
   }
 }


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/2843
- Reported in [pipeline-library#1004 (comment)](https://github.com/jenkins-infra/pipeline-library/pull/1004/changes#r3080434656)

Fixes `MissingContextVariableException` when `publishBuildStatusReport()` runs in the terraform pipeline. The call was placed outside any `node` block after `parallel parallelStages`.

Wraps the call in `node(finalConfig.agentLabel)`.

**Failing build:** https://infra.ci.jenkins.io/job/terraform-jobs/job/datadog/job/main/70
