### PR TITLE
feat(publishBuildStatusReport): allow to pass `AZCOPY_LOGIN_IDENTITY_RESOURCE_ID`

### DIFF
--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -8,7 +8,6 @@ set -euxo pipefail
 # Required parameters that must be set by the caller
 : "${JOB_NAME:?JOB_NAME is not set}"
 : "${BUILD_NUMBER:?BUILD_NUMBER is not set}"
-: "${BUILD_STATUS:?BUILD_STATUS is not set}"
 
 # Extract hostname from JENKINS_URL
 controller_hostname=$(echo "${JENKINS_URL}" | sed 's|https\?://||' | cut -d'/' -f1)
@@ -29,7 +28,6 @@ cat > "${report_file}" << EOF
   "controller_url": "${JENKINS_URL}",
   "job_name": "${JOB_NAME}",
   "build_number": "${BUILD_NUMBER}",
-  "build_status": "${BUILD_STATUS}",
   "report_timestamp": "${report_timestamp}"
 }
 EOF

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -43,4 +43,4 @@ if [[ -n "${AZCOPY_LOGIN_IDENTITY_RESOURCE_ID:-}" ]]; then
 else
   azcopy login --identity
 fi
-azcopy copy "status.json" "${destination_url}"
+azcopy copy "status.json" "${destination_url}" --recursive

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -1,36 +1,44 @@
 #!/bin/bash
-set -euo pipefail
-set -x
+set -euxo pipefail
+
+# Required parameters set by Jenkins controller
+: "${JENKINS_URL:?JENKINS_URL is not set}"
+: "${WORKSPACE:?WORKSPACE is not set}"
+
+# Required parameters that must be set by the caller
+: "${JOB_NAME:?JOB_NAME is not set}"
+: "${BUILD_NUMBER:?BUILD_NUMBER is not set}"
+: "${BUILD_STATUS:?BUILD_STATUS is not set}"
 
 # Extract hostname from JENKINS_URL
-CONTROLLER_HOSTNAME=$(echo "$JENKINS_URL" | sed 's|https\?://||' | cut -d'/' -f1)
+controller_hostname=$(echo "${JENKINS_URL}" | sed 's|https\?://||' | cut -d'/' -f1)
 
 # Build file path
-REPORT_DIR="$WORKSPACE/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME"
-REPORT_FILE="$REPORT_DIR/status.json"
+report_dir="${WORKSPACE}/build_status_reports/${controller_hostname}/${JOB_NAME}"
+report_file="${report_dir}/status.json"
 
 # Create directory
-mkdir -p "$REPORT_DIR"
+mkdir -p "${report_dir}"
 
 # Generate timestamp
-REPORT_TIMESTAMP=$(date -u +%s)
+report_timestamp=$(date -u +%s)
 
 # Generate JSON report
-cat > "$REPORT_FILE" << EOF
+cat > "${report_file}" << EOF
 {
-  "controller_url": "$JENKINS_URL",
-  "job_name": "$JOB_NAME",
-  "build_number": "$BUILD_NUMBER",
-  "build_status": "$BUILD_STATUS",
-  "report_timestamp": "$REPORT_TIMESTAMP"
+  "controller_url": "${JENKINS_URL}",
+  "job_name": "${JOB_NAME}",
+  "build_number": "${BUILD_NUMBER}",
+  "build_status": "${BUILD_STATUS}",
+  "report_timestamp": "${report_timestamp}"
 }
 EOF
 
 # Upload with azcopy
-DESTINATION_URL="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/$CONTROLLER_HOSTNAME/$JOB_NAME/"
+destination_url="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/${controller_hostname}/${JOB_NAME}/"
 
-cd "$REPORT_DIR"
+cd "${report_dir}"
 azcopy logout >/dev/null 2>&1 || true
 test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
 azcopy login --identity
-azcopy copy "status.json" "$DESTINATION_URL" --recursive
+azcopy copy "status.json" "${destination_url}"

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -38,5 +38,9 @@ destination_url="https://buildsreportsjenkinsio.file.core.windows.net/builds-rep
 cd "${report_dir}"
 azcopy logout >/dev/null 2>&1 || true
 test -z "${AZURE_FEDERATED_TOKEN_FILE:-}" || export AZCOPY_AUTO_LOGIN_TYPE=WORKLOAD
-azcopy login --identity
+if [[ -n "${AZCOPY_LOGIN_IDENTITY_RESOURCE_ID:-}" ]]; then
+  azcopy login --identity --identity-resource-id "${AZCOPY_LOGIN_IDENTITY_RESOURCE_ID}"
+else
+  azcopy login --identity
+fi
 azcopy copy "status.json" "${destination_url}"


### PR DESCRIPTION
This change allows with a92c1e9 to pass `AZCOPY_LOGIN_IDENTITY_RESOURCE_ID` to specify the UAID to use (ex from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json) when calling `generateAndWriteBuildStatusReport.sh` script directly. (In a freestyle job like update_center on trusted.ci.jenkins.io for example).

It also applies shellcheck, requires parameters and uses lowercase for internal variable in 8ff17cd, and removes the unused `BUILD_STATUS` variable in a316e50 so it doesn't have to be set when calling the script directly.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2843

#### Testing done
`mvn test -Dtest=PublishBuildStatusReportStepTests`