### PR TITLE
fix(generateAndWriteBuildStatusReport): quote `SCRIPT_PATH` to handle workspace paths with spaces

### DIFF
--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -12,8 +12,11 @@ set -euxo pipefail
 # Extract hostname from JENKINS_URL
 controller_hostname=$(echo "${JENKINS_URL}" | sed 's|https\?://||' | cut -d'/' -f1)
 
+# Sanitize JOB_NAME for filesystem and URL safety
+sanitized_job_name=$(echo "${JOB_NAME}" | tr ' ' '-')
+
 # Build file path
-report_dir="${WORKSPACE}/build_status_reports/${controller_hostname}/${JOB_NAME}"
+report_dir="${WORKSPACE}/build_status_reports/${controller_hostname}/${sanitized_job_name}"
 report_file="${report_dir}/status.json"
 
 # Create directory
@@ -33,7 +36,7 @@ cat > "${report_file}" << EOF
 EOF
 
 # Upload with azcopy
-destination_url="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/${controller_hostname}/${JOB_NAME}/"
+destination_url="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/${controller_hostname}/${sanitized_job_name}/"
 
 cd "${report_dir}"
 azcopy logout >/dev/null 2>&1 || true

--- a/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
+++ b/resources/io/jenkins/infra/pipeline/generateAndWriteBuildStatusReport.sh
@@ -12,11 +12,8 @@ set -euxo pipefail
 # Extract hostname from JENKINS_URL
 controller_hostname=$(echo "${JENKINS_URL}" | sed 's|https\?://||' | cut -d'/' -f1)
 
-# Sanitize JOB_NAME for filesystem and URL safety
-sanitized_job_name=$(echo "${JOB_NAME}" | tr ' ' '-')
-
 # Build file path
-report_dir="${WORKSPACE}/build_status_reports/${controller_hostname}/${sanitized_job_name}"
+report_dir="${WORKSPACE}/build_status_reports/${controller_hostname}/${JOB_NAME}"
 report_file="${report_dir}/status.json"
 
 # Create directory
@@ -36,7 +33,7 @@ cat > "${report_file}" << EOF
 EOF
 
 # Upload with azcopy
-destination_url="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/${controller_hostname}/${sanitized_job_name}/"
+destination_url="https://buildsreportsjenkinsio.file.core.windows.net/builds-reports-jenkins-io/build_status_reports/${controller_hostname}/${JOB_NAME}/"
 
 cd "${report_dir}"
 azcopy logout >/dev/null 2>&1 || true

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -44,7 +44,7 @@ def call(Map config = [:]) {
   withEnv(["BUILD_STATUS=${currentBuild.currentResult ?: 'UNKNOWN'}", "SCRIPT_PATH=${scriptPath}"]) {
     try {
       sh '''
-            bash ${SCRIPT_PATH}
+            bash "${SCRIPT_PATH}"
         '''
     } catch (err) {
       currentBuild.result = 'FAILURE'


### PR DESCRIPTION
### Ref: 

- https://github.com/jenkins-infra/helpdesk/issues/2843
- https://github.com/jenkins-infra/release/pull/891

Jobs with spaces in their name (e.g. "Infra Agents Health") cause the `publishBuildStatusReport` step to fail with exit code 127:

```
+ bash /home/jenkins/agent/workspace/Infra Agents Health@tmp/generateAndWriteBuildStatusReport.sh
bash: /home/jenkins/agent/workspace/Infra: No such file or directory
```

The unquoted `${SCRIPT_PATH}` in the `sh` block undergoes word splitting, bash receives `/home/jenkins/agent/workspace/Infra` as the script path instead of the full string.

