### PR TITLE
chore(infra.runWithMaven): don't use `tool 'mvn'`

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -275,7 +275,7 @@ Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = 
   withArtifactCachingProxy(useArtifactCachingProxy) {
     mvnOptions.addAll(options)
     mvnOptions.unique()
-    String command = "mvn ${mvnOptions.join(' ')}"
+    String command = "mvn -X ${mvnOptions.join(' ')}"
     runWithMaven(command, jdk, extraEnv, addToolEnv)
   }
 }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -275,7 +275,7 @@ Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = 
   withArtifactCachingProxy(useArtifactCachingProxy) {
     mvnOptions.addAll(options)
     mvnOptions.unique()
-    String command = "mvn -X ${mvnOptions.join(' ')}"
+    String command = "mvn ${mvnOptions.join(' ')}"
     runWithMaven(command, jdk, extraEnv, addToolEnv)
   }
 }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -303,10 +303,6 @@ Object runMaven(List<String> options, Integer jdk, List<String> extraEnv = null,
  */
 Object runWithMaven(String command, String jdk = '8', List<String> extraEnv = null, Boolean addToolEnv = true) {
   List<String> javaEnv = []
-  if (addToolEnv) {
-    javaEnv += "PATH+MAVEN=${tool 'mvn'}/bin"
-  }
-
   if (extraEnv) {
     javaEnv.addAll(extraEnv)
   }


### PR DESCRIPTION
Ref:
- jenkins-infra/helpdesk#5090

### Testing done

- `mvn test -Dtest=InfraStepTests`
- Test PR on Jenkins Core which calls `infra.runMaven` (itself calling `infra.runWithMaven`): https://github.com/jenkinsci/jenkins/pull/26758