### PR TITLE
fix(buildDockerAndPublishImage) perform `git gc` before calling `jx-release-version`

### DIFF
--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -21,7 +21,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
   static final String fullTestImageName = defaultDockerRegistryNamespace + '/' + testImageName
   static final String defaultGitTag = '1.0.0'
   static final String defaultGitTagIncludingImageName = '1.0.0-bitcoinminerimage'
-  static final String defaultNextVersionCommand = 'jx-release-version'
+  static final String defaultNextVersionCommand = 'git gc && jx-release-version'
   static final String defaultOrigin = 'https://github.com/org/repository.git'
   static final String defaultReleaseId = '12345'
   static final String defaultDockerBakeFile = 'jenkinsinfrabakefile.hcl'

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -45,7 +45,8 @@ def call(String imageShortName, Map userConfig=[:]) {
     automaticSemanticVersioning: true, // automagically increase semantic version by default
     dockerfile: 'Dockerfile', // Obvious default
     targetplatforms: '', // // Define the (comma separated) list of Docker supported platforms to build the image for. Defaults to `linux/amd64` when unspecified. Incompatible with the legacy `platform` attribute.
-    nextVersionCommand: 'jx-release-version', // Commmand line used to retrieve the next version
+    // git gc ensures we don't run into https://github.com/jenkins-infra/docker-jenkins-lts/issues/1084
+    nextVersionCommand: 'git gc && jx-release-version', // Commmand line used to retrieve the next version
     gitCredentials: 'github-app-infra.ci.jenkins.io-docker-deploy', // Credential ID for tagging and creating release
     imageDir: '.', // Relative path to the context directory for the Docker build
     registryNamespace: '', // Empty by default (means "autodiscover based on the current controller")


### PR DESCRIPTION
As it can fails like in https://github.com/jenkins-infra/docker-jenkins-lts/issues/1084 with trying to retrieve annotated tags