### PR TITLE
fix(updatecli) enforce build discarder, max. 50 builds per branch

### DIFF
--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -18,6 +18,15 @@ def call(userConfig = [:]) {
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html  final Map
   def finalConfig = defaultConfig << userConfig
 
+  def projectProperties = [
+    disableConcurrentBuilds(abortPrevious: true),
+    buildDiscarder(logRotator(numToKeepStr: '50')),
+  ]
+  if (finalConfig.cronTriggerExpression) {
+    projectProperties.add(pipelineTriggers([cron(finalConfig.cronTriggerExpression)]))
+  }
+  properties(projectProperties)
+
   // Set cron trigger if requested
   if (finalConfig.cronTriggerExpression) {
     properties([pipelineTriggers([cron(finalConfig.cronTriggerExpression)])])


### PR DESCRIPTION
This PR introduces the 2 following changes in the `updatecli()` pipeline library:

- Enforce build discarder with max. 50 build kept per branch - https://github.com/jenkins-infra/helpdesk/issues/5145#issuecomment-4575645259
- Disable concurrent build and cancel running builds, to avoid concurrent calls on repository PRs by updatecli 

Tested with https://github.com/jenkins-infra/helm-charts/pull/1958#issuecomment-4575967868