### PR TITLE
fix(updatecli) remove duplicated condition for `properties` step

### DIFF
--- a/vars/updatecli.groovy
+++ b/vars/updatecli.groovy
@@ -27,11 +27,6 @@ def call(userConfig = [:]) {
   }
   properties(projectProperties)
 
-  // Set cron trigger if requested
-  if (finalConfig.cronTriggerExpression) {
-    properties([pipelineTriggers([cron(finalConfig.cronTriggerExpression)])])
-  }
-
   // Define a closure that encapsulates all updatecli execution logic
   def executeUpdatecli = {
     final String customUpdatecliPath = "${pwd tmp: true}/custom_updatecli"


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/pipeline-library/pull/1018 where I forgot to remove this block.

It results on the "second" properties call which remove the others options (such as buildDiscarder) as absent in its list.