### PR TITLE
Format Asciidoc with Spotless

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -166,7 +166,6 @@ Supported parameters:
 `artifacts`::
 (Optional) If `artifacts` is not null, invokes `archiveArtifacts` with the given string value.
 
-
 ==== Example
 
 [source, groovy]
@@ -207,6 +206,7 @@ Name of the docker image to build
 * disablePublication: (Optional, default to false) Allow to disable tagging and publication of container image and GitHub release
 
 ==== Example
+
 [source, groovy]
 ----
 buildDockerAndPublishImage('plugins-site-api')

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <version>3.7.0</version>
         <configuration>
+          <asciidoc>
+            <includes>
+              <include>**/*.adoc</include>
+            </includes>
+            <adocfmt />
+          </asciidoc>
           <groovy>
             <includes>
               <include>Jenkinsfile</include>

--- a/resources/io/jenkins/infra/docker/README.adoc
+++ b/resources/io/jenkins/infra/docker/README.adoc
@@ -40,7 +40,6 @@ grep 'Makefile' .gitignore || echo 'Makefile' | tee -a .gitignore
 ** Or `CONTAINER_BIN=docker make all` if you have Docker
 ** And/or `make -C <Path to the directory containing your Makefile> all`
 
-
 == Requirements
 
 * Command prompt with bash (or zsh/ksh)
@@ -99,7 +98,6 @@ You can customize the different steps through the following environment variable
 ** `BUILD_DATE` (Default to "now" when called): UTC timestamp formatted in `%Y-%m-%dT%H:%M:%S` when the command occurs.
 
 You can check the file `Makefile` if you want to get a better deep-dive understanding.
-
 
 == Contributing
 


### PR DESCRIPTION
## Format Asciidoc with Spotless

Spotless 3.7.0 adds an Asciidoc formatter.  The formatting process and its defaults are described in the [documentation](https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md#asciidoc).
