### PR TITLE
feat(infra) implement Windows case for `loadMavenLocalCacheIfAny()` and refine existing shell code

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -299,16 +299,22 @@ Object loadMavenLocalCacheIfAny(String mvnLocalRepo, String cachePath = '/cache/
   if (isUnix()) {
     withEnv(["MVN_LOCAL_REPO=${mvnLocalRepo}", "MVN_CACHE_PATH=${cachePath}",]) {
       sh '''
-      test -n "${MVN_LOCAL_REPO}" || export MVN_LOCAL_REPO="$HOME/.m2/repository"
+      : "${MVN_CACHE_PATH:?MVN_CACHE_PATH must be set}"
+      export MVN_LOCAL_REPO="${MVN_LOCAL_REPO:-$HOME/.m2/repository}"
+
       mkdir -p "${MVN_LOCAL_REPO}"
-      if test -f "${MVN_CACHE_PATH}";
+
+      if test -f "${MVN_CACHE_PATH}"
       then
-        pushd "${MVN_LOCAL_REPO}"
-        cache_archive_name=../"$(basename "${MVN_CACHE_PATH}")"
+        # MVN_CACHE_PATH might served from a CSI S3 volume which does not support seeking.
+        # tar requires a seekable source, so we copy the archive locally first.
+        # The copy lands in the parent of MVN_LOCAL_REPO which has sufficient disk space.
+        cache_archive_name="$(dirname "${MVN_LOCAL_REPO}")/$(basename "${MVN_CACHE_PATH}")"
         time cp "${MVN_CACHE_PATH}" "${cache_archive_name}"
-        time tar xzf "${cache_archive_name}" ./
+        time tar xzf "${cache_archive_name}" -C "${MVN_LOCAL_REPO}"
         rm -f "${cache_archive_name}"
-        popd
+      else
+        echo "${MVN_CACHE_PATH} archive not found: skipping maven cache retrieval."
       fi
       '''
     }
@@ -332,6 +338,8 @@ Object loadMavenLocalCacheIfAny(String mvnLocalRepo, String cachePath = '/cache/
       Write-Host "tar: ${elapsed}s"
 
       Remove-Item -Force $cacheArchiveName
+    } else {
+      Write-Host "${env:MVN_CACHE_PATH} archive not found: skipping maven cache retrieval."
     }
     '''
   }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -306,7 +306,7 @@ Object loadMavenLocalCacheIfAny(String mvnLocalRepo, String cachePath = '/cache/
 
       if test -f "${MVN_CACHE_PATH}"
       then
-        # MVN_CACHE_PATH might served from a CSI S3 volume which does not support seeking.
+        # MVN_CACHE_PATH might be served from a CSI S3 volume which does not support seeking.
         # tar requires a seekable source, so we copy the archive locally first.
         # The copy lands in the parent of MVN_LOCAL_REPO which has sufficient disk space.
         cache_archive_name="$(dirname "${MVN_LOCAL_REPO}")/$(basename "${MVN_CACHE_PATH}")"

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -313,7 +313,27 @@ Object loadMavenLocalCacheIfAny(String mvnLocalRepo, String cachePath = '/cache/
       '''
     }
   } else {
-    echo "WARNING: Maven cache loading not implemented on Windows yet."
+    pwsh '''
+    if (-not $env:MVN_LOCAL_REPO) {
+      $env:MVN_LOCAL_REPO = Join-Path $HOME ".m2/repository"
+    }
+    New-Item -ItemType Directory -Force -Path $env:MVN_LOCAL_REPO | Out-Null
+
+    if ($env:MVN_CACHE_PATH -and (Test-Path -PathType Leaf $env:MVN_CACHE_PATH)) {
+      # MVN_CACHE_PATH might be served from a CSI S3 volume which does not support seeking.
+      # tar requires a seekable source, so we copy the archive locally first.
+      # The copy lands in the parent of MVN_LOCAL_REPO which has sufficient disk space.
+      $cacheArchiveName = Join-Path (Split-Path -Parent $env:MVN_LOCAL_REPO) (Split-Path -Leaf $env:MVN_CACHE_PATH)
+
+      $elapsed = (Measure-Command { Copy-Item $env:MVN_CACHE_PATH $cacheArchiveName }).TotalSeconds
+      Write-Host "cp: ${elapsed}s"
+
+      $elapsed = (Measure-Command { tar xzf $cacheArchiveName -C $env:MVN_LOCAL_REPO }).TotalSeconds
+      Write-Host "tar: ${elapsed}s"
+
+      Remove-Item -Force $cacheArchiveName
+    }
+    '''
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5194, this PR implements the Windows (powershell) case for the `infra.loadMavenLocalCacheIfAny()` function.

It includes 2 changes:

- Implementation in Powershell
- A set of refinements in the Linux shell code (feedbacks from Claude Code, my shell habits and feedbacks from @lemeurherve during code review) gathered along the way following #1025 


----

Note: currently being tested in https://ci.jenkins.io/job/Plugins/job/jenkins-infra-test-plugin/job/PR-220/3/stages/?selected-node=7 (https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/220/changes/09fa9c382cbcbdc156c31e6898a74279e63f88e7)
