### PR TITLE
fix(infra) set cache path per-OS and ensure all env vars are passed to Windows

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -293,11 +293,14 @@ Object runMaven(List<String> options, String jdk = '8', List<String> extraEnv = 
 /**
  * Load Maven cache into local repository from the cachePath archive (tar.gz)
  * @param mvnLocalRepo (required) path to the Maven local repository directory
- * @param cachePath (optional) path to the tar.gz archive (usually on a shared remote volume) filled with the cache
  */
-Object loadMavenLocalCacheIfAny(String mvnLocalRepo, String cachePath = '/cache/maven-bom-local-repo.tar.gz') {
+Object loadMavenLocalCacheIfAny(String mvnLocalRepo, String cachePath = '') {
   if (isUnix()) {
-    withEnv(["MVN_LOCAL_REPO=${mvnLocalRepo}", "MVN_CACHE_PATH=${cachePath}",]) {
+    // Default archive name comes from https://github.com/jenkins-infra/helm-charts/blob/2db07ddfe7df0847f975486226e342ba7bf434cd/charts/maven-cacher/maven-cacher.sh#L7
+    // Default dirname comes from the agents mountpoints of Linux container and Linux VM agents in jenkins-infra/jenkins-infra
+    // It's a convention, we can do better (automatic update? shared metadata? other) but at least the reader is aware
+    final String mvnCachePath = (cachePath ?: '/cache/maven-bom-local-repo.tar.gz')
+    withEnv(["MVN_LOCAL_REPO=${mvnLocalRepo}","MVN_CACHE_PATH=${mvnCachePath}"]) {
       sh '''
       : "${MVN_CACHE_PATH:?MVN_CACHE_PATH must be set}"
       export MVN_LOCAL_REPO="${MVN_LOCAL_REPO:-$HOME/.m2/repository}"
@@ -319,29 +322,35 @@ Object loadMavenLocalCacheIfAny(String mvnLocalRepo, String cachePath = '/cache/
       '''
     }
   } else {
-    pwsh '''
-    if (-not $env:MVN_LOCAL_REPO) {
-      $env:MVN_LOCAL_REPO = Join-Path $HOME ".m2/repository"
+    // Default archive name comes from https://github.com/jenkins-infra/helm-charts/blob/2db07ddfe7df0847f975486226e342ba7bf434cd/charts/maven-cacher/maven-cacher.sh#L7
+    // Default dirname comes from the agents mountpoints of Windows VM agents in jenkins-infra/jenkins-infra
+    // It's a convention, we can do better (automatic update? shared metadata? other) but at least the reader is aware
+    final String mvnCachePath = (cachePath ?: 'C:/cache/maven-bom-local-repo.tar.gz')
+    withEnv(["MVN_LOCAL_REPO=${mvnLocalRepo}","MVN_CACHE_PATH=${mvnCachePath}"]) {
+      pwsh '''
+      if (-not $env:MVN_LOCAL_REPO) {
+        $env:MVN_LOCAL_REPO = Join-Path $HOME ".m2/repository"
+      }
+      New-Item -ItemType Directory -Force -Path $env:MVN_LOCAL_REPO | Out-Null
+
+      if ($env:MVN_CACHE_PATH -and (Test-Path -PathType Leaf $env:MVN_CACHE_PATH)) {
+        # MVN_CACHE_PATH might be served from a CSI S3 volume which does not support seeking.
+        # tar requires a seekable source, so we copy the archive locally first.
+        # The copy lands in the parent of MVN_LOCAL_REPO which has sufficient disk space.
+        $cacheArchiveName = Join-Path (Split-Path -Parent $env:MVN_LOCAL_REPO) (Split-Path -Leaf $env:MVN_CACHE_PATH)
+
+        $elapsed = (Measure-Command { Copy-Item $env:MVN_CACHE_PATH $cacheArchiveName }).TotalSeconds
+        Write-Host "cp: ${elapsed}s"
+
+        $elapsed = (Measure-Command { tar xzf $cacheArchiveName -C $env:MVN_LOCAL_REPO }).TotalSeconds
+        Write-Host "tar: ${elapsed}s"
+
+        Remove-Item -Force $cacheArchiveName
+      } else {
+        Write-Host "${env:MVN_CACHE_PATH} archive not found: skipping maven cache retrieval."
+      }
+      '''
     }
-    New-Item -ItemType Directory -Force -Path $env:MVN_LOCAL_REPO | Out-Null
-
-    if ($env:MVN_CACHE_PATH -and (Test-Path -PathType Leaf $env:MVN_CACHE_PATH)) {
-      # MVN_CACHE_PATH might be served from a CSI S3 volume which does not support seeking.
-      # tar requires a seekable source, so we copy the archive locally first.
-      # The copy lands in the parent of MVN_LOCAL_REPO which has sufficient disk space.
-      $cacheArchiveName = Join-Path (Split-Path -Parent $env:MVN_LOCAL_REPO) (Split-Path -Leaf $env:MVN_CACHE_PATH)
-
-      $elapsed = (Measure-Command { Copy-Item $env:MVN_CACHE_PATH $cacheArchiveName }).TotalSeconds
-      Write-Host "cp: ${elapsed}s"
-
-      $elapsed = (Measure-Command { tar xzf $cacheArchiveName -C $env:MVN_LOCAL_REPO }).TotalSeconds
-      Write-Host "tar: ${elapsed}s"
-
-      Remove-Item -Force $cacheArchiveName
-    } else {
-      Write-Host "${env:MVN_CACHE_PATH} archive not found: skipping maven cache retrieval."
-    }
-    '''
   }
 }
 

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -300,7 +300,8 @@ Object loadMavenLocalCacheIfAny(String mvnLocalRepo, String cachePath = '') {
     // Default dirname comes from the agents mountpoints of Linux container and Linux VM agents in jenkins-infra/jenkins-infra
     // It's a convention, we can do better (automatic update? shared metadata? other) but at least the reader is aware
     final String mvnCachePath = (cachePath ?: '/cache/maven-bom-local-repo.tar.gz')
-    withEnv(["MVN_LOCAL_REPO=${mvnLocalRepo}","MVN_CACHE_PATH=${mvnCachePath}"]) {
+    withEnv(["MVN_LOCAL_REPO=${mvnLocalRepo}", "MVN_CACHE_PATH=${mvnCachePath}"]) {
+      echo "Trying to load Maven cache from ${mvnCachePath} to ${mvnLocalRepo}..."
       sh '''
       : "${MVN_CACHE_PATH:?MVN_CACHE_PATH must be set}"
       export MVN_LOCAL_REPO="${MVN_LOCAL_REPO:-$HOME/.m2/repository}"
@@ -326,7 +327,8 @@ Object loadMavenLocalCacheIfAny(String mvnLocalRepo, String cachePath = '') {
     // Default dirname comes from the agents mountpoints of Windows VM agents in jenkins-infra/jenkins-infra
     // It's a convention, we can do better (automatic update? shared metadata? other) but at least the reader is aware
     final String mvnCachePath = (cachePath ?: 'C:/cache/maven-bom-local-repo.tar.gz')
-    withEnv(["MVN_LOCAL_REPO=${mvnLocalRepo}","MVN_CACHE_PATH=${mvnCachePath}"]) {
+    withEnv(["MVN_LOCAL_REPO=${mvnLocalRepo}", "MVN_CACHE_PATH=${mvnCachePath}"]) {
+      echo "Trying to load Maven cache from ${mvnCachePath} to ${mvnLocalRepo}..."
       pwsh '''
       if (-not $env:MVN_LOCAL_REPO) {
         $env:MVN_LOCAL_REPO = Join-Path $HOME ".m2/repository"


### PR DESCRIPTION
description WiP

Testing:
- Non regression on Linux:
  - ✅ With the `buildPlugin()` function: https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/220/changes#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8
    
    ```text
    12:54:29  + : /cache/maven-bom-local-repo.tar.gz
    12:54:29  + export MVN_LOCAL_REPO=/home/jenkins/agent/workspace/jenkins-infra-test-plugin_PR-220@tmp/m2repo
    12:54:29  + MVN_LOCAL_REPO=/home/jenkins/agent/workspace/jenkins-infra-test-plugin_PR-220@tmp/m2repo
    12:54:29  + mkdir -p /home/jenkins/agent/workspace/jenkins-infra-test-plugin_PR-220@tmp/m2repo
    12:54:29  + test -f /cache/maven-bom-local-repo.tar.gz
    12:54:30  ++ dirname /home/jenkins/agent/workspace/jenkins-infra-test-plugin_PR-220@tmp/m2repo
    12:54:30  ++ basename /cache/maven-bom-local-repo.tar.gz
    12:54:30  + cache_archive_name=/home/jenkins/agent/workspace/jenkins-infra-test-plugin_PR-220@tmp/maven-bom-local-repo.tar.gz
    12:54:30  + cp /cache/maven-bom-local-repo.tar.gz /home/jenkins/agent/workspace/jenkins-infra-test-plugin_PR-220@tmp/maven-bom-local-repo.tar.gz
    12:54:32  
    12:54:32  real	0m2.067s
    12:54:32  user	0m0.044s
    12:54:32  sys	0m0.830s
    12:54:32  + tar xzf /home/jenkins/agent/workspace/jenkins-infra-test-plugin_PR-220@tmp/maven-bom-local-repo.tar.gz -C /home/jenkins/agent/workspace/jenkins-infra-test-plugin_PR-220@tmp/m2repo
    12:54:41  
    12:54:41  real	0m9.578s
    12:54:41  user	0m9.258s
    12:54:41  sys	0m1.925s
    12:54:41  + rm -f /home/jenkins/agent/workspace/jenkins-infra-test-plugin_PR-220@tmp/maven-bom-local-repo.tar.gz
    ```

  - ATH: ✅ https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/2038/stages/?selected-node=316
  - Core: ✅  https://ci.jenkins.io/job/Core/job/jenkins/job/master/ (replayed with `@Library('pipeline-library@pull/1029/head') _`)
- Non regression on Windows: ✅ https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/220#issuecomment-4800335293
  - Without cache (non regression): https://ci.jenkins.io/job/Plugins/job/jenkins-infra-test-plugin/job/master/390/