### PR TITLE
fix(infra.groovy) use `windows-2025` label instead of `docker-windows`

### DIFF
--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -434,7 +434,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('powershell','make build'))
 
 
-    assertTrue(assertMethodCallContainsPattern('node', 'docker-windows'))
+    assertTrue(assertMethodCallContainsPattern('node', 'windows-2025'))
     // And the expected environment variables set to their default values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=.'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=Dockerfile'))
@@ -648,7 +648,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     mockPrincipalBranch()
     withMocks{
       script.call(testImageName, [
-        agentLabels: 'docker-windows',
+        agentLabels: 'windows-2025',
         targetplatforms: 'linux/arm64,linux/amd64',
       ])
     }
@@ -671,7 +671,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
       script.call(testImageName, [
         dockerBakeFile: 'bake.yml',
         targetplatforms: 'windows/amd64',
-        agentLabels: 'docker-windows',
+        agentLabels: 'windows-2025',
       ])
     }
 
@@ -692,7 +692,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     withMocks{
       script.call(testImageName, [
         targetplatforms: 'linux/amd64',
-        agentLabels: 'docker-windows',
+        agentLabels: 'windows-2025',
       ])
     }
     printCallStack()
@@ -733,7 +733,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     mockTag()
     withMocks{
       script.call(customImageNameWithTag,[
-        agentLabels: 'docker-windows',
+        agentLabels: 'windows-2025',
         targetplatforms: 'windows/amd64',
       ])
     }
@@ -766,7 +766,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     mockTag()
     withMocks{
       script.call(testImageName,[
-        agentLabels: 'docker-windows',
+        agentLabels: 'windows-2025',
         targetplatforms: 'windows/amd64',
       ])
     }

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -746,7 +746,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('powershell','make lint'))
     assertTrue(assertMethodCallContainsPattern('powershell','make build'))
 
-    assertTrue(assertMethodCallContainsPattern('node', 'docker'))
+    assertTrue(assertMethodCallContainsPattern('node', 'windows-2025'))
     // And generated reports are recorded with named without ':' but '-' instead
     assertTrue(assertRecordIssues(fullCustomImageName.replaceAll(':','-')))
     // With the deploy step called with the correct image name
@@ -779,7 +779,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('powershell','make lint'))
     assertTrue(assertMethodCallContainsPattern('powershell','make build'))
 
-    assertTrue(assertMethodCallContainsPattern('node', 'docker'))
+    assertTrue(assertMethodCallContainsPattern('node', 'windows-2025'))
     // And generated reports are recorded with named without ':' but '-' instead
     assertTrue(assertRecordIssues(fullCustomImageName.replaceAll(':','-')))
     // With the deploy step called with the correct image name

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -421,7 +421,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     def script = loadScript(scriptName)
     withMocks {
       script.call(testImageName, [
-        agentLabels: 'docker-windows',
+        agentLabels: 'windows-2025',
       ])
     }
     printCallStack()

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -546,7 +546,7 @@ class InfraStepTests extends BaseTest {
       [platform: 'windows', jdk: '17', container: true,  expected: 'maven-17-windows', warning: null],
       // VM agents
       [platform: 'linux',   jdk: '8',  container: false, expected: 'vm && linux',      warning: null],
-      [platform: 'windows', jdk: '8',  container: false, expected: 'docker-windows',   warning: null],
+      [platform: 'windows', jdk: '8',  container: false, expected: 'windows-2025',     warning: null],
       // unknown platform
       [platform: 'openbsd', jdk: '11', container: false, expected: 'openbsd',          warning: 'vm'],
       [platform: 'openbsd', jdk: '11', container: true,  expected: 'openbsd',          warning: 'container'],

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -582,7 +582,7 @@ private String vmAgentLabel(String platform, Integer spotRetryCounter) {
     case 'linux':
       return 'vm && linux'
     case 'windows':
-      return 'docker-windows'
+      return 'windows-2025'
     // For docker controller and agents jobs
     case 'docker-highmem':
       if (isTrusted()) {


### PR DESCRIPTION
Following https://github.com/jenkins-infra/helpdesk/issues/5202#issuecomment-4858381370, we should stop using the `docker-windows` label at all as it is a confusing one.