### PR TITLE
fix(docker) ignore hadolint DL3064 and DL3066

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -53,9 +53,10 @@ help: ## Show this Makefile's help
 
 all: clean lint build test ## Execute the complete process except the "deploy" step
 
+# DL3064 matches variable names instead of values (e.g. JENKINS_USERNAME) and DL3066 flags the usual `USER <name>`: both are false positives on our images
 lint: ## Lint the $(IMAGE_DOCKERFILE) content
 	@echo "== Linting $(call FixPath,$(IMAGE_DOCKERFILE)) with hadolint:"
-	hadolint --format=json "$(call FixPath,$(IMAGE_DOCKERFILE))" > "$(call FixPath,$(HADOLINT_REPORT))"
+	hadolint --ignore DL3064 --ignore DL3066 --format=json "$(call FixPath,$(IMAGE_DOCKERFILE))" > "$(call FixPath,$(HADOLINT_REPORT))"
 	@echo "== Lint succeeded"
 
 build: ## Build the Docker Image $(IMAGE_NAME) from $(IMAGE_DOCKERFILE)


### PR DESCRIPTION
Fixes 
- jenkins-infra/helpdesk#5253


hadolint 2.15.0 landed on the agents with packer-images 2.124.0 and added DL3064 and DL3066. Both are false positives for us, and they break the `lint` stage of 6 docker repos on their next build:

DL3066 (non-numeric user id): docker-404, docker-geoipupdate, docker-mirrorbits, docker-plugin-site-issues, docker-rsyncd
DL3064 (sensitive data in ARG/ENV): docker-ldap

DL3066 fires on `USER <name>`, which is normal and deliberate. DL3064 keys off the variable name rather than the value, so anything containing PASSWORD or USER trips it - that's how docker-packaging got caught, on `JENKINS_USERNAME`.

I hit this on docker-packaging and worked around it with inline pragmas in jenkins-infra/docker-packaging#281, but that just means adding the same pragmas to every repo, hence doing it here instead.

Checked with 2.15.0 locally over all 15 active docker-* repos: the 6 above go from failing to clean, no change anywhere else. Other rules still fire normally - DL3008 and DL3015 on a deliberately bad Dockerfile still fail the target. 

`mvn test` is green (121 tests). The existing tests assert on `make lint` rather than the hadolint flags, so they needed no change.

