### PR TITLE
feat(infra.maybePublishIncrementals): allow to pass an alternative build id

### DIFF
--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -526,7 +526,7 @@ void prepareToPublishIncrementals() {
  * Call at the end of the build, outside any node, when #prepareToPublishIncrementals may have been called previously.
  * See INFRA-1571 and JEP-305.
  */
-void maybePublishIncrementals(String optionalAlternativeBuildUrl = '') {
+void maybePublishIncrementals(int optionalAlternativeBuildId = 0) {
   if (new InfraConfig(env).isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
     if (env.CHANGE_ID == null) {
       def skip
@@ -540,9 +540,9 @@ void maybePublishIncrementals(String optionalAlternativeBuildUrl = '') {
     }
     stage('Deploy') {
       def buildUrlToUse = env.BUILD_URL
-      if (optionalAlternativeBuildUrl && optionalAlternativeBuildUrl != buildUrlToUse) {
-        echo "Using alternative build URL ${optionalAlternativeBuildUrl} instead of ${buildUrlToUse}"
-        buildUrlToUse = optionalAlternativeBuildUrl ?: env.BUILD_URL
+      if (optionalAlternativeBuildId > 0 && optionalAlternativeBuildId != env.BUILD_ID) {
+        buildUrlToUse = "${env.JOB_URL}/${optionalAlternativeBuildId}/"
+        echo "Using alternative build URL ${buildUrlToUse} instead of ${env.BUILD_URL}"
       }
 
       withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -541,7 +541,7 @@ void maybePublishIncrementals(int alternativeBuildId = 0) {
     stage('Deploy') {
       def buildUrlToUse = env.BUILD_URL
       if (alternativeBuildId> 0 && alternativeBuildId != env.BUILD_ID) {
-        buildUrlToUse = "${env.JOB_URL}/${alternativeBuildId}/"
+        buildUrlToUse = "${env.JOB_URL}${alternativeBuildId}/"
         echo "Using alternative build URL ${buildUrlToUse} instead of ${env.BUILD_URL}"
       }
 

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -540,7 +540,7 @@ void maybePublishIncrementals(int optionalAlternativeBuildId = 0) {
     }
     stage('Deploy') {
       def buildUrlToUse = env.BUILD_URL
-      if (optionalAlternativeBuildId > 0 && optionalAlternativeBuildId != env.BUILD_ID) {
+      if (optionalAlternativeBuildId> 0 && optionalAlternativeBuildId != env.BUILD_ID) {
         buildUrlToUse = "${env.JOB_URL}/${optionalAlternativeBuildId}/"
         echo "Using alternative build URL ${buildUrlToUse} instead of ${env.BUILD_URL}"
       }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -526,7 +526,7 @@ void prepareToPublishIncrementals() {
  * Call at the end of the build, outside any node, when #prepareToPublishIncrementals may have been called previously.
  * See INFRA-1571 and JEP-305.
  */
-void maybePublishIncrementals(int optionalAlternativeBuildId = 0) {
+void maybePublishIncrementals(int alternativeBuildId = 0) {
   if (new InfraConfig(env).isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
     if (env.CHANGE_ID == null) {
       def skip
@@ -540,8 +540,8 @@ void maybePublishIncrementals(int optionalAlternativeBuildId = 0) {
     }
     stage('Deploy') {
       def buildUrlToUse = env.BUILD_URL
-      if (optionalAlternativeBuildId> 0 && optionalAlternativeBuildId != env.BUILD_ID) {
-        buildUrlToUse = "${env.JOB_URL}/${optionalAlternativeBuildId}/"
+      if (alternativeBuildId> 0 && alternativeBuildId != env.BUILD_ID) {
+        buildUrlToUse = "${env.JOB_URL}/${alternativeBuildId}/"
         echo "Using alternative build URL ${buildUrlToUse} instead of ${env.BUILD_URL}"
       }
 

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -526,7 +526,7 @@ void prepareToPublishIncrementals() {
  * Call at the end of the build, outside any node, when #prepareToPublishIncrementals may have been called previously.
  * See INFRA-1571 and JEP-305.
  */
-void maybePublishIncrementals() {
+void maybePublishIncrementals(String optionalAlternativeBuildUrl = '') {
   if (new InfraConfig(env).isRunningOnJenkinsInfra() && currentBuild.currentResult == 'SUCCESS') {
     if (env.CHANGE_ID == null) {
       def skip
@@ -539,13 +539,19 @@ void maybePublishIncrementals() {
       }
     }
     stage('Deploy') {
+      def buildUrlToUse = env.BUILD_URL
+      if (optionalAlternativeBuildUrl && optionalAlternativeBuildUrl != buildUrlToUse) {
+        echo "Using alternative build URL ${optionalAlternativeBuildUrl} instead of ${buildUrlToUse}"
+        buildUrlToUse = optionalAlternativeBuildUrl ?: env.BUILD_URL
+      }
+
       withCredentials([string(credentialsId: 'incrementals-publisher-token', variable: 'FUNCTION_TOKEN')]) {
         httpRequest url: 'https://incrementals.jenkins.io/',
         httpMode: 'POST',
         contentType: 'APPLICATION_JSON',
         validResponseCodes: '100:599',
         timeout: 300,
-        requestBody: /{"build_url":"$BUILD_URL"}/,
+        requestBody: /{"build_url":"$buildUrlToUse"}/,
         customHeaders: [[name: 'Authorization', value: 'Bearer ' + FUNCTION_TOKEN]],
         consoleLogResponseBody: true
       }


### PR DESCRIPTION
This change allows to pass an alternative build URL to incrementals-publisher service on publication.

Use case: `infra.prepareToPublishIncrementals()` artifacts prepared and archived in a previous build, then calling `infra.maybePublishIncrementals` in a subsequent build which doesn't have those archives.

### Testing done

Build of https://github.com/jenkinsci/bom/pull/7324 (testing https://github.com/jenkinsci/bom/pull/7319)

https://ci.jenkins.io/job/Tools/job/bom/job/PR-7324/12/stages/?selected-node=89
> <img width="2197" height="465" alt="image" src="https://github.com/user-attachments/assets/83c8384e-ba05-4900-b127-5088563fe4b3" />

