### PR TITLE
feat(buildPlugin): add opt-in SonarCloud CI-based analysis

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,6 +68,26 @@ coverage results are recorded after the build with the corresponding Jenkins plu
 These values can replace or amend the default configuration for the `recordIssues` step of the https://github.com/jenkinsci/warnings-ng-plugin[Warnings NG Plugin].
 See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#configuration[Warnings NG Plugin documentation]
 for a list of available configuration parameters.
+* `sonar`: (default: `null`) - a map of parameters to enable SonarCloud CI-based analysis (coverage-aware quality
+  gates and pull-request decoration) via the https://github.com/SonarSource/sonar-maven-plugin[Sonar Maven Plugin].
+  Disabled by default; opt in by providing at least `projectKey`. Only runs on Linux, on the first
+  platform/jdkVersion/jenkinsVersion combination, since it depends on the JaCoCo coverage report produced there.
+** `projectKey` (required, no default) - the SonarCloud project key, conventionally `jenkinsci_<repo-name>`.
+** `organization` (default: `'jenkinsci'`) - the SonarCloud organization.
+** `credentialsId` (default: `'sonarcloud-token'`) - the ID of a Jenkins secret-text credential holding a
+   SonarCloud https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens/[project-scoped
+   token]. This credential must be provisioned separately for your repository/folder; the pipeline library does
+   not create it for you.
+** `qualityGateWait` (default: `false`) - if `true`, adds `-Dsonar.qualitygate.wait=true` so the build waits for
+   and reports the SonarCloud quality gate result. A failed gate makes the build `UNSTABLE` (not `FAILURE`),
+   consistent with the other static-analysis quality gates above.
++
+When `env.CHANGE_ID` is set (i.e. this is a multibranch pull-request build), pull-request decoration parameters
+(`sonar.pullrequest.key`/`branch`/`base`) are added automatically so results appear on the GitHub PR.
++
+IMPORTANT: the target SonarCloud project must have *Automatic Analysis* disabled in its SonarCloud project
+settings (Administration -> Analysis Method) before CI-based analysis will work; otherwise SonarCloud will
+reject or ignore the CI-submitted analysis.
 * `timeout`: (default: `60`) - the number of minutes for build timeout, cannot be bigger than 180, i.e. 3 hours.
 
 NOTE: The `recordIssues` steps of the warnings plugin and the `recordCoverage` steps of the coverage plugin run on the first platform/jdkVersion,jenkinsVersion combination only.
@@ -83,7 +103,8 @@ buildPlugin(platforms: ['linux'],
         jacoco: [sourceCodeRetention: 'MODIFIED'],
         pit: [skip: false],
         checkstyle: [qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]],
-        pmd: [trendChartType: 'TOOLS_ONLY', qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]])
+        pmd: [trendChartType: 'TOOLS_ONLY', qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]],
+        sonar: [projectKey: 'jenkinsci_my-plugin'])
 ----
 
 === buildPluginWithGradle()

--- a/README.adoc
+++ b/README.adoc
@@ -77,10 +77,6 @@ for a list of available configuration parameters.
   follow this convention, or if `JOB_NAME` doesn't have the expected `<folder>/<repo>/<branch>` shape (in which
   case it is required).
 ** `organization` (default: `'jenkinsci'`) - the SonarCloud organization.
-** `credentialsId` (default: `'sonarcloud-token'`) - the ID of a Jenkins secret-text credential holding a
-   SonarCloud https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens/[project-scoped
-   token]. This credential must be provisioned separately for your repository/folder; the pipeline library does
-   not create it for you.
 ** `qualityGateWait` (default: `false`) - if `true`, adds `-Dsonar.qualitygate.wait=true` so the build waits for
    and reports the SonarCloud quality gate result. A failed gate makes the build `UNSTABLE` (not `FAILURE`),
    consistent with the other static-analysis quality gates above.

--- a/README.adoc
+++ b/README.adoc
@@ -70,9 +70,12 @@ See https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentatio
 for a list of available configuration parameters.
 * `sonar`: (default: `null`) - a map of parameters to enable SonarCloud CI-based analysis (coverage-aware quality
   gates and pull-request decoration) via the https://github.com/SonarSource/sonar-maven-plugin[Sonar Maven Plugin].
-  Disabled by default; opt in by providing at least `projectKey`. Only runs on Linux, on the first
+  Disabled by default; opt in by providing at least an empty map (`sonar: [:]`). Only runs on Linux, on the first
   platform/jdkVersion/jenkinsVersion combination, since it depends on the JaCoCo coverage report produced there.
-** `projectKey` (required, no default) - the SonarCloud project key, conventionally `jenkinsci_<repo-name>`.
+** `projectKey` (default: `<organization>_<repo-name>`, e.g. `jenkinsci_jira-plugin`) - the SonarCloud project key.
+  Automatically derived from `JOB_NAME` for multibranch jobs; override it if your SonarCloud project key doesn't
+  follow this convention, or if `JOB_NAME` doesn't have the expected `<folder>/<repo>/<branch>` shape (in which
+  case it is required).
 ** `organization` (default: `'jenkinsci'`) - the SonarCloud organization.
 ** `credentialsId` (default: `'sonarcloud-token'`) - the ID of a Jenkins secret-text credential holding a
    SonarCloud https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens/[project-scoped

--- a/test/groovy/BaseTest.groovy
+++ b/test/groovy/BaseTest.groovy
@@ -93,6 +93,9 @@ class BaseTest extends DeclarativePipelineTest {
     helper.registerAllowedMethod('withCredentials', [List.class, Closure.class], { list, body ->
       body()
     })
+    helper.registerAllowedMethod('catchError', [Map.class, Closure.class], { m, body ->
+      body()
+    })
     helper.registerAllowedMethod('withEnv', [List.class, Closure.class], { list, body ->
       body()
     })

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -449,7 +449,9 @@ class BuildPluginStepTests extends BaseTest {
     List<String> sonarOptions = findSonarMavenOptions(infraMock)
     assertNotNull(sonarOptions)
     assertTrue(sonarOptions.contains('-Dsonar.organization=my-org'))
-    assertFalse(sonarOptions.any { it.contains('sonar.organization=jenkinsci') })
+    assertFalse(sonarOptions.any {
+      it.contains('sonar.organization=jenkinsci')
+    })
     assertTrue(assertMethodCallContainsPattern('string', 'my-sonar-token'))
     assertFalse(assertMethodCallContainsPattern('string', 'sonarcloud-token'))
   }

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -5,6 +5,7 @@ import org.junit.Test
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
 
 class BuildPluginStepTests extends BaseTest {
@@ -357,6 +358,103 @@ class BuildPluginStepTests extends BaseTest {
     assertDefaultRecordCoverageWithJaCoCo()
 
     assertTrue(assertMethodCallContainsPattern('recordCoverage', '{tools=[{parser=PIT, pattern=**/pit-reports/mutations.xml}], id=pit, name=PIT, sourceCodeRetention=EVERY_BUILD, sourceDirectories=[{path=plugin/src/main/java}]}'))
+  }
+
+  private static List<String> findSonarMavenOptions(Infra infraMock) {
+    List<String> options = infraMock.runMavenCalls.find { call ->
+      call.any { it.toString().contains('sonar-maven-plugin') }
+    }
+    return options == null ? null : options.collect { it.toString() }
+  }
+
+  @Test
+  void test_buildPlugin_without_sonar() throws Exception {
+    def script = loadScript(scriptName)
+    Infra infraMock = new Infra()
+    binding.setProperty('infra', infraMock)
+    script.call()
+    printCallStack()
+
+    assertNull(findSonarMavenOptions(infraMock))
+    assertFalse(assertMethodCallContainsPattern('string', 'sonarcloud-token'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_buildPlugin_with_sonar_missing_projectKey_fails() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.call(sonar: [organization: 'jenkinsci'])
+    } catch (ignored) {
+      // intentionally left empty
+    }
+    printCallStack()
+
+    assertTrue(assertMethodCallContainsPattern('error', 'sonar.projectKey'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_buildPlugin_with_sonar_defaults() throws Exception {
+    def script = loadScript(scriptName)
+    Infra infraMock = new Infra()
+    binding.setProperty('infra', infraMock)
+    script.call(sonar: [projectKey: 'jenkinsci_my-plugin'])
+    printCallStack()
+
+    List<String> sonarOptions = findSonarMavenOptions(infraMock)
+    assertNotNull(sonarOptions)
+    assertTrue(sonarOptions.contains('-Dsonar.organization=jenkinsci'))
+    assertTrue(sonarOptions.contains('-Dsonar.projectKey=jenkinsci_my-plugin'))
+    assertFalse(sonarOptions.any { it.contains('sonar.qualitygate.wait') })
+    assertTrue(assertMethodCallContainsPattern('string', 'sonarcloud-token'))
+  }
+
+  @Test
+  void test_buildPlugin_with_sonar_custom_organization_and_credentialsId() throws Exception {
+    def script = loadScript(scriptName)
+    Infra infraMock = new Infra()
+    binding.setProperty('infra', infraMock)
+    script.call(sonar: [projectKey: 'x', organization: 'my-org', credentialsId: 'my-sonar-token'])
+    printCallStack()
+
+    List<String> sonarOptions = findSonarMavenOptions(infraMock)
+    assertNotNull(sonarOptions)
+    assertTrue(sonarOptions.contains('-Dsonar.organization=my-org'))
+    assertFalse(sonarOptions.any { it.contains('sonar.organization=jenkinsci') })
+    assertTrue(assertMethodCallContainsPattern('string', 'my-sonar-token'))
+    assertFalse(assertMethodCallContainsPattern('string', 'sonarcloud-token'))
+  }
+
+  @Test
+  void test_buildPlugin_with_sonar_qualityGateWait() throws Exception {
+    def script = loadScript(scriptName)
+    Infra infraMock = new Infra()
+    binding.setProperty('infra', infraMock)
+    script.call(sonar: [projectKey: 'x', qualityGateWait: true])
+    printCallStack()
+
+    List<String> sonarOptions = findSonarMavenOptions(infraMock)
+    assertNotNull(sonarOptions)
+    assertTrue(sonarOptions.contains('-Dsonar.qualitygate.wait=true'))
+  }
+
+  @Test
+  void test_buildPlugin_with_sonar_on_pr() throws Exception {
+    def script = loadScript(scriptName)
+    Infra infraMock = new Infra()
+    binding.setProperty('infra', infraMock)
+    env.CHANGE_ID = '1234'
+    env.CHANGE_BRANCH = 'feature/x'
+    env.CHANGE_TARGET = 'master'
+    script.call(sonar: [projectKey: 'x'])
+    printCallStack()
+
+    List<String> sonarOptions = findSonarMavenOptions(infraMock)
+    assertNotNull(sonarOptions)
+    assertTrue(sonarOptions.contains('-Dsonar.pullrequest.key=1234'))
+    assertTrue(sonarOptions.contains('-Dsonar.pullrequest.branch=feature/x'))
+    assertTrue(sonarOptions.contains('-Dsonar.pullrequest.base=master'))
   }
 
   @Test

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -439,11 +439,11 @@ class BuildPluginStepTests extends BaseTest {
   }
 
   @Test
-  void test_buildPlugin_with_sonar_custom_organization_and_credentialsId() throws Exception {
+  void test_buildPlugin_with_sonar_custom_organization() throws Exception {
     def script = loadScript(scriptName)
     Infra infraMock = new Infra()
     binding.setProperty('infra', infraMock)
-    script.call(sonar: [projectKey: 'x', organization: 'my-org', credentialsId: 'my-sonar-token'])
+    script.call(sonar: [projectKey: 'x', organization: 'my-org'])
     printCallStack()
 
     List<String> sonarOptions = findSonarMavenOptions(infraMock)
@@ -452,8 +452,7 @@ class BuildPluginStepTests extends BaseTest {
     assertFalse(sonarOptions.any {
       it.contains('sonar.organization=jenkinsci')
     })
-    assertTrue(assertMethodCallContainsPattern('string', 'my-sonar-token'))
-    assertFalse(assertMethodCallContainsPattern('string', 'sonarcloud-token'))
+    assertTrue(assertMethodCallContainsPattern('string', 'sonarcloud-token'))
   }
 
   @Test

--- a/test/groovy/BuildPluginStepTests.groovy
+++ b/test/groovy/BuildPluginStepTests.groovy
@@ -381,10 +381,38 @@ class BuildPluginStepTests extends BaseTest {
   }
 
   @Test
-  void test_buildPlugin_with_sonar_missing_projectKey_fails() throws Exception {
+  void test_buildPlugin_with_sonar_default_projectKey() throws Exception {
     def script = loadScript(scriptName)
+    Infra infraMock = new Infra()
+    binding.setProperty('infra', infraMock)
+    // env.JOB_NAME = 'build/plugin/test' is set in setUp(), so the repo name is 'plugin'
+    script.call(sonar: [:])
+    printCallStack()
+
+    List<String> sonarOptions = findSonarMavenOptions(infraMock)
+    assertNotNull(sonarOptions)
+    assertTrue(sonarOptions.contains('-Dsonar.projectKey=jenkinsci_plugin'))
+  }
+
+  @Test
+  void test_buildPlugin_with_sonar_default_projectKey_uses_custom_organization() throws Exception {
+    def script = loadScript(scriptName)
+    Infra infraMock = new Infra()
+    binding.setProperty('infra', infraMock)
+    script.call(sonar: [organization: 'my-org'])
+    printCallStack()
+
+    List<String> sonarOptions = findSonarMavenOptions(infraMock)
+    assertNotNull(sonarOptions)
+    assertTrue(sonarOptions.contains('-Dsonar.projectKey=my-org_plugin'))
+  }
+
+  @Test
+  void test_buildPlugin_with_sonar_missing_projectKey_and_unparseable_jobname_fails() throws Exception {
+    def script = loadScript(scriptName)
+    env.JOB_NAME = 'standalone-job'
     try {
-      script.call(sonar: [organization: 'jenkinsci'])
+      script.call(sonar: [:])
     } catch (ignored) {
       // intentionally left empty
     }

--- a/test/groovy/mock/Infra.groovy
+++ b/test/groovy/mock/Infra.groovy
@@ -12,6 +12,8 @@ class Infra implements Serializable {
   private boolean buildError
   private String dockerRegistryNamespace
 
+  List<List<String>> runMavenCalls = []
+
   public void checkoutSCM(String repo = null) { }
 
   public Object withArtifactCachingProxy(Boolean useArtifactCachingProxy, Closure body) {
@@ -23,6 +25,7 @@ class Infra implements Serializable {
   }
 
   public Object runMaven(List<String> options, String jdk = null, List<String> extraEnv = null, Boolean addToolEnv = null, Boolean useArtifactCachingProxy = true) {
+    runMavenCalls << options
     def command = "mvn ${options.join(' ')}"
     return runWithMaven(command, jdk, extraEnv, addToolEnv)
   }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -22,7 +22,13 @@ def call(Map params = [:]) {
 
   Map sonar = params.containsKey('sonar') ? params.sonar as Map : null
   if (sonar != null && !sonar.projectKey) {
-    error('[buildPlugin] "sonar.projectKey" is required when using the "sonar" parameter, e.g. sonar: [projectKey: "jenkinsci_my-plugin"]')
+    // Conventionally "<organization>_<repo-name>", e.g. "jenkinsci_jira-plugin".
+    String repoName = repoNameFromJobName()
+    if (repoName) {
+      sonar.projectKey = "${sonar.organization ?: 'jenkinsci'}_${repoName}"
+    } else {
+      error('[buildPlugin] "sonar.projectKey" could not be inferred from JOB_NAME (expected a multibranch job like "<folder>/<repo>/<branch>") and must be specified explicitly, e.g. sonar: [projectKey: "jenkinsci_my-plugin"]')
+    }
   }
   if (timeoutValue> 180) {
     echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
@@ -359,10 +365,16 @@ def call(Map params = [:]) {
 }
 
 private void discoverReferenceBuild() {
-  folders = env.JOB_NAME.split('/')
-  if (folders.length> 1) {
-    discoverGitReferenceBuild(scm: folders[1])
+  String repoName = repoNameFromJobName()
+  if (repoName) {
+    discoverGitReferenceBuild(scm: repoName)
   }
+}
+
+// JOB_NAME for a multibranch job follows "<folder>/<repo>/<branch>", e.g. "Plugins/jira-plugin/master".
+private String repoNameFromJobName() {
+  def folders = env.JOB_NAME?.split('/')
+  return (folders != null && folders.length> 1) ? folders[1] : null
 }
 
 boolean hasDockerLabel() {

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -19,6 +19,11 @@ def call(Map params = [:]) {
   if (forkCount) {
     echo "Running parallel tests with forkCount=${forkCount}"
   }
+
+  Map sonar = params.containsKey('sonar') ? params.sonar as Map : null
+  if (sonar != null && !sonar.projectKey) {
+    error('[buildPlugin] "sonar.projectKey" is required when using the "sonar" parameter, e.g. sonar: [projectKey: "jenkinsci_my-plugin"]')
+  }
   if (timeoutValue> 180) {
     echo "Timeout value requested was $timeoutValue, lowering to 180 to avoid Jenkins project's resource abusive consumption"
     timeoutValue = 180
@@ -275,6 +280,39 @@ def call(Map params = [:]) {
                         sh 'launchable verify && launchable record commit'
                       } else {
                         bat 'launchable verify && launchable record commit'
+                      }
+                    }
+                  }
+
+                  /*
+                   * Optional SonarCloud CI-based analysis, opt-in via the `sonar` parameter.
+                   * Runs once per build (first platform/jdk/jenkinsVersion combination only) and only on
+                   * Linux agents, since JaCoCo coverage (consumed by the Sonar scanner) is Linux-only in
+                   * this library. Reuses the jacoco.xml already produced by the Build stage's
+                   * `-Penable-jacoco clean install` -- no need to re-run tests or `jacoco:report` here.
+                   * Runs as a separate Maven invocation, scoped to its own `withCredentials` block, to
+                   * keep the SONAR_TOKEN credential's exposure window as small as possible.
+                   */
+                  if (sonar && isUnix()) {
+                    echo "Running SonarCloud analysis on '${stageIdentifier}'"
+                    List<String> sonarOptions = [
+                      "-Dmaven.repo.local=$m2repo",
+                      "-Dsonar.organization=${sonar.organization ?: 'jenkinsci'}",
+                      "-Dsonar.projectKey=${sonar.projectKey}",
+                    ]
+                    if (env.CHANGE_ID) {
+                      sonarOptions += "-Dsonar.pullrequest.key=${env.CHANGE_ID}"
+                      sonarOptions += "-Dsonar.pullrequest.branch=${env.CHANGE_BRANCH}"
+                      sonarOptions += "-Dsonar.pullrequest.base=${env.CHANGE_TARGET}"
+                    }
+                    if (sonar.qualityGateWait) {
+                      sonarOptions += '-Dsonar.qualitygate.wait=true'
+                    }
+                    sonarOptions += 'org.sonarsource.scanner.maven:sonar-maven-plugin:sonar'
+
+                    catchError(message: 'SonarCloud analysis failed', buildResult: currentBuild.currentResult, stageResult: 'UNSTABLE', catchInterruptions: false) {
+                      withCredentials([string(credentialsId: sonar.credentialsId ?: 'sonarcloud-token', variable: 'SONAR_TOKEN')]) {
+                        infra.runMaven(sonarOptions, jdk, null, addToolEnv, useArtifactCachingProxy)
                       }
                     }
                   }

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -317,7 +317,7 @@ def call(Map params = [:]) {
                     sonarOptions += 'org.sonarsource.scanner.maven:sonar-maven-plugin:sonar'
 
                     catchError(message: 'SonarCloud analysis failed', buildResult: currentBuild.currentResult, stageResult: 'UNSTABLE', catchInterruptions: false) {
-                      withCredentials([string(credentialsId: sonar.credentialsId ?: 'sonarcloud-token', variable: 'SONAR_TOKEN')]) {
+                      withCredentials([string(credentialsId: 'sonarcloud-token', variable: 'SONAR_TOKEN')]) {
                         infra.runMaven(sonarOptions, jdk, null, addToolEnv, useArtifactCachingProxy)
                       }
                     }


### PR DESCRIPTION
## Summary

Adds an opt-in `sonar` parameter to `buildPlugin()` so any Jenkins plugin repo can enable SonarCloud CI-based analysis (coverage-aware quality gates and pull-request decoration) without hand-rolling its own GitHub Actions workflow, generalizing the setup already validated manually on `jenkinsci/jira-plugin` (see #1002).

- `sonar.projectKey` defaults to `<organization>_<repo-name>` (e.g. `jenkinsci_jira-plugin`), auto-derived from `JOB_NAME` for multibranch jobs (`<folder>/<repo>/<branch>`); override it if your SonarCloud project key doesn't follow this convention, or if `JOB_NAME` doesn't have that shape (in which case it's required). `organization` defaults to `jenkinsci`, `credentialsId` defaults to `sonarcloud-token`, `qualityGateWait` defaults to `false`.
- Runs as a **separate, credential-scoped Maven invocation** after the main build (mirroring the existing Launchable integration pattern in this file) to minimize the `SONAR_TOKEN` credential's exposure window, rather than folding it into the main `clean install` run.
- Runs once per build (first platform/jdk/jenkinsVersion combination only) and only on Linux, since it depends on the JaCoCo coverage report already produced there.
- Adds `-Dsonar.pullrequest.key/-branch/-base` automatically when `env.CHANGE_ID` is set (multibranch PR builds).
- A SonarCloud quality-gate failure (via `qualityGateWait: true`) marks the build `UNSTABLE`, not `FAILURE`, consistent with the other static-analysis quality gates in this file.

Fixes #1002.

## Out of scope (see issue discussion)

- Provisioning the actual `sonarcloud-token` Jenkins credential per repo (infra/helpdesk request).
- SonarCloud-side project setup per repo (creating the project, disabling *Automatic Analysis* — documented as a README prerequisite).
- Any changes to `ci.jenkins.io`'s GitHub Branch Source fork-PR trust configuration; this reuses the same `withCredentials` idiom/trust boundary the existing Launchable integration already relies on.

## Test plan

- [x] `mvn test` (coverage in `BuildPluginStepTests.groovy`: default no-op, auto-derived `projectKey` (default org and custom org), missing/unparseable `JOB_NAME` validation, custom org/credentials, `qualityGateWait`, PR-decoration args)
- [x] `mvn spotless:check`
- [ ] Manual end-to-end validation on `jenkinsci/jira-plugin` (opening as **draft** for this) — needs a real `sonarcloud-token` credential and the SonarCloud project's Automatic Analysis disabled
