### PR TITLE
feat(buildDockerAndPublishImage) add support of `cert.ci.jenkins.io`

### DIFF
--- a/test/groovy/mock/Infra.groovy
+++ b/test/groovy/mock/Infra.groovy
@@ -8,6 +8,7 @@ class Infra implements Serializable {
   private boolean trustedCi
   private boolean releaseCi
   private boolean infraCi
+  private boolean certCi
   private boolean ci
   private boolean buildError
   private String dockerRegistryNamespace
@@ -53,6 +54,10 @@ class Infra implements Serializable {
 
   public boolean isInfraCiController() {
     return infraCi
+  }
+
+  public boolean isCertCiController() {
+    return certCi
   }
 
   public boolean isCiController() {

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -143,7 +143,6 @@ def call(String imageShortName, Map userConfig =[:]) {
       "BAKE_TARGETPLATFORMS=${finalConfig.targetplatforms}",
       "REGISTRY=${registryHost}",
     ]) {
-      String nextVersion = ''
       stage("Prepare ${imageName}") {
         checkout scm
         if (finalConfig.unstash != '') {
@@ -167,16 +166,26 @@ def call(String imageShortName, Map userConfig =[:]) {
               powershell 'make lint'
             }
           } finally {
-            boolean skipChecks = false
-            if (env.BRANCH_IS_PRIMARY) {
-              skipChecks = true
+            // Only ci.jenkins.io and infra.ci.jenkins.io are expected to have the 'warnings' plugin
+            if (infra.isInfraCiController() || infra.isCiController()) {
+              boolean skipChecks = false
+              if (env.BRANCH_IS_PRIMARY) {
+                skipChecks = true
+              }
+              recordIssues(
+                  skipPublishingChecks: skipChecks,
+                  enabledForFailure: true,
+                  aggregatingResults: false,
+                  tool: hadoLint(id: hadolintReportId, pattern: hadoLintReportFile)
+                  )
+            } else {
+              // Print the hadolint report file to stdout in case of error when no warnings plugin is available
+              if (isUnix()) {
+                sh 'cat "${HADOLINT_REPORT}"'
+              } else {
+                powershell 'type $env:HADOLINT_REPORT'
+              }
             }
-            recordIssues(
-                skipPublishingChecks: skipChecks,
-                enabledForFailure: true,
-                aggregatingResults: false,
-                tool: hadoLint(id: hadolintReportId, pattern: hadoLintReportFile)
-                )
           }
         }
       } // stage
@@ -212,7 +221,9 @@ def call(String imageShortName, Map userConfig =[:]) {
         } // if else
       } // each
 
-      if (env.BRANCH_IS_PRIMARY || env.TAG_NAME) {
+      String nextVersion = ''
+
+      if (env.BRANCH_IS_PRIMARY || env.TAG_NAME || infra.isCertCiController()) {
         // Automatic tagging on principal branch is not enabled by default, show potential next version in PR anyway
         if (finalConfig.automaticSemanticVersioning) {
           stage("Get Next Version of ${imageName}") {
@@ -222,16 +233,18 @@ def call(String imageShortName, Map userConfig =[:]) {
             } else {
               powershell 'git fetch --all --tags' // Ensure that all the tags are retrieved (uncoupling from job configuration, wether tags are fetched or not)
               nextVersion = powershell(script: finalConfig.nextVersionCommand, returnStdout: true).trim()
-            }
-            echo "Next Release Version = ${nextVersion}"
+            } // if
+            echo "nextVersion: ${nextVersion}"
           } // stage
+        } else if (env.TAG_NAME) {
+          // if a tag is scanned, it need to be the nextVersion
+          nextVersion = env.TAG_NAME
+          echo "nextVersion: ${nextVersion}"
         } else {
-          if (env.TAG_NAME) {
-            // if a tag is scanned, it need to be the nextVersion
-            nextVersion = env.TAG_NAME
-          }
+          echo "INFO: no 'nextVersion' detected. Relying on the user-provided image name for Docker tag (${imageName})."
         } // if
 
+        // env var 'NEXT_VERSION' may be used by the docker bake file so we need it early
         withEnv(["NEXT_VERSION=${nextVersion}"]) {
           // Only deploy on primary branch
           stage("Deploy ${imageName}") {
@@ -245,7 +258,7 @@ def call(String imageShortName, Map userConfig =[:]) {
           } // stage
 
           // Automatic tagging on principal branch is not enabled by default, and disabled if disablePublication is set to true
-          if (semVerEnabledOnPrimaryBranch) {
+          if (semVerEnabledOnPrimaryBranch && nextVersion) {
             stage("Semantic Release of ${imageName}") {
               echo "Configuring credential.helper"
               // The credential.helper will execute everything after the '!', here echoing the username, the password and an empty line to be passed to git as credentials when git needs it.
@@ -283,7 +296,7 @@ def call(String imageShortName, Map userConfig =[:]) {
 
           // GitHub Release stage: Use NEXT_VERSION and only on primary branch
           // Create release only if SemVer is enabled, on primary branch, and publication is NOT disabled.
-          if (finalConfig.automaticSemanticVersioning && !finalConfig.disablePublication) {
+          if (finalConfig.automaticSemanticVersioning && !finalConfig.disablePublication && nextVersion) {
             stage('GitHub Release') {
               withCredentials([
                 usernamePassword(credentialsId: "${finalConfig.gitCredentials}", passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -28,6 +28,10 @@ Boolean isInfraCiController() {
   return isJenkinsIoURLSubdomaincontains('infra.ci')
 }
 
+Boolean isCertCiController() {
+  return isJenkinsIoURLSubdomaincontains('cert.ci')
+}
+
 // Deprecated, kept for backward compatibility
 Boolean isInfra() {
   echo 'DEPRECATION WARNING: the function "infra.isInfra()" is deprecated and should be replaced by "infra.isInfraCiController()".'
@@ -41,7 +45,7 @@ Boolean isTrusted() {
 }
 
 String getDockerRegistryNamespace() {
-  if (isTrustedCiController() || isInfraCiController() || isReleaseCiController()) {
+  if (isTrustedCiController() || isInfraCiController() || isReleaseCiController() || isCertCiController()) {
     return 'jenkinsciinfra'
   } else {
     return 'jenkins4eval'

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -29,6 +29,12 @@
     Returns if the pipeline is running on the internal "release.ci.jenkins.io" Jenkins controller.
 </p>
 
+<strong>infra.isCertCiController()</strong>
+
+<p>
+    Returns if the pipeline is running on the internal "cert.ci.jenkins.io" Jenkins controller.
+</p>
+
 <strong>infra.withContainerRegistry(String containerRegistry = '', Closure body)</strong>
 
 <p>

--- a/vars/publishBuildStatusReport.groovy
+++ b/vars/publishBuildStatusReport.groovy
@@ -25,13 +25,23 @@ def call(Map config = [:]) {
     return
   }
 
-  if (env.JENKINS_URL?.trim() == 'https://ci.jenkins.io/') {
+  final String jenkinsURL = env.JENKINS_URL?.trim()
+
+  if (!jenkinsURL) {
+    error("JENKINS_URL is not set or empty")
+  }
+
+  if (jenkinsURL == 'https://ci.jenkins.io/') {
     echo '[WARNING] Not publishing any build status report from ci.jenkins.io, skipping'
     return
   }
 
-  if (!env.JENKINS_URL?.trim()) {
-    error("JENKINS_URL is not set or empty")
+  if (jenkinsURL == 'https://cert.ci.jenkins.io/') {
+    final String allowedJobName = 'acceptance-tests-check-agent-availability'
+    if (env.JOB_NAME != allowedJobName) {
+      echo "[WARNING] Not publishing any build status report from cert.ci.jenkins.io unless the job is '${allowedJobName}', skipping"
+      return
+    }
   }
 
   def tempDir = pwd(tmp: true)


### PR DESCRIPTION
Requires #1045 #1047 and #1048

This PR introduces the support of the library `buildDockerAndPublishImage()` in cert.ci.jenkins.io to allow the Jenkins Security team to build and publish privately Docker images of the Jenkins infrastructure for autonomy during security advisories.

Notes:
- It does NOT cover publishing the `jenkinsci/docker*` images neither it is a staging for Docker images.
- The target is the (private) container registry in Azure which requires credentials set up per job inside cert.ci.jenkins.io
- For cert.ci.jenkins.io, we want the lint phase to happen (to avoid bad surprises for the Jenkins Security team when publishing code fixes) but we print the hadolint report in the stdout as the `warnings` plugin (providing the `recordIssue pipeline step` is not available
  - Also the case of trusted.ci.jenkins.io. Never had it until now but could be.
- The container image's tag must be provided by the calling pipeline as part of the "imageName" string parameter. cert.ci.jenkins.io is not expected to build from git tag or principal branch.
- We also disable publication of build report: no infra monitoring for these builds. The goal is to avoid leaking any reference

----


Tested with success in cert.ci.jenkins.io:

```
pushing manifest for *****/******/account-app:SECURITY-testddu@sha256:2381ea5af801316ac4ed69773c651d6234b6d30a1d2403af1d95a738fbcc7dce 1.5s done
```