### PR TITLE
feat!(infra,BuildDockerAndPublishImage) Factorize all container registry logins to a generic reusable method

### DIFF
--- a/src/io/jenkins/infra/InfraConfig.groovy
+++ b/src/io/jenkins/infra/InfraConfig.groovy
@@ -45,21 +45,4 @@ class InfraConfig implements Serializable {
       return 'jenkins4eval'
     }
   }
-
-  // Returns the Docker Informations for pushing images
-  Map getDockerPushOrgAndCredentialsId() {
-    switch(jenkinsHostname){
-      case 'ci.jenkins.io':
-        return [error: false, organisation: 'jenkins4eval', credentialId: 'cijenkinsio-dockerhub-push']
-        break
-      case 'trusted.ci.jenkins.io':
-        return [error: false, organisation: 'jenkins', credentialId: 'jenkinsciinfra-dockerhub-push']
-        break
-      case 'infra.ci.jenkins.io':
-        return [error: false, organisation: 'jenkinsciinfra', credentialId: 'jenkinsinfraadmin-dockerhub-push']
-        break
-      default:
-        return [error: true, msg: 'Cannot use Docker credentials outside of jenkins infra environments']
-    }
-  }
 }

--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -65,7 +65,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     // Mock Pipeline methods which are not already declared in the parent class
     helper.registerAllowedMethod('hadoLint', [Map.class], { m -> m })
     helper.registerAllowedMethod('fileExists', [String.class], { true })
-    binding.setVariable('infra', ['withDockerPushCredentials': {body ->
+    binding.setVariable('infra', ['withContainerRegistry': {registry, body ->
         body()
       }])
     helper.registerAllowedMethod('sh', [Map.class], { m ->
@@ -795,6 +795,9 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     def script = loadScript(scriptName)
     mockPrincipalBranch()
     final String cacheValue = "type=inline"
+    infraConfigMock.demand.with {
+      isCi{ false }
+    }
     withMocks {
       script.call(testImageName, [cacheTo: cacheValue])
     }
@@ -825,11 +828,6 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('libraryResource','io/jenkins/infra/docker/Makefile'))
     assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
     assertTrue(assertMethodCallContainsPattern('node', 'docker'))
-
-    // And the Azure credential-less authentication is performed
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'ACR_NAME=dockerhubmirror'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'az login --identity'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'az acr login --name "${ACR_NAME}"'))
 
     // And the expected image name (with registry prefix) is set
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DEPLOY_NAME=' + fullTestImageName))

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -74,7 +74,6 @@ class InfraStepTests extends BaseTest {
     assertTrue(isOK)
     assertJobStatusSuccess()
     assertTrue(assertMethodCallContainsPattern('sh', 'echo "${DOCKER_CONFIG_PSW}" | docker login "${CONTAINER_REGISTRY}" --username "${DOCKER_CONFIG_USR}" --password-stdin'))
-    // assertTrue(assertMethodCallContainsPattern('echo', 'INFO: logged in Docker Hub as'))
   }
 
   @Test

--- a/test/groovy/InfraStepTests.groovy
+++ b/test/groovy/InfraStepTests.groovy
@@ -63,77 +63,37 @@ class InfraStepTests extends BaseTest {
   }
 
   @Test
-  void testWithDockerCredentials() throws Exception {
+  void testWithContainerRegistry() throws Exception {
     def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://ci.jenkins.io/'
+    env.JENKINS_URL = 'https://infra.ci.jenkins.io/'
     def isOK = false
-    script.withDockerCredentials() {
+    script.withContainerRegistry() {
       isOK = true
     }
     printCallStack()
     assertTrue(isOK)
     assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('sh', 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'echo "INFO: logged in Docker Hub as \'${DOCKER_CONFIG_USR}\' with \'${DOCKERHUB_CREDENTIALS_ID}\' credentials, namespace: ${DOCKERHUB_ORGANISATION}"'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'echo "${DOCKER_CONFIG_PSW}" | docker login "${CONTAINER_REGISTRY}" --username "${DOCKER_CONFIG_USR}" --password-stdin'))
+    // assertTrue(assertMethodCallContainsPattern('echo', 'INFO: logged in Docker Hub as'))
   }
 
   @Test
-  void testWithDockerCredentialsOutsideInfra() throws Exception {
+  void testWithContainerRegistryOutsideInfra() throws Exception {
     def script = loadScript(scriptName)
     env.JENKINS_URL = 'https://foo/'
     def isOK = false
-    script.withDockerCredentials() {
-      isOK = true
+    try {
+      script.withContainerRegistry() {
+        isOK = true
+      }
+    } catch(e) {
+      //NOOP
     }
     printCallStack()
     assertFalse(isOK)
-    assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environment'))
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void testWithDockerPushCredentials() throws Exception {
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://ci.jenkins.io/'
-    def isOK = false
-    script.withDockerPushCredentials() {
-      isOK = true
-    }
+    assertJobStatusFailure()
     printCallStack()
-    assertTrue(isOK)
-    assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('sh', 'echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'echo "INFO: logged in Docker Hub as \'${DOCKER_CONFIG_USR}\' with \'${DOCKERHUB_CREDENTIALS_ID}\' credentials, namespace: ${DOCKERHUB_ORGANISATION}"'))
-  }
-
-  @Test
-  void testWithDockerPushCredentialsWindows() throws Exception {
-    helper.registerAllowedMethod('isUnix', [], { false })
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://ci.jenkins.io/'
-    def isOK = false
-    script.withDockerPushCredentials() {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    assertJobStatusSuccess()
-    assertTrue(assertMethodCallContainsPattern('pwsh', 'Write-Output ${env:DOCKER_CONFIG_PSW} | & ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin'))
-    assertTrue(assertMethodCallContainsPattern('pwsh', 'Write-Host "INFO: logged in Docker Hub as \'$env:DOCKER_CONFIG_USR\' with \'$env:DOCKERHUB_CREDENTIALS_ID\' credentials, namespace: $env:DOCKERHUB_ORGANISATION"'))
-  }
-
-  @Test
-  void testWithDockerPushCredentialsOutsideInfra() throws Exception {
-    def script = loadScript(scriptName)
-    env.JENKINS_URL = 'https://foo/'
-    def isOK = false
-    script.withDockerPushCredentials() {
-      isOK = true
-    }
-    printCallStack()
-    assertFalse(isOK)
-    assertTrue(assertMethodCallContainsPattern('echo', 'Cannot use Docker credentials outside of jenkins infra environments'))
-    assertJobStatusSuccess()
+    assertTrue(assertMethodCallContainsPattern('error', 'Unknown Jenkins host (foo): cannot log-in to container registry.'))
   }
 
   @Test

--- a/test/groovy/io/jenkins/infra/InfraConfigTest.groovy
+++ b/test/groovy/io/jenkins/infra/InfraConfigTest.groovy
@@ -20,8 +20,6 @@ class InfraConfigTest {
     assertTrue(infraConfig.isCI())
     assertTrue(infraConfig.isRunningOnJenkinsInfra())
     assertEquals('jenkins4eval', infraConfig.getDockerRegistryNamespace())
-    assertEquals('jenkins4eval', infraConfig.getDockerPushOrgAndCredentialsId().organisation)
-    assertEquals('cijenkinsio-dockerhub-push', infraConfig.getDockerPushOrgAndCredentialsId().credentialId)
   }
 
   @Test
@@ -34,8 +32,6 @@ class InfraConfigTest {
     assertFalse(infraConfig.isCI())
     assertTrue(infraConfig.isRunningOnJenkinsInfra())
     assertEquals('jenkinsciinfra', infraConfig.getDockerRegistryNamespace())
-    assertEquals('jenkins', infraConfig.getDockerPushOrgAndCredentialsId().organisation)
-    assertEquals('jenkinsciinfra-dockerhub-push', infraConfig.getDockerPushOrgAndCredentialsId().credentialId)
   }
 
   @Test
@@ -48,7 +44,6 @@ class InfraConfigTest {
     assertFalse(infraConfig.isCI())
     assertTrue(infraConfig.isRunningOnJenkinsInfra())
     assertEquals('jenkins4eval', infraConfig.getDockerRegistryNamespace())
-    assertTrue(infraConfig.getDockerPushOrgAndCredentialsId().error)
   }
 
   @Test
@@ -61,8 +56,6 @@ class InfraConfigTest {
     assertFalse(infraConfig.isCI())
     assertTrue(infraConfig.isRunningOnJenkinsInfra())
     assertEquals('jenkinsciinfra', infraConfig.getDockerRegistryNamespace())
-    assertEquals('jenkinsciinfra', infraConfig.getDockerPushOrgAndCredentialsId().organisation)
-    assertEquals('jenkinsinfraadmin-dockerhub-push', infraConfig.getDockerPushOrgAndCredentialsId().credentialId)
   }
 
   @Test
@@ -75,7 +68,6 @@ class InfraConfigTest {
     assertFalse(infraConfig.isCI())
     assertFalse(infraConfig.isRunningOnJenkinsInfra())
     assertEquals('jenkins4eval', infraConfig.getDockerRegistryNamespace())
-    assertTrue(infraConfig.getDockerPushOrgAndCredentialsId().error)
   }
 
   @Test
@@ -88,7 +80,6 @@ class InfraConfigTest {
     assertFalse(infraConfig.isCI())
     assertFalse(infraConfig.isRunningOnJenkinsInfra())
     assertEquals('jenkins4eval', infraConfig.getDockerRegistryNamespace())
-    assertTrue(infraConfig.getDockerPushOrgAndCredentialsId().error)
   }
 
   @Test
@@ -101,6 +92,5 @@ class InfraConfigTest {
     assertFalse(infraConfig.isCI())
     assertFalse(infraConfig.isRunningOnJenkinsInfra())
     assertEquals('jenkins4eval', infraConfig.getDockerRegistryNamespace())
-    assertTrue(infraConfig.getDockerPushOrgAndCredentialsId().error)
   }
 }

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -118,9 +118,8 @@ def call(String imageShortName, Map userConfig =[:]) {
   final InfraConfig infraConfig = new InfraConfig(env)
   final String defaultRegistryNamespace = infraConfig.getDockerRegistryNamespace()
   final String registryNamespace = finalConfig.registryNamespace ?: defaultRegistryNamespace
-  final String acrName = 'dockerhubmirror'
   final String imageName = registryNamespace + '/' + imageShortName
-  final String registryHost = finalConfig.publishToPrivateAzureRegistry ? "${acrName}.azurecr.io" : 'docker.io'
+  final String registryHost = finalConfig.publishToPrivateAzureRegistry ? 'dockerhubmirror.azurecr.io' : 'docker.io'
 
   echo "INFO: Resolved Container Image Name: ${imageName}"
 
@@ -174,12 +173,16 @@ def call(String imageShortName, Map userConfig =[:]) {
 
       stage("Build ${imageName}") {
         if (env.BRANCH_IS_PRIMARY && finalConfig.cacheTo) {
-          infra.withDockerPushCredentials {
-            makecall('build', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget, finalConfig.cacheTo)
-          }
+          if (infraConfig.isCi()) {
+            echo '[WARNING]: ci.jenkins.io is not allowed to push container layers to any registry. Continuing without publishing cache.'
+          } else {
+            infra.withContainerRegistry(registryHost) {
+              makecall('build', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget, finalConfig.cacheTo)
+            }
+          } // if
         } else {
           makecall('build', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget)
-        }
+        } // if
       } //stage
 
       // There can be 2 kind of tests: per image and per repository
@@ -223,16 +226,7 @@ def call(String imageShortName, Map userConfig =[:]) {
           // Only deploy on primary branch
           stage("Deploy ${imageName}") {
             if (!finalConfig.disablePublication) {
-              if (finalConfig.publishToPrivateAzureRegistry) {
-                // Assume credential-less authentication (Azure Workload Identity)
-                withEnv(["ACR_NAME=${acrName}"]) {
-                  sh '''
-                  az login --identity
-                  az acr login --name "${ACR_NAME}"
-                  '''
-                }
-              }
-              infra.withDockerPushCredentials{
+              infra.withContainerRegistry(registryHost) {
                 makecall('deploy', imageName, operatingSystem, finalConfig.dockerBakeFile, finalConfig.dockerBakeTarget, '')
               }
             } else {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -24,67 +24,83 @@ Boolean isInfra() {
   return new InfraConfig(env).isInfra()
 }
 
-//withDockerCredentials deprecated method present for backward compatibility
+/**
+ * Method kept for backward compatibility until all consumers are removed:
+ * - https://github.com/jenkinsci/docker/blob/c0cda9f24f6e05ffe34b713aa3d477c53c9db97e/Jenkinsfile#L106
+ * - https://github.com/jenkinsci/docker-agents/blob/a72bee7bd8967866790bcf65c8c82bc4cc78c55d/Jenkinsfile#L154
+ * - https://github.com/jenkinsci/docker-ssh-agent/blob/6e5cd9050638ae4f2e17a5d63084db4f13cd78d7/Jenkinsfile#L81
+ **/
 Object withDockerCredentials(Closure body) {
-  return withDockerPushCredentials(body)
+  // It's only an alias
+  return withContainerRegistry(body)
 }
 
-Object withDockerCredentials(Map orgAndCredentialsId, Closure body) {
-  if (orgAndCredentialsId.error) {
-    echo orgAndCredentialsId.msg
-  } else {
-    withEnv([
-      "CONTAINER_BIN=${env.CONTAINER_BIN ?: 'docker'}",
-      "DOCKERHUB_ORGANISATION=${orgAndCredentialsId.organisation}",
-      "DOCKERHUB_CREDENTIALS_ID=${orgAndCredentialsId.credentialId}",
-    ]){
+// withContainerRegistry is a step which ensures the agent's Docker Engine is logged-in to the specified container registry or DockerHub if unspecified.
+// It errors (pipeline failure) if the specified registry is unknown or forbidden (no credentials, blocker, etc.)
+Object withContainerRegistry(String containerRegistry = '', Closure body) {
+  // empty value means credential-less (aka. Azure workload identity)
+  final Map containerRegistriesCredentials = [
+    'infra.ci.jenkins.io': [
+      'index.docker.io': 'jenkinsciinfra-dockerhub-push',
+      'dockerhubmirror.azurecr.io': '',
+    ],
+    'trusted.ci.jenkins.io': [
+      'index.docker.io': 'jenkinsinfraadmin-dockerhub-push',
+    ],
+    'cert.ci.jenkins.io': [
+      'dockerhubmirror.azurecr.io': 'azure-container-registry-push',
+    ],
+  ]
+  final String jenkinsHostname = new InfraConfig(env).jenkinsHostname
+  final String containerRegistryURL = containerRegistry ?: 'index.docker.io'
+
+  // Check if the current context is allowed to log-in
+  if (!containerRegistriesCredentials.containsKey(jenkinsHostname)) {
+    error "Unknown Jenkins host (${jenkinsHostname}): cannot log-in to container registry."
+  }
+  if (!containerRegistriesCredentials[jenkinsHostname].containsKey(containerRegistryURL)) {
+    error "Unsupported container registry (${containerRegistryURL}) for this Jenkins host (${jenkinsHostname})cannot log-in to container registry."
+  }
+
+  final String credentialId = containerRegistriesCredentials[jenkinsHostname][containerRegistryURL]
+  if (credentialId) {
+    withEnv(["CONTAINER_REGISTRY=${containerRegistry}"]) {
       withCredentials([
-        usernamePassword(credentialsId: orgAndCredentialsId.credentialId, passwordVariable: 'DOCKER_CONFIG_PSW', usernameVariable: 'DOCKER_CONFIG_USR')
+        usernamePassword(credentialsId: credentialId, passwordVariable: 'DOCKER_CONFIG_PSW', usernameVariable: 'DOCKER_CONFIG_USR'),
       ]) {
-        // Logging in on the Dockerhub helps to avoid request limit from DockerHub
         if (isUnix()) {
           sh '''
-          echo "${DOCKER_CONFIG_PSW}" | "${CONTAINER_BIN}" login --username "${DOCKER_CONFIG_USR}" --password-stdin
-          set +x
-          ip_all_json="$(curl -s https://ifconfig.me/all.json | jq || true)"
-          echo "INFO: logged in Docker Hub as '${DOCKER_CONFIG_USR}' with '${DOCKERHUB_CREDENTIALS_ID}' credentials, namespace: ${DOCKERHUB_ORGANISATION}"
-          if [[ -n "${ip_all_json}" ]]; then
-            echo 'INFO: IP address details from ifconfig.me/all.json:'
-            echo "${ip_all_json}"
-          fi
+          echo "${DOCKER_CONFIG_PSW}" | docker login "${CONTAINER_REGISTRY}" --username "${DOCKER_CONFIG_USR}" --password-stdin
           '''
         } else {
           pwsh '''
-          Write-Output ${env:DOCKER_CONFIG_PSW} | & ${Env:CONTAINER_BIN} login --username ${Env:DOCKER_CONFIG_USR} --password-stdin
-          try {
-              $ipAll = (Invoke-RestMethod -Uri "https://ifconfig.me/all.json" -TimeoutSec 5 | Out-String)
-          } catch {
-              $ipAll = ""
-          }
-          Write-Host "INFO: logged in Docker Hub as '$env:DOCKER_CONFIG_USR' with '$env:DOCKERHUB_CREDENTIALS_ID' credentials, namespace: $env:DOCKERHUB_ORGANISATION"
-          if ($ipAll) {
-            Write-Host 'INFO: IP address details from ifconfig.me/all.json:'
-            Write-Host $ipAll
-          }
+          Write-Output ${env:DOCKER_CONFIG_PSW} | & docker login --username ${Env:DOCKER_CONFIG_USR} --password-stdin
           '''
-        }
-
-        body.call()
-        // Logging out to ensure credentials are cleaned up if the current agent is reused
-        if (isUnix()) {
-          sh '"${CONTAINER_BIN}" logout'
-        } else {
-          pwsh 'Invoke-Expression "${Env:CONTAINER_BIN} logout"'
-        }
-        return
+        } // if
       } // withCredentials
-    }// withEnv
-  }
-}
+    } // withEnv
+  } else {
+    // Assume credential-less authentication with Azure Workload Identity to an Azure Container Registry
+    sh 'az login --identity'
+    final String acrSuffix = '.azurecr.io'
+    final String acrName = containerRegistry.substring(0, containerRegistry.length() - acrSuffix.length())
+    withEnv(["ACR_NAME=${acrName}"]) {
+      sh 'az acr login --name "${ACR_NAME}"'
+    } // withEnv
+  } // if
 
-Object withDockerPushCredentials(Closure body) {
-  Map orgAndCredentialsId = new InfraConfig(env).getDockerPushOrgAndCredentialsId()
-  return withDockerCredentials(orgAndCredentialsId, body)
+  // Execute inner steps
+  body.call()
+
+  // Logging out to ensure credentials are cleaned up if the current agent is reused
+  withEnv(["CONTAINER_REGISTRY=${containerRegistry}"]) {
+    if (isUnix()) {
+      sh 'docker logout "${CONTAINER_REGISTRY}"'
+    } else {
+      pwsh 'docker logout "${env:CONTAINER_REGISTRY}"'
+    } // if
+  } // withEnv
+  return
 }
 
 /**

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -36,7 +36,7 @@ Object withDockerCredentials(Closure body) {
 }
 
 // withContainerRegistry is a step which ensures the agent's Docker Engine is logged-in to the specified container registry or DockerHub if unspecified.
-// It errors (pipeline failure) if the specified registry is unknown or forbidden (no credentials, blocker, etc.)
+// It fails if the specified registry is unknown or forbidden (no credentials, blocker, etc.)
 Object withContainerRegistry(String containerRegistry = '', Closure body) {
   // empty value means credential-less (aka. Azure workload identity)
   final Map containerRegistriesCredentials = [

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -23,11 +23,11 @@
     Return true if this Pipeline is executing on an infrastructure CI environment.
 </p>
 
-<strong>infra.withDockerCredentials(Closure body)</strong>
+<strong>infra.withContainerRegistry(String containerRegistry = '', Closure body)</strong>
 
 <p>
-    Run the specified Closure with Docker credentials.
-    Note that the credentials are available only on a trusted CI environment; execution will fail on other CI instances.
+    Run the specified Closure with Docker Engine logged-in to the specified container registry or DockerHub if unspecified.
+    Note that the credentials are only available in some Jenkins infra environments; execution will fail on other CI instances.
 </p>
 
 <strong>infra.checkoutSCM(String repo = null)</strong>

--- a/vars/infra.txt
+++ b/vars/infra.txt
@@ -27,7 +27,7 @@
 
 <p>
     Run the specified Closure with Docker Engine logged-in to the specified container registry or DockerHub if unspecified.
-    Note that the credentials are only available in some Jenkins infra environments; execution will fail on other CI instances.
+    Note that the credentials are only available in some Jenkins controllers; execution will fail on other CI instances.
 </p>
 
 <strong>infra.checkoutSCM(String repo = null)</strong>


### PR DESCRIPTION
Following #1044 , we have to cleanup the Jenkins infrastructure credential usages. We now only have "push" credentials so let's clean up our old code and remove ci.jenkins.io from the equation.

- Introduces a new `withContainerRegistry()` function which accepts an eventual container registry URL (fallback to Dockerhub if empty) and the pipeline closure to execute. It uses the same login/logout method as in the past.
- CredentialsIDs have been move to a static map. No need to use many indirections anymore: we only work with Push credentials so the list is short

Tested with https://infra.ci.jenkins.io/job/docker-jobs/job/docker-404/job/main/253/ (replay of https://github.com/jenkins-infra/docker-404/blob/main/Jenkinsfile_k8s with the `@Library('pipeline-library@pull/1045/head') _
` preliminary line), and also as part of https://github.com/jenkins-infra/pipeline-library/pull/1043 in cert.ci.jenkins.io.

BREAKING: Removes all `infra.withDocker*()` functions except `withDockerCredentials()` kept for backward compatibility