### PR TITLE
feat(buildDockerAndPublishImage): allow execution in the current agent instead of allocating a new one. opt-in feature.

### DIFF
--- a/test/groovy/BuildDockerAndPublishImageStepTests.groovy
+++ b/test/groovy/BuildDockerAndPublishImageStepTests.groovy
@@ -297,6 +297,7 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
         automaticSemanticVersioning: true,
         gitCredentials: 'git-creds',
         registryNamespace: 'jenkins',
+        runInCurrentAgent: true,
       ])
     }
     final String expectedImageName = 'jenkins/' + testImageName
@@ -309,7 +310,8 @@ class BuildDockerAndPublishImageStepTests extends BaseTest {
     assertTrue(assertMethodCallContainsPattern('sh','make lint'))
     assertTrue(assertMethodCallContainsPattern('sh','make bake-build'))
 
-    assertTrue(assertMethodCallContainsPattern('node', 'docker'))
+    // Running in current agent is enabled: don't allocate one
+    assertFalse(assertMethodCallContainsPattern('node', 'docker'))
     // And the environement variables set with the custom configuration values
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DIR=docker/'))
     assertTrue(assertMethodCallContainsPattern('withEnv', 'IMAGE_DOCKERFILE=build.Dockerfile'))

--- a/vars/buildDockerAndPublishImage.groovy
+++ b/vars/buildDockerAndPublishImage.groovy
@@ -39,6 +39,17 @@ def makecall(String action, String imageDeployName, String targetOperationSystem
   } // unix agent
 }
 
+def withAgent(Boolean runInCurrentAgent, String agentLabels, Closure body) {
+  if (runInCurrentAgent) {
+    echo 'INFO: user specified "runInCurrentAgent" to true. Assuming the current agent has all requirements (Docker CE, etc.).'
+    body()
+  } else {
+    node(agentLabels) {
+      body()
+    }
+  }
+}
+
 def call(String imageShortName, Map userConfig =[:]) {
   def defaultConfig = [
     agentLabels: 'docker || linux-amd64-docker', // String expression for the labels the agent must match
@@ -56,6 +67,7 @@ def call(String imageShortName, Map userConfig =[:]) {
     cacheTo: '', // New parameter for Docker build cache export using cache-to
     disablePublication: false, // Allow to disable tagging and publication of container image and GitHub release
     publishToPrivateAzureRegistry: false, // Set to 'true' to publish the image into the private jenkins-infra private Azure Container Registry instead of DockerHub
+    runInCurrentAgent: false, // Specify wether to allocate an agent to run updatecli (default) or reuse the current one
   ]
   // Merging the 2 maps - https://blog.mrhaki.com/2010/04/groovy-goodness-adding-maps-to-map_21.html
   final Map finalConfig = defaultConfig << userConfig
@@ -123,7 +135,7 @@ def call(String imageShortName, Map userConfig =[:]) {
 
   echo "INFO: Resolved Container Image Name: ${imageName}"
 
-  node(finalConfig.agentLabels) {
+  withAgent(finalConfig.runInCurrentAgent, finalConfig.agentLabels) {
     withEnv([
       "BUILD_DATE=${buildDate}",
       "IMAGE_NAME=${imageName}",
@@ -321,5 +333,5 @@ def call(String imageShortName, Map userConfig =[:]) {
         publishBuildStatusReport()
       } // if
     } // withEnv (outer)
-  } // node
+  } // withAgent
 } // call

--- a/vars/buildDockerAndPublishImage.txt
+++ b/vars/buildDockerAndPublishImage.txt
@@ -20,6 +20,7 @@ The following arguments are available for this function:
   * String **dockerBakeFile**: (Optionan, default to "") Specify the path to a custom Docker Bake file to use instead of the default one
   * String **dockerBakeTarget**: (Optional, default to "default") Specify the target of a custom Docker Bake file to work with
   * Boolean **disablePublication**: (Optional, default to false) Allow to disable tagging and publication of container image and GitHub release
+  * Boolean **runInCurrentAgent** (Optional, default to false) Specify wether to allocate an agent to run the Docker tasks or reuse the current one
 
 The lint phase generates a report when it fails, recorded by the hadolint tool in your Jenkins instance.
 


### PR DESCRIPTION
This PR introduces a new feature required by #1043 (cert.ci.jenkins.io) but which could be useful for some container images of our infrastructure