### PR TITLE
fix(buildDockerAndPublishImage): handle "non-nextversion" tags where the container tag is provided as suffix of the `imageName` parameter

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -13,6 +13,10 @@ export ARCH ?= $(shell case $(current_arch) in (x86_64) echo "amd64" ;; (i386) e
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
+ifeq (,$(findstring :,$(IMAGE_DEPLOY_NAME)))
+	TAGS_LIST := $(NEXTVERSION),latest
+	export TAGS_LIST
+endif
 BUILD_TARGETPLATFORM ?= linux/amd64
 # Paths
 # Detect Windows (only OS separating paths in $PATH with ";") to set specific absolute paths for linux (bake) only

--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -13,9 +13,11 @@ export ARCH ?= $(shell case $(current_arch) in (x86_64) echo "amd64" ;; (i386) e
 
 IMAGE_NAME ?= helloworld
 IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
+# If there are no ':' character in IMAGE_DEPLOY_NAME (nominal case) then we assume both $NEXTVERSION and 'latest' tags should be built/deployed
+# We use tedious Makefile because the HCL 'strcontains()' function is unavailable in Docker Bake
 ifeq (,$(findstring :,$(IMAGE_DEPLOY_NAME)))
-	TAGS_LIST := $(NEXTVERSION),latest
-	export TAGS_LIST
+	CUSTOMTAGS := $(NEXTVERSION),latest
+	export CUSTOMTAGS
 endif
 BUILD_TARGETPLATFORM ?= linux/amd64
 # Paths

--- a/resources/io/jenkins/infra/docker/jenkinsinfrabakefile.hcl
+++ b/resources/io/jenkins/infra/docker/jenkinsinfrabakefile.hcl
@@ -4,7 +4,7 @@ variable "REGISTRY" {
   default = "docker.io"
 }
 
-variable "NEXT_VERSION" {
+variable "TAGS_LIST" {
   default = ""
 }
 
@@ -33,19 +33,15 @@ variable "SCM_URI" {
   default = ""
 }
 
-# return the full image name
-function "full_image_name" {
-  params = [tag]
-  result = notequal("", tag) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${tag}" : "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest"
+function "all_tags" {
+  params = [image_full_name, tags_list]
+  result = notequal("", tags_list) ? formatlist("${image_full_name}:%s", compact(split(",", tags_list))) : [image_full_name]
 }
 
 target "default" {
   dockerfile = IMAGE_DOCKERFILE
   context = IMAGE_DIR
-  tags = [
-    full_image_name("latest"),
-    full_image_name(NEXT_VERSION)
-  ]
+  tags = all_tags("${REGISTRY}/${IMAGE_DEPLOY_NAME}", TAGS_LIST)
   platforms = [BAKE_TARGETPLATFORMS]
   args = {
     GIT_COMMIT_REV="${GIT_COMMIT_REV}",

--- a/resources/io/jenkins/infra/docker/jenkinsinfrabakefile.hcl
+++ b/resources/io/jenkins/infra/docker/jenkinsinfrabakefile.hcl
@@ -4,7 +4,7 @@ variable "REGISTRY" {
   default = "docker.io"
 }
 
-variable "TAGS_LIST" {
+variable "CUSTOMTAGS" {
   default = ""
 }
 
@@ -34,14 +34,14 @@ variable "SCM_URI" {
 }
 
 function "all_tags" {
-  params = [image_full_name, tags_list]
-  result = notequal("", tags_list) ? formatlist("${image_full_name}:%s", compact(split(",", tags_list))) : [image_full_name]
+  params = [image_full_name, tags]
+  result = notequal("", tags) ? formatlist("${image_full_name}:%s", compact(split(",", tags))) : [image_full_name]
 }
 
 target "default" {
   dockerfile = IMAGE_DOCKERFILE
   context = IMAGE_DIR
-  tags = all_tags("${REGISTRY}/${IMAGE_DEPLOY_NAME}", TAGS_LIST)
+  tags = all_tags("${REGISTRY}/${IMAGE_DEPLOY_NAME}", CUSTOMTAGS)
   platforms = [BAKE_TARGETPLATFORMS]
   args = {
     GIT_COMMIT_REV="${GIT_COMMIT_REV}",


### PR DESCRIPTION
Bug detected while working on #1043 

In such case (`buildDockerAndPublishImage("myapp:customtag", [automaticSemanticVersioning: false])`), the build fails with:

```
ERROR: invalid tag "myapp:customtag:latest": invalid reference format
````

This change fixes this behavior with 2 elements:
- Removes the concept of `NEXTVERSION` from the bake file in favor of a list of tags
  - Defaults is empty tags: it will imply an implicit `:latest` tag
- Makefile is responsible to detect the presence of a tag marker (the colon `:` character) in the provided image name.
  - If detected, it is passed as the only tag
  - Otherwise (nominal case) we passe the `NEXTVERSION` and `latest` explicit tags

NOTE: the bakefile does not have all HCL functions: it lacks `strcontains()` so we can't easily detect the colon inside bakefile

----


Tests in progress with 3 kinds of builds:

- [infra.ci] Replay a CD build for docker-404 to cover usual tagging when a release is published with a "NEXT VERSION" - https://infra.ci.jenkins.io/job/docker-jobs/job/docker-404/job/main/256/ 
- [infra.ci] Replay a PR build to ensure no non regression - https://infra.ci.jenkins.io/job/docker-jobs/job/docker-jenkins-lts/view/change-requests/job/PR-1120/4/
- [cert.ci] rebasing #1043 against this PR and retriggering a build to verify the "cert.ci" case with no NEXTVERSION