### PR TITLE
fix(buildDockerAndPublishImage) correct typo on `NEXTVERSION` preventing tag to be published

### DIFF
--- a/resources/io/jenkins/infra/docker/Makefile
+++ b/resources/io/jenkins/infra/docker/Makefile
@@ -16,7 +16,7 @@ IMAGE_DEPLOY_NAME ?= "$(IMAGE_NAME)"
 # If there are no ':' character in IMAGE_DEPLOY_NAME (nominal case) then we assume both $NEXTVERSION and 'latest' tags should be built/deployed
 # We use tedious Makefile because the HCL 'strcontains()' function is unavailable in Docker Bake
 ifeq (,$(findstring :,$(IMAGE_DEPLOY_NAME)))
-	CUSTOMTAGS := $(NEXTVERSION),latest
+	CUSTOMTAGS := $(NEXT_VERSION),latest
 	export CUSTOMTAGS
 endif
 BUILD_TARGETPLATFORM ?= linux/amd64


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/pipeline-library/pull/1052/changes#r3958321284

Testing with a replay: https://infra.ci.jenkins.io/job/docker-jobs/job/docker-jenkins-weeklyci/job/main/293/